### PR TITLE
feat(gateway): JWT auth layer -- RS256 via JWKS and HS256

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Bun monorepo with 6 packages:
 | eval | `core/src/eval/` | 23 scorers (11 rule + 12 LLM-as-judge), dataset loader, experiment runner, comparator, consistency runner (pass^k) |
 | observability (core) | `core/src/observability/` | OTel span mapper (exhaustive event-to-span mapping) + OTelExporter (EventStore sink) |
 | observability (runtime) | `runtime/src/observability/` | PrometheusCollector (EventStore sink, dynamic prom-client import), CompositeEventStore (fan-out to multiple sinks) |
-| gateway | `runtime/src/gateway/` | Multi-app loading, Mode B routes, budget middleware, composable auth middleware (timing-safe), conversation event emitter (incl. tool execution events), delegation, dev routes, safety/security middleware, audio preprocessing, knowledge pipeline wiring, STT/knowledge factories, webhook tool executor, integration runtime (IntegrationRegistry + IntegrationExecutor + LocalCredentialResolver), tenant tool factory, Meta webhook foundation (shared verification + HMAC-SHA256), WebhookDedup (Meta at-least-once protection), Instagram/Messenger/Email webhook routes, email loop guard, SqliteEmailThreadStore, WebSocket heartbeat (30s ping, 90s timeout), WhatsApp coexistence auto-handoff (smb_message_echoes) |
+| gateway | `runtime/src/gateway/` | Multi-app loading, Mode B routes, budget middleware, composable auth middleware (timing-safe, API key + JWT RS256/HS256 via JWKS), conversation event emitter (incl. tool execution events), delegation, dev routes, safety/security middleware, audio preprocessing, knowledge pipeline wiring, STT/knowledge factories, webhook tool executor, integration runtime (IntegrationRegistry + IntegrationExecutor + LocalCredentialResolver), tenant tool factory, Meta webhook foundation (shared verification + HMAC-SHA256), WebhookDedup (Meta at-least-once protection), Instagram/Messenger/Email webhook routes, email loop guard, SqliteEmailThreadStore, WebSocket heartbeat (30s ping, 90s timeout), WhatsApp coexistence auto-handoff (smb_message_echoes) |
 | a2a | `runtime/src/a2a/` | A2AClient (outbound delegation only) |
 | trigger | `runtime/src/trigger/` | TriggerRegistry, webhook handler (HMAC-SHA256), event listener, cron scheduler |
 | session | `runtime/src/session/` | ModeBSession (version tracking, optimistic concurrency, token/turn tracking), ModeBOrchestrator (tool authorization, retry/fallback, result sanitization, ToolRAG, PerCallToolConfig, AI guard, model routing via ModelRouter + providerPool), SessionRegistry (pluggable SessionStore, save with concurrency check), SessionMode state machine (ai_active/queued/human_active/resolved), session serializer, repetitive abuse detector |
@@ -180,7 +180,8 @@ Scopes: core, engine, orchestrator, agents, domain, package, skill, memory, tree
 |------|---------|
 | `gateway/gateway-server.ts` | startGateway() + startDevServer(): Bun.serve, multi-app, Mode B, triggers, dev mode, lightweight Mode A dashboard, integration adapter wiring (StartGatewayOptions.integrations + secretKeyEnv) |
 | `gateway/gateway-routes.ts` | Hono app factory: health + per-App routes + A2A + webhooks |
-| `gateway/auth-middleware.ts` | Composable auth: requireApiKey, requireBearer, requireWebhookSignature, isOriginAllowed |
+| `gateway/auth-middleware.ts` | Composable auth: requireApiKey, requireBearer, requireWebhookSignature, requireJwt, isOriginAllowed |
+| `gateway/jwt-verifier.ts` | JWT verification: buildJwtVerifier() -- RS256 via JWKS (jose createRemoteJWKSet) or HS256 via shared secret |
 | `gateway/mode-b-routes.ts` | POST /message, GET/DELETE /sessions |
 | `gateway/delegation-handler.ts` | DelegationRegistry, executeDelegation() (Kiln-native + A2A) |
 | `gateway/budget-middleware.ts` | checkBudget(), reportUsage() -- fail-open |
@@ -264,6 +265,10 @@ Kiln as production runtime for CLI agents (Claude Code, Codex CLI, Goose) via MC
 ### OpenKiln (Personal AI Agent)
 
 Product layer on `@kilnai/core` + `@kilnai/runtime`. Single-user mode, local-first SQLite, quick-start CLI (`npx openkiln init`), new channel adapters (Telegram, Discord, Signal). Separate bounded context — packaging and channel defaults, not a fork. Research needed.
+
+### Widget Customization
+
+Theming API for `@kilnai/widget`: custom CSS variables, brand colors, fonts, logo slot. Current widget uses hardcoded Kiln palette. Admit Console integration chose native SDK rebuild over widget due to lack of customization. Unblock widget adoption for themed integrations.
 
 ## Documentation
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/cli": {
       "name": "@kilnai/cli",
-      "version": "0.3.0",
+      "version": "0.19.0",
       "bin": {
         "kiln": "./dist/index.js",
       },
@@ -33,7 +33,7 @@
     },
     "packages/core": {
       "name": "@kilnai/core",
-      "version": "0.4.0",
+      "version": "0.19.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -55,9 +55,10 @@
     },
     "packages/runtime": {
       "name": "@kilnai/runtime",
-      "version": "0.4.0",
+      "version": "0.19.0",
       "dependencies": {
         "hono": "^4.7.0",
+        "jose": "^5.0.0",
       },
       "peerDependencies": {
         "@kilnai/core": "workspace:*",
@@ -71,7 +72,7 @@
     },
     "packages/sdk": {
       "name": "@kilnai/react",
-      "version": "0.3.0",
+      "version": "0.19.0",
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
         "@types/react": "^19.0.0",
@@ -87,7 +88,7 @@
     },
     "packages/studio": {
       "name": "@kilnai/studio",
-      "version": "0.1.0",
+      "version": "0.10.0",
       "devDependencies": {
         "@kilnai/react": "workspace:*",
         "@tanstack/react-query": "^5.64.0",
@@ -103,7 +104,7 @@
     },
     "packages/widget": {
       "name": "@kilnai/widget",
-      "version": "0.3.0",
+      "version": "0.19.0",
       "devDependencies": {
         "jsdom": "^25.0.0",
         "vitest": "^4.0.18",
@@ -635,7 +636,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
@@ -910,6 +911,8 @@
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@modelcontextprotocol/sdk/jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.20.0 (2026-03-14) -- Gateway JWT Auth (RS256 + HS256)
+
+### Zero-Trust Inter-Service Authentication
+
+- **`GatewayAuthConfig`** (`core/src/engine/gateway/auth-config.ts`): New domain type for gateway-level JWT authentication. Supports `algorithm: RS256` (JWKS) or `HS256` (shared secret). Optional `issuer` and `audience` claim validation. Exported from `@kilnai/core`.
+- **`auth` block in `gateway.yaml`**: Top-level optional config. RS256 requires `jwksUri`; HS256 requires `secretEnv` (env var name). Parsed and validated by `parseGatewayYaml` with the same error accumulation pattern as `observability`.
+- **`buildJwtVerifier()`** (`runtime/src/gateway/jwt-verifier.ts`): Builds a `JwtVerifyFn` from `GatewayAuthConfig`. RS256 uses `jose createRemoteJWKSet` (cached, auto-refreshing on key rotation). HS256 resolves the secret from `process.env` once at startup — fails fast if the env var is missing. Dynamic `import("jose")` so the library is only loaded when JWT auth is configured.
+- **`requireJwt(verify)`** (`runtime/src/gateway/auth-middleware.ts`): New composable middleware. Extracts Bearer token from `Authorization` header, verifies via `JwtVerifyFn`, attaches decoded payload to `c.set("jwtPayload", payload)`. Returns 401 with no error detail leakage on failure.
+- **`GatewayServerConfig.jwtVerifier`**: New optional field. When set, `createGatewayApp` applies `requireJwt` to all API channels (`/path/*`), admin routes (`/admin/:name/*`), outbound routes (`/outbound/:name/*`), handoff routes (`/handoff/:name/*`), and memory routes (`/api/memory/*`). Webhook channels (WhatsApp, Instagram, Messenger, Email) retain their HMAC-SHA256 auth unchanged. Health endpoint is always public.
+- **`startGateway` wiring**: JWT verifier built once at startup after `parseGatewayYaml`. Startup log confirms the active mode. Auth warning suppressed for API channels when gateway-level JWT is configured.
+- **Backward compatible**: No `auth` block → zero behavior change. Existing `apiKeyEnv` deployments continue working exactly as before.
+- **`jose` dependency**: Added to `@kilnai/runtime` dependencies.
+
+**Config examples:**
+
+```yaml
+# RS256 -- verify tokens issued by any Vigil-based service (e.g. SHRAD)
+auth:
+  algorithm: RS256
+  jwksUri: "https://auth.myapp.com/.well-known/jwks.json"
+  issuer: "https://auth.myapp.com"
+  audience: "kiln-gateway"
+
+# HS256 -- shared secret (same as Vigil HS256 mode)
+auth:
+  algorithm: HS256
+  secretEnv: GATEWAY_JWT_SECRET
+```
+
 ## v0.19.0 (2026-03-11) -- RAG Grounding Tier 2 (Post-Generation Rail)
 
 ### Hallucination Prevention: Post-Generation LLM Judge

--- a/packages/core/src/engine/gateway/auth-config.ts
+++ b/packages/core/src/engine/gateway/auth-config.ts
@@ -1,0 +1,61 @@
+// Engine type: GatewayAuthConfig -- gateway-level JWT authentication configuration
+// Domain types only -- no external dependencies
+
+/** JWT algorithm supported at the gateway level */
+export type JwtAlgorithm = "RS256" | "HS256";
+
+/**
+ * Gateway-level JWT authentication configuration.
+ * Loaded from the `auth` block in gateway.yaml.
+ *
+ * RS256: verifies tokens by fetching public keys from a JWKS endpoint.
+ * HS256: verifies tokens using a shared secret resolved from an env var.
+ */
+export interface GatewayAuthConfig {
+  readonly algorithm: JwtAlgorithm;
+  /** RS256 only: URL of the JWKS endpoint (e.g. "https://auth.myapp.com/.well-known/jwks.json") */
+  readonly jwksUri?: string;
+  /** HS256 only: env var name containing the shared HMAC secret */
+  readonly secretEnv?: string;
+  /** Optional: expected `iss` claim. Tokens with a different issuer are rejected. */
+  readonly issuer?: string;
+  /** Optional: expected `aud` claim. Tokens must include this audience. */
+  readonly audience?: string;
+}
+
+/** Validation error for auth configuration */
+export interface GatewayAuthValidationError {
+  readonly field: string;
+  readonly message: string;
+}
+
+/** Validate a GatewayAuthConfig. Returns an array of errors; empty means valid. */
+export function validateGatewayAuthConfig(config: GatewayAuthConfig): GatewayAuthValidationError[] {
+  const errors: GatewayAuthValidationError[] = [];
+
+  const validAlgorithms: JwtAlgorithm[] = ["RS256", "HS256"];
+  if (!validAlgorithms.includes(config.algorithm)) {
+    errors.push({ field: "auth.algorithm", message: `must be one of: ${validAlgorithms.join(", ")}` });
+    return errors; // Cannot continue without a valid algorithm
+  }
+
+  if (config.algorithm === "RS256") {
+    if (!config.jwksUri || typeof config.jwksUri !== "string" || !config.jwksUri.trim()) {
+      errors.push({ field: "auth.jwksUri", message: "required when algorithm is RS256" });
+    }
+    if (config.secretEnv) {
+      errors.push({ field: "auth.secretEnv", message: "must not be set when algorithm is RS256" });
+    }
+  }
+
+  if (config.algorithm === "HS256") {
+    if (!config.secretEnv || typeof config.secretEnv !== "string" || !config.secretEnv.trim()) {
+      errors.push({ field: "auth.secretEnv", message: "required when algorithm is HS256" });
+    }
+    if (config.jwksUri) {
+      errors.push({ field: "auth.jwksUri", message: "must not be set when algorithm is HS256" });
+    }
+  }
+
+  return errors;
+}

--- a/packages/core/src/engine/gateway/gateway-config.ts
+++ b/packages/core/src/engine/gateway/gateway-config.ts
@@ -2,6 +2,7 @@
 // Declares which Apps to host and how they bind to channels
 
 import type { ObservabilityConfig } from "./observability-config.js";
+import type { GatewayAuthConfig } from "./auth-config.js";
 
 /** Channel binding for a specific platform adapter */
 export interface GatewayChannelBinding {
@@ -26,11 +27,12 @@ export interface GatewayAppBinding {
   readonly channels: readonly GatewayChannelBinding[];
 }
 
-/** Top-level gateway configuration: port + multiple app bindings + optional observability */
+/** Top-level gateway configuration: port + multiple app bindings + optional observability + optional auth */
 export interface GatewayConfig {
   readonly port: number;
   readonly apps: readonly GatewayAppBinding[];
   readonly observability?: ObservabilityConfig;
+  readonly auth?: GatewayAuthConfig;
 }
 
 /** Validation error for gateway configuration */

--- a/packages/core/src/engine/gateway/gateway-loader.ts
+++ b/packages/core/src/engine/gateway/gateway-loader.ts
@@ -7,6 +7,8 @@ import type { GatewayConfig, GatewayAppBinding, GatewayChannelBinding, GatewayVa
 import { validateGatewayConfig } from "./gateway-config.js";
 import type { ObservabilityConfig } from "./observability-config.js";
 import { validateObservabilityConfig } from "./observability-config.js";
+import type { GatewayAuthConfig } from "./auth-config.js";
+import { validateGatewayAuthConfig } from "./auth-config.js";
 
 /** Error class for gateway YAML loader failures, aggregating all validation errors */
 export class GatewayLoaderError extends KilnError {
@@ -46,6 +48,7 @@ interface RawGateway {
   port?: unknown;
   apps?: unknown;
   observability?: unknown;
+  auth?: unknown;
 }
 
 // ---------------------------------------------------------------------------
@@ -179,9 +182,33 @@ export function parseGatewayYaml(content: string): GatewayConfig {
     }
   }
 
+  // Parse optional auth block
+  let auth: GatewayAuthConfig | undefined;
+  if (raw.auth !== undefined) {
+    if (typeof raw.auth !== "object" || Array.isArray(raw.auth) || raw.auth === null) {
+      errors.push({ field: "auth", message: "must be an object" });
+    } else {
+      const rawAuth = raw.auth as Record<string, unknown>;
+      const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+      const parsed: GatewayAuthConfig = {
+        algorithm: (str(rawAuth["algorithm"]) ?? "") as GatewayAuthConfig["algorithm"],
+        ...(str(rawAuth["jwksUri"]) ? { jwksUri: str(rawAuth["jwksUri"]) } : {}),
+        ...(str(rawAuth["secretEnv"]) ? { secretEnv: str(rawAuth["secretEnv"]) } : {}),
+        ...(str(rawAuth["issuer"]) ? { issuer: str(rawAuth["issuer"]) } : {}),
+        ...(str(rawAuth["audience"]) ? { audience: str(rawAuth["audience"]) } : {}),
+      };
+      const authErrors = validateGatewayAuthConfig(parsed);
+      if (authErrors.length > 0) {
+        errors.push(...authErrors);
+      } else {
+        auth = parsed;
+      }
+    }
+  }
+
   if (errors.length > 0) throw new GatewayLoaderError(errors);
 
-  const config: GatewayConfig = { port, apps, ...(observability ? { observability } : {}) };
+  const config: GatewayConfig = { port, apps, ...(observability ? { observability } : {}), ...(auth ? { auth } : {}) };
 
   const validationErrors = validateGatewayConfig(config);
   if (validationErrors.length > 0) throw new GatewayLoaderError(validationErrors);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,8 @@ export { validateGatewayConfig } from "./engine/gateway/gateway-config.js";
 export { GatewayLoaderError, parseGatewayYaml } from "./engine/gateway/gateway-loader.js";
 export type { ObservabilityConfig, ObservabilityExporter } from "./engine/gateway/observability-config.js";
 export { validateObservabilityConfig } from "./engine/gateway/observability-config.js";
+export type { GatewayAuthConfig, JwtAlgorithm, GatewayAuthValidationError } from "./engine/gateway/auth-config.js";
+export { validateGatewayAuthConfig } from "./engine/gateway/auth-config.js";
 
 // App loader re-exported for direct access by runtime gateway
 export type { App, MemoryConfig, AppValidationError } from "./engine/composites/app.js";

--- a/packages/core/tests/engine/gateway/auth-config.test.ts
+++ b/packages/core/tests/engine/gateway/auth-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { validateGatewayAuthConfig } from "../../../src/engine/gateway/auth-config.js";
+import type { GatewayAuthConfig } from "../../../src/engine/gateway/auth-config.js";
+
+describe("validateGatewayAuthConfig", () => {
+  describe("RS256", () => {
+    it("accepts valid RS256 config with jwksUri", () => {
+      const config: GatewayAuthConfig = {
+        algorithm: "RS256",
+        jwksUri: "https://auth.example.com/.well-known/jwks.json",
+      };
+      expect(validateGatewayAuthConfig(config)).toHaveLength(0);
+    });
+
+    it("accepts RS256 with optional issuer and audience", () => {
+      const config: GatewayAuthConfig = {
+        algorithm: "RS256",
+        jwksUri: "https://auth.example.com/.well-known/jwks.json",
+        issuer: "https://auth.example.com",
+        audience: "my-api",
+      };
+      expect(validateGatewayAuthConfig(config)).toHaveLength(0);
+    });
+
+    it("rejects RS256 missing jwksUri", () => {
+      const config: GatewayAuthConfig = { algorithm: "RS256" };
+      const errors = validateGatewayAuthConfig(config);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]!.field).toBe("auth.jwksUri");
+    });
+
+    it("rejects RS256 with secretEnv set", () => {
+      const config: GatewayAuthConfig = {
+        algorithm: "RS256",
+        jwksUri: "https://auth.example.com/.well-known/jwks.json",
+        secretEnv: "JWT_SECRET",
+      };
+      const errors = validateGatewayAuthConfig(config);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]!.field).toBe("auth.secretEnv");
+    });
+  });
+
+  describe("HS256", () => {
+    it("accepts valid HS256 config with secretEnv", () => {
+      const config: GatewayAuthConfig = { algorithm: "HS256", secretEnv: "JWT_SECRET" };
+      expect(validateGatewayAuthConfig(config)).toHaveLength(0);
+    });
+
+    it("accepts HS256 with optional issuer and audience", () => {
+      const config: GatewayAuthConfig = {
+        algorithm: "HS256",
+        secretEnv: "JWT_SECRET",
+        issuer: "my-service",
+        audience: "my-api",
+      };
+      expect(validateGatewayAuthConfig(config)).toHaveLength(0);
+    });
+
+    it("rejects HS256 missing secretEnv", () => {
+      const config: GatewayAuthConfig = { algorithm: "HS256" };
+      const errors = validateGatewayAuthConfig(config);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]!.field).toBe("auth.secretEnv");
+    });
+
+    it("rejects HS256 with jwksUri set", () => {
+      const config: GatewayAuthConfig = {
+        algorithm: "HS256",
+        secretEnv: "JWT_SECRET",
+        jwksUri: "https://auth.example.com/.well-known/jwks.json",
+      };
+      const errors = validateGatewayAuthConfig(config);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]!.field).toBe("auth.jwksUri");
+    });
+  });
+
+  it("rejects unknown algorithm", () => {
+    const config = { algorithm: "ES256" } as unknown as GatewayAuthConfig;
+    const errors = validateGatewayAuthConfig(config);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.field).toBe("auth.algorithm");
+  });
+});

--- a/packages/core/tests/engine/gateway/gateway-loader.test.ts
+++ b/packages/core/tests/engine/gateway/gateway-loader.test.ts
@@ -275,3 +275,65 @@ observability:
   });
 });
 
+describe("parseGatewayYaml -- auth block", () => {
+  const BASE = `
+port: 4800
+apps:
+  - name: my-app
+    config: app.yaml
+    channels:
+      - type: api
+        path: /api/v1
+`;
+
+  it("omits auth when auth block is absent (backward compat)", () => {
+    const config = parseGatewayYaml(BASE);
+    expect(config.auth).toBeUndefined();
+  });
+
+  it("parses valid RS256 auth block", () => {
+    const yaml = BASE + `auth:\n  algorithm: RS256\n  jwksUri: "https://auth.example.com/.well-known/jwks.json"\n`;
+    const config = parseGatewayYaml(yaml);
+    expect(config.auth).toBeDefined();
+    expect(config.auth!.algorithm).toBe("RS256");
+    expect(config.auth!.jwksUri).toBe("https://auth.example.com/.well-known/jwks.json");
+    expect(config.auth!.secretEnv).toBeUndefined();
+  });
+
+  it("parses valid HS256 auth block", () => {
+    const yaml = BASE + `auth:\n  algorithm: HS256\n  secretEnv: JWT_SECRET\n`;
+    const config = parseGatewayYaml(yaml);
+    expect(config.auth!.algorithm).toBe("HS256");
+    expect(config.auth!.secretEnv).toBe("JWT_SECRET");
+  });
+
+  it("parses optional issuer and audience", () => {
+    const yaml =
+      BASE +
+      `auth:\n  algorithm: RS256\n  jwksUri: "https://auth.example.com/.well-known/jwks.json"\n  issuer: "https://auth.example.com"\n  audience: my-api\n`;
+    const config = parseGatewayYaml(yaml);
+    expect(config.auth!.issuer).toBe("https://auth.example.com");
+    expect(config.auth!.audience).toBe("my-api");
+  });
+
+  it("throws GatewayLoaderError when auth is not an object", () => {
+    const yaml = BASE + `auth: "not-an-object"\n`;
+    expect(() => parseGatewayYaml(yaml)).toThrow(GatewayLoaderError);
+  });
+
+  it("throws GatewayLoaderError when RS256 is missing jwksUri", () => {
+    const yaml = BASE + `auth:\n  algorithm: RS256\n`;
+    expect(() => parseGatewayYaml(yaml)).toThrow(GatewayLoaderError);
+  });
+
+  it("throws GatewayLoaderError when HS256 is missing secretEnv", () => {
+    const yaml = BASE + `auth:\n  algorithm: HS256\n`;
+    expect(() => parseGatewayYaml(yaml)).toThrow(GatewayLoaderError);
+  });
+
+  it("throws GatewayLoaderError on unknown algorithm", () => {
+    const yaml = BASE + `auth:\n  algorithm: ES256\n`;
+    expect(() => parseGatewayYaml(yaml)).toThrow(GatewayLoaderError);
+  });
+});
+

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -39,7 +39,8 @@
     "access": "public"
   },
   "dependencies": {
-    "hono": "^4.7.0"
+    "hono": "^4.7.0",
+    "jose": "^5.0.0"
   },
   "peerDependencies": {
     "@kilnai/core": "workspace:*",

--- a/packages/runtime/src/gateway/auth-middleware.ts
+++ b/packages/runtime/src/gateway/auth-middleware.ts
@@ -4,6 +4,7 @@
 import type { Context, Next } from "hono";
 import { timingSafeEqual } from "node:crypto";
 import { verifyHmacSha256 } from "../utils/hmac.js";
+import type { JwtVerifyFn, JwtPayload } from "./jwt-verifier.js";
 
 /** Timing-safe string comparison. Returns false immediately for different lengths (safe — no content leak). */
 function safeEqual(a: string, b: string): boolean {
@@ -60,6 +61,30 @@ export function requireWebhookSignature(
     }
 
     return next();
+  };
+}
+
+/**
+ * Require a valid JWT via Authorization: Bearer <token>.
+ * Verifies using the provided JwtVerifyFn (JWKS or HS256).
+ * Attaches the decoded payload to the Hono context under key "jwtPayload" for downstream use.
+ * Returns 401 if the header is missing, malformed, or the token is invalid/expired.
+ * No error details are leaked in the response body.
+ */
+export function requireJwt(verify: JwtVerifyFn): (c: Context, next: Next) => Promise<Response | void> {
+  return async (c: Context, next: Next): Promise<Response | void> => {
+    const auth = c.req.header("authorization");
+    if (!auth || !auth.startsWith("Bearer ")) {
+      return c.json({ error: "unauthorized", message: "Missing or malformed Authorization header" }, 401);
+    }
+    const token = auth.slice(7);
+    try {
+      const payload: JwtPayload = await verify(token);
+      c.set("jwtPayload", payload);
+      return next();
+    } catch {
+      return c.json({ error: "unauthorized", message: "Invalid or expired JWT" }, 401);
+    }
   };
 }
 

--- a/packages/runtime/src/gateway/gateway-routes.ts
+++ b/packages/runtime/src/gateway/gateway-routes.ts
@@ -46,6 +46,8 @@ import { createMemoryRoutes } from "./memory-routes.js";
 import type { TriggerRegistry } from "../trigger/trigger-registry.js";
 import type { ConversationEventEmitter } from "./conversation-event-emitter.js";
 import type { KnowledgePipelineResult } from "./knowledge-factory.js";
+import type { JwtVerifyFn } from "./jwt-verifier.js";
+import { requireJwt } from "./auth-middleware.js";
 
 export interface LoadedApp {
   readonly name: string;
@@ -85,6 +87,8 @@ export interface GatewayServerConfig {
   readonly studioDistPath?: string;
   readonly upgradeWebSocket?: WsRoutesConfig["upgradeWebSocket"];
   readonly validateToken?: WsRoutesConfig["validateToken"];
+  /** Gateway-level JWT verifier. When set, applied to all API and admin routes. */
+  readonly jwtVerifier?: JwtVerifyFn;
 }
 
 export function createGatewayApp(config: GatewayServerConfig): Hono {
@@ -95,6 +99,9 @@ export function createGatewayApp(config: GatewayServerConfig): Hono {
     const scanner = new PromptScanner(config.securityConfig.promptInjection);
     app.use("*", securityMiddleware(scanner, config.auditLog, config.securityConfig.promptInjection));
   }
+
+  // JWT middleware factory -- created once, reused for all protected route groups
+  const jwtMiddleware = config.jwtVerifier ? requireJwt(config.jwtVerifier) : undefined;
 
   // Health endpoint
   app.get("/health", async (c) => {
@@ -139,12 +146,27 @@ export function createGatewayApp(config: GatewayServerConfig): Hono {
 
   // Production memory routes (available in all modes)
   if (config.memoryRoutesConfig) {
+    if (jwtMiddleware) {
+      app.use("/api/memory/*", jwtMiddleware);
+    }
     const memoryRoutes = createMemoryRoutes(config.memoryRoutesConfig);
     app.route("/api", memoryRoutes);
   }
 
   // Per-app routes
   for (const loadedApp of config.apps) {
+    // JWT auth: applied to API/admin/outbound/handoff routes when gateway-level JWT is configured
+    if (jwtMiddleware) {
+      for (const channel of loadedApp.binding.channels) {
+        if (channel.type === "api" && channel.path) {
+          app.use(`${channel.path}/*`, jwtMiddleware);
+        }
+      }
+      app.use(`/admin/${loadedApp.name}/*`, jwtMiddleware);
+      app.use(`/outbound/${loadedApp.name}/*`, jwtMiddleware);
+      app.use(`/handoff/${loadedApp.name}/*`, jwtMiddleware);
+    }
+
     // Safety middleware per app (scans both input and output)
     const safetyPipeline = config.safetyPipelines?.get(loadedApp.name);
     if (safetyPipeline) {

--- a/packages/runtime/src/gateway/gateway-server.ts
+++ b/packages/runtime/src/gateway/gateway-server.ts
@@ -657,7 +657,7 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
   // Auth warnings: notify when channels lack auth configuration
   for (const loaded of loadedApps) {
     for (const channel of loaded.binding.channels) {
-      if (channel.type === "api" && channel.path && !channel.apiKeyEnv) {
+      if (channel.type === "api" && channel.path && !channel.apiKeyEnv && !gatewayConfig.auth) {
         console.warn(`  [warn] API channel at ${channel.path} has no apiKeyEnv -- endpoints are unauthenticated`);
       }
       if (channel.type === "whatsapp" && !channel.appSecretEnv) {
@@ -757,6 +757,25 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
 
   const tokenStore = options?.devMode ? new DevTokenStore() : undefined;
 
+  // JWT verifier: built once at startup when auth block is present in gateway.yaml
+  let jwtVerifier: import("./jwt-verifier.js").JwtVerifyFn | undefined;
+  if (gatewayConfig.auth) {
+    try {
+      const { buildJwtVerifier } = await import("./jwt-verifier.js");
+      jwtVerifier = await buildJwtVerifier(gatewayConfig.auth);
+      const mode =
+        gatewayConfig.auth.algorithm === "RS256"
+          ? `RS256 JWKS (${gatewayConfig.auth.jwksUri})`
+          : `HS256 (${gatewayConfig.auth.secretEnv})`;
+      console.log(`Auth: JWT verification enabled -- ${mode}`);
+    } catch (err) {
+      throw new KilnError("CONFIG_INVALID", `Failed to initialize JWT verifier: ${err instanceof Error ? err.message : String(err)}`, {
+        context: { algorithm: gatewayConfig.auth.algorithm },
+        retryable: false,
+      });
+    }
+  }
+
   const { upgradeWebSocket, websocket: bunWebsocket } = createBunWebSocket();
 
   const honoApp = createGatewayApp({
@@ -769,6 +788,7 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
     safetyPipelines,
     upgradeWebSocket,
     validateToken: tokenStore ? (token) => tokenStore.validate(token) : undefined,
+    jwtVerifier,
     devMode: options?.devMode,
     studioDistPath,
     devRoutesConfig: options?.devMode

--- a/packages/runtime/src/gateway/jwt-verifier.ts
+++ b/packages/runtime/src/gateway/jwt-verifier.ts
@@ -1,0 +1,71 @@
+// Gateway: JwtVerifier -- JWT verification via JWKS (RS256) or shared secret (HS256)
+// Initialized once at gateway startup; jose handles JWKS caching and key refresh internally.
+
+import type { GatewayAuthConfig } from "@kilnai/core";
+
+/** Decoded JWT payload passed to downstream handlers */
+export interface JwtPayload {
+  readonly sub?: string;
+  readonly iss?: string;
+  readonly aud?: string | readonly string[];
+  readonly exp?: number;
+  readonly nbf?: number;
+  readonly iat?: number;
+  readonly jti?: string;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * A callable that verifies a raw JWT string and returns its decoded payload.
+ * Throws a jose error (JWTExpired, JWTInvalid, JWSSignatureVerificationFailed, etc.)
+ * if the token is missing, expired, or has an invalid signature.
+ */
+export type JwtVerifyFn = (token: string) => Promise<JwtPayload>;
+
+/**
+ * Build a JwtVerifyFn from a GatewayAuthConfig.
+ *
+ * RS256: uses jose's createRemoteJWKSet, which fetches and caches the JWKS
+ *        automatically, refreshing on key rotation (cache miss).
+ * HS256: imports the secret from process.env once at startup; fails fast if the
+ *        env var is not set.
+ */
+export async function buildJwtVerifier(config: GatewayAuthConfig): Promise<JwtVerifyFn> {
+  // Dynamic import: jose loads only when JWT auth is configured.
+  const { jwtVerify, createRemoteJWKSet } = await import("jose");
+
+  const verifyOptions = {
+    ...(config.issuer ? { issuer: config.issuer } : {}),
+    ...(config.audience ? { audience: config.audience } : {}),
+  };
+
+  if (config.algorithm === "RS256") {
+    const jwks = createRemoteJWKSet(new URL(config.jwksUri!), {
+      headers: { Accept: "application/json" },
+    });
+
+    return async (token: string): Promise<JwtPayload> => {
+      const { payload } = await jwtVerify(token, jwks, {
+        algorithms: ["RS256"],
+        ...verifyOptions,
+      });
+      return payload as JwtPayload;
+    };
+  }
+
+  // HS256: resolve secret at startup, not per-request
+  const secret = process.env[config.secretEnv!];
+  if (!secret) {
+    throw new Error(`Gateway JWT auth: env var "${config.secretEnv}" is not set`);
+  }
+
+  const secretBytes = new TextEncoder().encode(secret);
+
+  return async (token: string): Promise<JwtPayload> => {
+    const { payload } = await jwtVerify(token, secretBytes, {
+      algorithms: ["HS256"],
+      ...verifyOptions,
+    });
+    return payload as JwtPayload;
+  };
+}

--- a/packages/runtime/tests/gateway/auth-middleware.test.ts
+++ b/packages/runtime/tests/gateway/auth-middleware.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { Hono } from "hono";
-import { requireApiKey, requireBearer, requireWebhookSignature, isOriginAllowed } from "../../src/gateway/auth-middleware.js";
+import { requireApiKey, requireBearer, requireWebhookSignature, requireJwt, isOriginAllowed } from "../../src/gateway/auth-middleware.js";
 import { createHmac } from "node:crypto";
+import type { JwtVerifyFn, JwtPayload } from "../../src/gateway/jwt-verifier.js";
 
 function makeApp(middleware: Parameters<Hono["use"]>[1]): Hono {
   const app = new Hono();
@@ -211,5 +212,77 @@ describe("isOriginAllowed", () => {
 
   it("exact match: protocol matters", () => {
     expect(isOriginAllowed("http://example.com", ["https://example.com"])).toBe(false);
+  });
+});
+
+describe("requireJwt", () => {
+  const validPayload: JwtPayload = { sub: "user-123", iss: "https://auth.example.com" };
+
+  const successVerifier: JwtVerifyFn = async () => validPayload;
+  const failVerifier: JwtVerifyFn = async () => {
+    throw new Error("JWTExpired");
+  };
+
+  function makeApp(verifier: JwtVerifyFn): Hono {
+    const app = new Hono();
+    app.use("*", requireJwt(verifier));
+    app.get("/test", (c) => c.json({ ok: true, payload: c.get("jwtPayload") }));
+    return app;
+  }
+
+  it("allows request with valid JWT Bearer token", async () => {
+    const app = makeApp(successVerifier);
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer valid.jwt.token" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("attaches decoded payload to context on success", async () => {
+    const app = makeApp(successVerifier);
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer valid.jwt.token" },
+    });
+    const body = (await res.json()) as { payload: JwtPayload };
+    expect(body.payload.sub).toBe("user-123");
+  });
+
+  it("rejects request with missing Authorization header", async () => {
+    const app = makeApp(successVerifier);
+    const res = await app.request("/test");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("rejects request with non-Bearer Authorization scheme", async () => {
+    const app = makeApp(successVerifier);
+    const res = await app.request("/test", {
+      headers: { Authorization: "Basic dXNlcjpwYXNz" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects request when verifier throws (expired or invalid token)", async () => {
+    const app = makeApp(failVerifier);
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer expired.jwt.token" },
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("does not leak internal error details in 401 response", async () => {
+    const leakyVerifier: JwtVerifyFn = async () => {
+      throw new Error("Internal crypto error with sensitive info");
+    };
+    const app = makeApp(leakyVerifier);
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer any.token" },
+    });
+    const body = await res.text();
+    expect(body).not.toContain("sensitive info");
+    expect(body).not.toContain("crypto error");
   });
 });

--- a/packages/runtime/tests/gateway/jwt-verifier.test.ts
+++ b/packages/runtime/tests/gateway/jwt-verifier.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { JwtPayload } from "../../src/gateway/jwt-verifier.js";
+
+// jose is mocked so tests don't make real JWKS network calls
+vi.mock("jose", () => ({
+  jwtVerify: vi.fn(),
+  createRemoteJWKSet: vi.fn(),
+}));
+
+async function getJose() {
+  return (await import("jose")) as {
+    jwtVerify: ReturnType<typeof vi.fn>;
+    createRemoteJWKSet: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("buildJwtVerifier -- RS256", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("calls createRemoteJWKSet with the configured URL", async () => {
+    const jose = await getJose();
+    const mockJwks = Symbol("jwks");
+    jose.createRemoteJWKSet.mockReturnValue(mockJwks);
+    const mockPayload: JwtPayload = { sub: "user-1", iss: "https://auth.example.com" };
+    jose.jwtVerify.mockResolvedValue({ payload: mockPayload });
+
+    const { buildJwtVerifier } = await import("../../src/gateway/jwt-verifier.js");
+    const verify = await buildJwtVerifier({
+      algorithm: "RS256",
+      jwksUri: "https://auth.example.com/.well-known/jwks.json",
+    });
+
+    expect(jose.createRemoteJWKSet).toHaveBeenCalledWith(
+      new URL("https://auth.example.com/.well-known/jwks.json"),
+      expect.any(Object),
+    );
+
+    const result = await verify("fake.token.here");
+    expect(result.sub).toBe("user-1");
+  });
+
+  it("passes issuer and audience to jwtVerify when configured", async () => {
+    const jose = await getJose();
+    jose.createRemoteJWKSet.mockReturnValue(Symbol("jwks"));
+    jose.jwtVerify.mockResolvedValue({ payload: { sub: "u" } });
+
+    const { buildJwtVerifier } = await import("../../src/gateway/jwt-verifier.js");
+    const verify = await buildJwtVerifier({
+      algorithm: "RS256",
+      jwksUri: "https://auth.example.com/.well-known/jwks.json",
+      issuer: "https://auth.example.com",
+      audience: "kiln-api",
+    });
+
+    await verify("any.token");
+
+    const call = jose.jwtVerify.mock.calls[0] as unknown[];
+    const opts = call[2] as { issuer?: string; audience?: string };
+    expect(opts.issuer).toBe("https://auth.example.com");
+    expect(opts.audience).toBe("kiln-api");
+  });
+
+  it("propagates jose errors (expired, invalid signature) to the caller", async () => {
+    const jose = await getJose();
+    jose.createRemoteJWKSet.mockReturnValue(Symbol("jwks"));
+    jose.jwtVerify.mockRejectedValue(new Error("JWTExpired"));
+
+    const { buildJwtVerifier } = await import("../../src/gateway/jwt-verifier.js");
+    const verify = await buildJwtVerifier({
+      algorithm: "RS256",
+      jwksUri: "https://auth.example.com/.well-known/jwks.json",
+    });
+
+    await expect(verify("expired.token")).rejects.toThrow("JWTExpired");
+  });
+});
+
+describe("buildJwtVerifier -- HS256", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetAllMocks();
+  });
+
+  it("throws at startup when the secretEnv var is not set", async () => {
+    delete process.env["JWT_SECRET"];
+
+    const { buildJwtVerifier } = await import("../../src/gateway/jwt-verifier.js");
+    await expect(
+      buildJwtVerifier({ algorithm: "HS256", secretEnv: "JWT_SECRET" }),
+    ).rejects.toThrow(`env var "JWT_SECRET" is not set`);
+  });
+
+  it("builds a verifier when the secretEnv var is set", async () => {
+    process.env["JWT_SECRET"] = "a-valid-secret-of-at-least-32-characters!";
+
+    const jose = await getJose();
+    const mockPayload: JwtPayload = { sub: "user-2" };
+    jose.jwtVerify.mockResolvedValue({ payload: mockPayload });
+
+    const { buildJwtVerifier } = await import("../../src/gateway/jwt-verifier.js");
+    const verify = await buildJwtVerifier({ algorithm: "HS256", secretEnv: "JWT_SECRET" });
+
+    const result = await verify("some.hs256.token");
+    expect(result.sub).toBe("user-2");
+  });
+
+  it("passes HS256 algorithm constraint to jwtVerify", async () => {
+    process.env["JWT_SECRET"] = "a-valid-secret-of-at-least-32-characters!";
+
+    const jose = await getJose();
+    jose.jwtVerify.mockResolvedValue({ payload: { sub: "u" } });
+
+    const { buildJwtVerifier } = await import("../../src/gateway/jwt-verifier.js");
+    const verify = await buildJwtVerifier({ algorithm: "HS256", secretEnv: "JWT_SECRET" });
+    await verify("any.token");
+
+    const call = jose.jwtVerify.mock.calls[0] as unknown[];
+    const opts = call[2] as { algorithms?: string[] };
+    expect(opts.algorithms).toEqual(["HS256"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds optional gateway-level JWT authentication via the `auth` block in `gateway.yaml`
- RS256 mode fetches public keys from any JWKS endpoint — no shared secret, zero-trust inter-service auth
- HS256 mode uses a shared secret resolved from an env var at startup
- `requireJwt` middleware applied to API/admin/outbound/handoff/memory routes; webhook routes (WhatsApp, Instagram, etc.) unchanged
- Fully backward compatible — no `auth` block = zero behavior change

## Test plan

- [x] `bun run typecheck` — zero errors
- [x] `packages/core` tests — 2409 passed (includes new `auth-config.test.ts` + `gateway-loader.test.ts` auth block cases)
- [x] `packages/runtime` tests — 1389 passed (includes new `jwt-verifier.test.ts` + `requireJwt` cases in `auth-middleware.test.ts`)
- [x] Backward compat: all existing gateway tests pass unchanged