### PR TITLE
feat(gateway): add MCP server for external agent tooling

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,16 @@
+# Kiln Backlog
+
+## Gateway Runtime
+
+- [ ] **Env var resolution in `auth.jwksUri`** — The `jwksUri` field in `gateway.yaml` auth config does not resolve `$ENV_VAR` references like other config fields (e.g., header `$` tokens, `secretEnv`). Currently requires a hardcoded URL per environment. Should support `$ADMIT_JWKS_URI` syntax for consistency. Discovered 2026-03-14 during Admit JWT auth setup.
+
+## Message API
+
+- [x] **User context in message requests** — Add optional `context: Record<string, string>` to the message API so product backends can pass user metadata (role, name, locale) without coupling Kiln to any product's auth model. Kiln injects this as a `[User Context]` block in the agent's system prompt. Agent personas can reference `{{user.role}}`, `{{user.name}}`, etc. in backstory/goal templates. **BLOCKING for Admit Phase 2** — must be implemented before org-scoped tools. Discovered 2026-03-14. Implemented v0.21.0.
+
+## Phase 2 Execution Order (Admit)
+
+1. ~~**User context in message API** (this repo)~~ — DONE (v0.21.0)
+2. **Org-scoped endpoint** (admit backend) — refactor `/cinemas/{cinemaId}/ai/chat` → `/ai/chat`, role determines data scope
+3. **MCP tools** (this repo, apps/admit) — read-only queries: sales, occupancy, showtimes, inventory
+4. **Knowledge RAG** (this repo) — ingest Admit user docs and FAQs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Bun monorepo with 6 packages:
 | eval | `core/src/eval/` | 23 scorers (11 rule + 12 LLM-as-judge), dataset loader, experiment runner, comparator, consistency runner (pass^k) |
 | observability (core) | `core/src/observability/` | OTel span mapper (exhaustive event-to-span mapping) + OTelExporter (EventStore sink) |
 | observability (runtime) | `runtime/src/observability/` | PrometheusCollector (EventStore sink, dynamic prom-client import), CompositeEventStore (fan-out to multiple sinks) |
+| mcp (runtime) | `runtime/src/mcp/` | GatewayMcpServer (Streamable HTTP, stateless per-request, 7 tools: memory CRUD, knowledge search/sources, cost summary, safety metrics), GatewayMcpDeps, tool schemas, dynamic SDK import |
 | gateway | `runtime/src/gateway/` | Multi-app loading, Mode B routes, budget middleware, composable auth middleware (timing-safe, API key + JWT RS256/HS256 via JWKS), conversation event emitter (incl. tool execution events), delegation, dev routes, safety/security middleware, audio preprocessing, knowledge pipeline wiring, STT/knowledge factories, webhook tool executor, integration runtime (IntegrationRegistry + IntegrationExecutor + LocalCredentialResolver), tenant tool factory, Meta webhook foundation (shared verification + HMAC-SHA256), WebhookDedup (Meta at-least-once protection), Instagram/Messenger/Email webhook routes, email loop guard, SqliteEmailThreadStore, WebSocket heartbeat (30s ping, 90s timeout), WhatsApp coexistence auto-handoff (smb_message_echoes) |
 | a2a | `runtime/src/a2a/` | A2AClient (outbound delegation only) |
 | trigger | `runtime/src/trigger/` | TriggerRegistry, webhook handler (HMAC-SHA256), event listener, cron scheduler |
@@ -178,7 +179,7 @@ Scopes: core, engine, orchestrator, agents, domain, package, skill, memory, tree
 
 | File | Purpose |
 |------|---------|
-| `gateway/gateway-server.ts` | startGateway() + startDevServer(): Bun.serve, multi-app, Mode B, triggers, dev mode, lightweight Mode A dashboard, integration adapter wiring (StartGatewayOptions.integrations + secretKeyEnv) |
+| `gateway/gateway-server.ts` | startGateway() + startDevServer(): Bun.serve, multi-app, Mode B, triggers, dev mode, lightweight Mode A dashboard, integration adapter wiring (StartGatewayOptions.integrations + secretKeyEnv), MCP server wiring (optional, gateway.yaml `mcp` block) |
 | `gateway/gateway-routes.ts` | Hono app factory: health + per-App routes + A2A + webhooks |
 | `gateway/auth-middleware.ts` | Composable auth: requireApiKey, requireBearer, requireWebhookSignature, requireJwt, isOriginAllowed |
 | `gateway/jwt-verifier.ts` | JWT verification: buildJwtVerifier() -- RS256 via JWKS (jose createRemoteJWKSet) or HS256 via shared secret |
@@ -243,6 +244,9 @@ Scopes: core, engine, orchestrator, agents, domain, package, skill, memory, tree
 | `enrichment/enrichment-runner.ts` | Fire-and-forget post-conversation enrichment runner |
 | `observability/prometheus-collector.ts` | PrometheusCollector EventStore (counters, histograms, /metrics) |
 | `observability/composite-event-store.ts` | Fan-out to multiple EventStore sinks |
+| `mcp/gateway-mcp-server.ts` | GatewayMcpServer: MCP Streamable HTTP server exposing 7 gateway tools (stateless per-request, dynamic SDK import, optional api-key auth) |
+| `mcp/gateway-mcp-types.ts` | GatewayMcpDeps: dependency injection interface for gateway capabilities |
+| `mcp/tool-schemas.ts` | JSON Schema definitions for 7 MCP tools (memory CRUD, knowledge search/sources, cost, safety) |
 
 ### CLI (`packages/cli/src/`)
 
@@ -260,7 +264,7 @@ Expose integration adapters as MCP tools (same implementation, two surfaces). Ph
 
 ### MCP-First Orchestration Layer
 
-Kiln as production runtime for CLI agents (Claude Code, Codex CLI, Goose) via MCP. Expand tool surface (knowledge, safety, routing, eval, enrichment). MCP server mode for gateway (Streamable HTTP). Cross-agent memory, swarm primitives, budget enforcement. Research needed.
+Kiln as production runtime for CLI agents (Claude Code, Codex CLI, Goose) via MCP. Phase 1 (gateway MCP server with 7 tools) complete. Remaining: expand tool surface (routing, eval, enrichment), cross-agent memory, swarm primitives, budget enforcement.
 
 ### OpenKiln (Personal AI Agent)
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/cli": {
       "name": "@kilnai/cli",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "bin": {
         "kiln": "./dist/index.js",
       },
@@ -33,7 +33,7 @@
     },
     "packages/core": {
       "name": "@kilnai/core",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -55,24 +55,26 @@
     },
     "packages/runtime": {
       "name": "@kilnai/runtime",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "dependencies": {
         "hono": "^4.7.0",
         "jose": "^5.0.0",
       },
       "peerDependencies": {
         "@kilnai/core": "workspace:*",
+        "@modelcontextprotocol/sdk": "^1.12.0",
         "@opentelemetry/api": "^1.9.0",
         "ioredis": ">=5.0.0",
       },
       "optionalPeers": [
+        "@modelcontextprotocol/sdk",
         "@opentelemetry/api",
         "ioredis",
       ],
     },
     "packages/sdk": {
       "name": "@kilnai/react",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
         "@types/react": "^19.0.0",
@@ -104,7 +106,7 @@
     },
     "packages/widget": {
       "name": "@kilnai/widget",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "devDependencies": {
         "jsdom": "^25.0.0",
         "vitest": "^4.0.18",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.22.0 (2026-03-24) -- Gateway MCP Server
+
+### MCP Tool Surface for External Agents
+
+- **`GatewayMcpConfig`** (`core/src/engine/gateway/mcp-config.ts`): New domain type for gateway-level MCP server configuration. Fields: `enabled`, optional `path` (default `/mcp`), optional `auth` (`api-key` with `keyEnv`, or `none`). Exported from `@kilnai/core`.
+- **`mcp` block in `gateway.yaml`**: Top-level optional config. Parsed and validated by `parseGatewayYaml` with the same error accumulation pattern as `auth` and `observability`.
+- **`GatewayMcpServer`** (`runtime/src/mcp/gateway-mcp-server.ts`): MCP server exposing 7 gateway tools via Streamable HTTP. Uses the low-level `Server` class with raw JSON Schema (no Zod dependency). Stateless per-request: fresh Server+Transport pair per request (MCP Streamable HTTP spec). `enableJsonResponse: true` for direct JSON responses. Dynamic `import("@modelcontextprotocol/sdk")` — optional peer dep, fail-open at startup.
+- **7 MCP tools**: `memory_recall` (FTS search by scope), `memory_store`, `memory_delete`, `knowledge_search` (RAG retrieval), `knowledge_sources` (list), `cost_summary` (token counts + USD), `safety_metrics` (PII/content/rail metrics).
+- **`GatewayMcpDeps`** (`runtime/src/mcp/gateway-mcp-types.ts`): Dependency injection interface decoupling tool handlers from concrete gateway wiring.
+- **Gateway wiring**: `startGateway()` initializes `GatewayMcpServer` when `mcp.enabled: true`. Mounts on configurable path via `honoApp.all()`. Resolves API key from env var. Cleanup on shutdown.
+- **`@modelcontextprotocol/sdk`**: Added as optional peer dependency to `@kilnai/runtime` (`^1.12.0`).
+
+**Config example:**
+
+```yaml
+mcp:
+  enabled: true
+  path: /mcp
+  auth:
+    type: api-key
+    keyEnv: MCP_API_KEY
+```
+
 ## v0.20.0 (2026-03-14) -- Gateway JWT Auth (RS256 + HS256)
 
 ### Zero-Trust Inter-Service Authentication

--- a/packages/core/src/engine/domain/user-context.ts
+++ b/packages/core/src/engine/domain/user-context.ts
@@ -1,0 +1,1 @@
+export type UserContext = Record<string, string>;

--- a/packages/core/src/engine/gateway/gateway-config.ts
+++ b/packages/core/src/engine/gateway/gateway-config.ts
@@ -3,6 +3,7 @@
 
 import type { ObservabilityConfig } from "./observability-config.js";
 import type { GatewayAuthConfig } from "./auth-config.js";
+import type { GatewayMcpConfig } from "./mcp-config.js";
 
 /** Channel binding for a specific platform adapter */
 export interface GatewayChannelBinding {
@@ -33,6 +34,7 @@ export interface GatewayConfig {
   readonly apps: readonly GatewayAppBinding[];
   readonly observability?: ObservabilityConfig;
   readonly auth?: GatewayAuthConfig;
+  readonly mcp?: GatewayMcpConfig;
 }
 
 /** Validation error for gateway configuration */

--- a/packages/core/src/engine/gateway/gateway-loader.ts
+++ b/packages/core/src/engine/gateway/gateway-loader.ts
@@ -9,6 +9,8 @@ import type { ObservabilityConfig } from "./observability-config.js";
 import { validateObservabilityConfig } from "./observability-config.js";
 import type { GatewayAuthConfig } from "./auth-config.js";
 import { validateGatewayAuthConfig } from "./auth-config.js";
+import type { GatewayMcpConfig } from "./mcp-config.js";
+import { validateGatewayMcpConfig } from "./mcp-config.js";
 
 /** Error class for gateway YAML loader failures, aggregating all validation errors */
 export class GatewayLoaderError extends KilnError {
@@ -49,6 +51,7 @@ interface RawGateway {
   apps?: unknown;
   observability?: unknown;
   auth?: unknown;
+  mcp?: unknown;
 }
 
 // ---------------------------------------------------------------------------
@@ -206,9 +209,39 @@ export function parseGatewayYaml(content: string): GatewayConfig {
     }
   }
 
+  // Parse optional mcp block
+  let mcp: GatewayMcpConfig | undefined;
+  if (raw.mcp !== undefined) {
+    if (typeof raw.mcp !== "object" || Array.isArray(raw.mcp) || raw.mcp === null) {
+      errors.push({ field: "mcp", message: "must be an object" });
+    } else {
+      const rawMcp = raw.mcp as Record<string, unknown>;
+      const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+      let mcpAuth: GatewayMcpConfig["auth"] | undefined;
+      if (rawMcp["auth"] && typeof rawMcp["auth"] === "object" && !Array.isArray(rawMcp["auth"])) {
+        const rawMcpAuth = rawMcp["auth"] as Record<string, unknown>;
+        mcpAuth = {
+          type: (str(rawMcpAuth["type"]) ?? "") as "api-key" | "none",
+          ...(str(rawMcpAuth["keyEnv"]) ? { keyEnv: str(rawMcpAuth["keyEnv"]) } : {}),
+        };
+      }
+      const parsed: GatewayMcpConfig = {
+        enabled: typeof rawMcp["enabled"] === "boolean" ? rawMcp["enabled"] : false,
+        ...(typeof rawMcp["path"] === "string" ? { path: rawMcp["path"] } : {}),
+        ...(mcpAuth ? { auth: mcpAuth } : {}),
+      };
+      const mcpErrors = validateGatewayMcpConfig(parsed);
+      if (mcpErrors.length > 0) {
+        errors.push(...mcpErrors);
+      } else {
+        mcp = parsed;
+      }
+    }
+  }
+
   if (errors.length > 0) throw new GatewayLoaderError(errors);
 
-  const config: GatewayConfig = { port, apps, ...(observability ? { observability } : {}), ...(auth ? { auth } : {}) };
+  const config: GatewayConfig = { port, apps, ...(observability ? { observability } : {}), ...(auth ? { auth } : {}), ...(mcp ? { mcp } : {}) };
 
   const validationErrors = validateGatewayConfig(config);
   if (validationErrors.length > 0) throw new GatewayLoaderError(validationErrors);

--- a/packages/core/src/engine/gateway/mcp-config.ts
+++ b/packages/core/src/engine/gateway/mcp-config.ts
@@ -1,0 +1,62 @@
+// Engine type: GatewayMcpConfig -- gateway-level MCP server configuration
+// Domain types only -- no external dependencies
+
+/** Authentication type for the MCP server endpoint */
+export type McpAuthType = "api-key" | "none";
+
+/** Authentication configuration for the MCP server */
+export interface GatewayMcpAuthConfig {
+  readonly type: McpAuthType;
+  /** Required when type is "api-key": env var name containing the API key */
+  readonly keyEnv?: string;
+}
+
+/**
+ * Gateway-level MCP server configuration.
+ * Loaded from the `mcp` block in gateway.yaml.
+ *
+ * Exposes internal gateway capabilities (memory, knowledge, cost, eval)
+ * as MCP tools for external agents (Claude Code, Codex CLI, etc.).
+ */
+export interface GatewayMcpConfig {
+  readonly enabled: boolean;
+  /** URL path where the MCP server listens (default: "/mcp") */
+  readonly path?: string;
+  /** Optional authentication for the MCP endpoint */
+  readonly auth?: GatewayMcpAuthConfig;
+}
+
+/** Validation error for MCP configuration */
+export interface GatewayMcpValidationError {
+  readonly field: string;
+  readonly message: string;
+}
+
+const VALID_AUTH_TYPES: readonly McpAuthType[] = ["api-key", "none"];
+
+/** Validate a GatewayMcpConfig. Returns an array of errors; empty means valid. */
+export function validateGatewayMcpConfig(config: GatewayMcpConfig): GatewayMcpValidationError[] {
+  const errors: GatewayMcpValidationError[] = [];
+
+  if (typeof config.enabled !== "boolean") {
+    errors.push({ field: "mcp.enabled", message: "must be a boolean" });
+  }
+
+  if (config.path !== undefined) {
+    if (typeof config.path !== "string" || !config.path.startsWith("/")) {
+      errors.push({ field: "mcp.path", message: "must be a string starting with \"/\"" });
+    }
+  }
+
+  if (config.auth !== undefined) {
+    if (!VALID_AUTH_TYPES.includes(config.auth.type)) {
+      errors.push({ field: "mcp.auth.type", message: `must be one of: ${VALID_AUTH_TYPES.join(", ")}` });
+    } else if (config.auth.type === "api-key") {
+      if (!config.auth.keyEnv || typeof config.auth.keyEnv !== "string" || !config.auth.keyEnv.trim()) {
+        errors.push({ field: "mcp.auth.keyEnv", message: "required when type is api-key" });
+      }
+    }
+  }
+
+  return errors;
+}

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -74,6 +74,15 @@ export type {
 export { validateGatewayConfig } from "./gateway/gateway-config.js";
 export { GatewayLoaderError, parseGatewayYaml } from "./gateway/gateway-loader.js";
 
+// MCP server config (Phase 28)
+export type {
+  GatewayMcpConfig,
+  GatewayMcpAuthConfig,
+  GatewayMcpValidationError,
+  McpAuthType,
+} from "./gateway/mcp-config.js";
+export { validateGatewayMcpConfig } from "./gateway/mcp-config.js";
+
 // Mode B -- provider-adapter runtime config (Phase 23)
 export type {
   RuntimeMode,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export type { UserContext } from "./engine/domain/user-context.js";
 export * from "./orchestrator/index.js";
 export * from "./agents/index.js";
 export * from "./domain/index.js";

--- a/packages/core/tests/engine/gateway/mcp-config.test.ts
+++ b/packages/core/tests/engine/gateway/mcp-config.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { validateGatewayMcpConfig } from "../../../src/engine/gateway/mcp-config.js";
+import type { GatewayMcpConfig } from "../../../src/engine/gateway/mcp-config.js";
+
+describe("validateGatewayMcpConfig", () => {
+  it("accepts valid config with enabled: true and no auth", () => {
+    const config: GatewayMcpConfig = { enabled: true };
+    expect(validateGatewayMcpConfig(config)).toHaveLength(0);
+  });
+
+  it("accepts valid config with enabled: false", () => {
+    const config: GatewayMcpConfig = { enabled: false };
+    expect(validateGatewayMcpConfig(config)).toHaveLength(0);
+  });
+
+  it("accepts valid config with path override", () => {
+    const config: GatewayMcpConfig = { enabled: true, path: "/mcp/v1" };
+    expect(validateGatewayMcpConfig(config)).toHaveLength(0);
+  });
+
+  it("accepts valid config with auth type api-key and keyEnv", () => {
+    const config: GatewayMcpConfig = {
+      enabled: true,
+      auth: { type: "api-key", keyEnv: "MCP_API_KEY" },
+    };
+    expect(validateGatewayMcpConfig(config)).toHaveLength(0);
+  });
+
+  it("accepts valid config with auth type none", () => {
+    const config: GatewayMcpConfig = {
+      enabled: true,
+      auth: { type: "none" },
+    };
+    expect(validateGatewayMcpConfig(config)).toHaveLength(0);
+  });
+
+  it("rejects enabled not boolean", () => {
+    const config = { enabled: "yes" } as unknown as GatewayMcpConfig;
+    const errors = validateGatewayMcpConfig(config);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.field).toBe("mcp.enabled");
+  });
+
+  it("rejects path not starting with /", () => {
+    const config: GatewayMcpConfig = { enabled: true, path: "mcp" };
+    const errors = validateGatewayMcpConfig(config);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.field).toBe("mcp.path");
+  });
+
+  it("rejects auth type api-key without keyEnv", () => {
+    const config: GatewayMcpConfig = {
+      enabled: true,
+      auth: { type: "api-key" },
+    };
+    const errors = validateGatewayMcpConfig(config);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.field).toBe("mcp.auth.keyEnv");
+  });
+
+  it("rejects unknown auth type", () => {
+    const config = {
+      enabled: true,
+      auth: { type: "bearer" },
+    } as unknown as GatewayMcpConfig;
+    const errors = validateGatewayMcpConfig(config);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.field).toBe("mcp.auth.type");
+  });
+});

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -44,10 +44,14 @@
   },
   "peerDependencies": {
     "@kilnai/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "@opentelemetry/api": "^1.9.0",
     "ioredis": ">=5.0.0"
   },
   "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    },
     "@opentelemetry/api": {
       "optional": true
     },

--- a/packages/runtime/src/gateway/context-formatter.ts
+++ b/packages/runtime/src/gateway/context-formatter.ts
@@ -19,6 +19,11 @@ export function formatContactContext(facts: readonly ContactFact[]): string | un
   return "--- Customer Context ---\n" + facts.map((f) => f.content).join("\n") + "\n---";
 }
 
+export function formatUserContext(ctx: Record<string, string> | undefined): string | undefined {
+  if (!ctx || Object.keys(ctx).length === 0) return undefined;
+  return "[User Context]:\n" + Object.entries(ctx).map(([k, v]) => `${k}: ${v}`).join("\n");
+}
+
 export function mergeContextSources(...sources: (string | undefined)[]): string | undefined {
   const filtered = sources.filter(Boolean);
   return filtered.length > 0 ? filtered.join("\n\n") : undefined;

--- a/packages/runtime/src/gateway/gateway-server.ts
+++ b/packages/runtime/src/gateway/gateway-server.ts
@@ -842,8 +842,7 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
         getTriggers: () => triggerRegistry.listAll(),
         getMemoryByScope: async (scope: string, q?: string, tags?: string) => {
           if (!devMemoryStores) return [];
-          const validLayers: MemoryLayer[] = ["user", "agent", "project"];
-          const layer = validLayers.includes(scope as MemoryLayer) ? (scope as MemoryLayer) : "project";
+          const layer = resolveMemoryLayer(scope);
           const store = devMemoryStores.get(layer);
           if (!store) return [];
 
@@ -875,10 +874,7 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
         },
         createMemoryEntry: async (entry: Record<string, unknown>) => {
           if (!devMemoryStores) return { id: "" };
-          const validLayers: MemoryLayer[] = ["user", "agent", "project"];
-          const layer = validLayers.includes(entry["layer"] as MemoryLayer)
-            ? (entry["layer"] as MemoryLayer)
-            : "project";
+          const layer = resolveMemoryLayer(entry["layer"]);
           const store = devMemoryStores.get(layer);
           if (!store) return { id: "" };
 
@@ -953,6 +949,96 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
     return c.text(metrics, 200, { "Content-Type": registry.contentType });
   });
 
+  // MCP server: expose gateway capabilities as MCP tools for external agents
+  let mcpServerInstance: { close(): Promise<void> } | undefined;
+  if (gatewayConfig.mcp?.enabled) {
+    try {
+      const { GatewayMcpServer } = await import("../mcp/gateway-mcp-server.js");
+      const mcpPath = gatewayConfig.mcp.path ?? "/mcp";
+      const mcpApiKey =
+        gatewayConfig.mcp.auth?.type === "api-key" && gatewayConfig.mcp.auth.keyEnv
+          ? process.env[gatewayConfig.mcp.auth.keyEnv]
+          : undefined;
+
+      const mcpServer = new GatewayMcpServer({
+        deps: {
+          getMemoryByScope: devMemoryStores
+            ? async (scope: string, q?: string, tags?: string) => {
+                const layer = resolveMemoryLayer(scope);
+                const store = devMemoryStores!.get(layer);
+                if (!store) return [];
+                if (q) {
+                  const results = await store.search(q, 100);
+                  return results.map((r) => ({
+                    id: r.entry.id, layer: r.entry.layer, content: r.entry.content,
+                    tags: r.entry.tags, score: r.score, snippet: r.snippet,
+                  }));
+                }
+                return store.listEntries({ tags }).map((e) => ({
+                  id: e.id, layer: e.layer, content: e.content, tags: e.tags,
+                }));
+              }
+            : undefined,
+          createMemoryEntry: devMemoryStores
+            ? async (entry: Record<string, unknown>) => {
+                const layer = resolveMemoryLayer(entry["scope"]);
+                const store = devMemoryStores!.get(layer);
+                if (!store) return { id: "" };
+                const content = typeof entry["content"] === "string" ? entry["content"] : String(entry["content"] ?? "");
+                const rawTags = typeof entry["tags"] === "string" ? entry["tags"].split(",").map((t) => t.trim()) : [];
+                const id = await store.save({ layer, content, tags: rawTags });
+                return { id };
+              }
+            : undefined,
+          deleteMemoryEntry: devMemoryStores
+            ? async (id: string) => {
+                for (const store of devMemoryStores!.values()) {
+                  if (store.hasEntry(id)) { await store.forget(id); return true; }
+                }
+                return false;
+              }
+            : undefined,
+          searchKnowledge: async (appName: string, query: string, limit?: number) => {
+            const loaded = loadedApps.find((a) => a.name === appName);
+            if (!loaded?.knowledgePipeline) return { results: [] };
+            const results = await loaded.knowledgePipeline.pipeline.retrieve(query, { topK: limit });
+            return {
+              results: results.map((r) => ({
+                content: r.content,
+                score: r.score,
+                source: r.metadata?.source as string | undefined,
+              })),
+            };
+          },
+          listKnowledgeSources: (appName: string) => {
+            const loaded = loadedApps.find((a) => a.name === appName);
+            if (!loaded?.knowledgeAdminConfig) return { sources: [] };
+            const sources = loaded.knowledgeAdminConfig.sourceManager.list(appName);
+            return { sources: sources.map((s) => ({ ...s })) };
+          },
+          getCostSummary: () => costTracker.summary,
+          getSafetyMetrics: () => {
+            if (safetyPipelines.size === 0) return { enabled: false };
+            const apps: Record<string, unknown> = {};
+            for (const [appName, pipeline] of safetyPipelines) apps[appName] = pipeline.metrics;
+            return { enabled: true, apps };
+          },
+        },
+        apiKey: mcpApiKey,
+      });
+
+      await mcpServer.initialize();
+      mcpServerInstance = mcpServer;
+
+      honoApp.all(`${mcpPath}`, async (c) => mcpServer.handleRequest(c.req.raw));
+      honoApp.all(`${mcpPath}/*`, async (c) => mcpServer.handleRequest(c.req.raw));
+
+      console.log(`MCP server: listening on ${mcpPath}${mcpApiKey ? " (api-key auth)" : " (no auth)"}`);
+    } catch (err) {
+      console.warn(`MCP server: failed to initialize -- ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   triggerRegistry.start();
 
   const appNames = loadedApps.map((a) => a.name).join(", ");
@@ -964,10 +1050,17 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
   await serveAndWait(honoApp, port, () => {
     triggerRegistry.stop();
     webhookDedup.close();
+    mcpServerInstance?.close().catch(() => {});
     for (const loaded of loadedApps) {
       loaded.knowledgePipeline?.close().catch(() => {});
     }
   }, bunWebsocket);
+}
+
+const VALID_MEMORY_LAYERS: MemoryLayer[] = ["user", "agent", "project"];
+
+function resolveMemoryLayer(scope: unknown): MemoryLayer {
+  return VALID_MEMORY_LAYERS.includes(scope as MemoryLayer) ? (scope as MemoryLayer) : "project";
 }
 
 /** Create a ProviderAdapter from a Mode B provider config */

--- a/packages/runtime/src/gateway/message-pipeline.ts
+++ b/packages/runtime/src/gateway/message-pipeline.ts
@@ -10,7 +10,7 @@ import type { ConversationEventEmitter } from "./conversation-event-emitter.js";
 import type { SessionMode } from "../session/session-mode.js";
 import type { EscalationSignal } from "../session/escalation-detector.js";
 import { TraceContext } from "./trace-context.js";
-import { appendGroundingDirective } from "./context-formatter.js";
+import { appendGroundingDirective, formatUserContext } from "./context-formatter.js";
 
 export interface InboundMessageContext {
   readonly orchestrator: ModeBOrchestrator;
@@ -45,6 +45,7 @@ export interface InboundMessageContext {
   readonly skillRegistry?: SkillRegistry;
   readonly activeSkills?: readonly string[];
   readonly activeSkillTags?: readonly string[];
+  readonly userContext?: Record<string, string>;
   readonly groundingMode?: GroundingMode;
   readonly groundingDeps?: {
     readonly rail: GroundingRail;
@@ -114,6 +115,11 @@ export async function processInboundMessage(ctx: InboundMessageContext): Promise
     idleTimeoutMs: ctx.idleTimeoutMs,
   });
   trace.log("pipeline", "Session ready", { sessionId: session.id, sessionMode: session.sessionMode });
+
+  // Merge incoming user context into session (merge semantics: keys accumulate)
+  if (ctx.userContext && Object.keys(ctx.userContext).length > 0) {
+    session.updateUserContext(ctx.userContext);
+  }
 
   // Session turn limit check
   if (ctx.sessionLimits?.maxTurns && session.userTurnCount >= ctx.sessionLimits.maxTurns) {
@@ -220,8 +226,9 @@ export async function processInboundMessage(ctx: InboundMessageContext): Promise
     }
   }
 
-  // Merge recalled memory + knowledge context + contact context
-  const mergedMemory = [ctx.recalledMemory, ctx.knowledgeContext, ctx.contactContext].filter(Boolean).join("\n\n") || undefined;
+  // Merge recalled memory + knowledge context + contact context (user context goes first)
+  const userCtxBlock = formatUserContext(session.userContext);
+  const mergedMemory = [userCtxBlock, ctx.recalledMemory, ctx.knowledgeContext, ctx.contactContext].filter(Boolean).join("\n\n") || undefined;
   const combinedMemory = appendGroundingDirective(mergedMemory, ctx.groundingMode);
 
   // Resolve active skills

--- a/packages/runtime/src/gateway/mode-b-routes.ts
+++ b/packages/runtime/src/gateway/mode-b-routes.ts
@@ -37,6 +37,7 @@ interface MessageRequest {
   readonly parts?: readonly ContentPart[];
   readonly userId: string;
   readonly plan?: string;
+  readonly context?: Record<string, string>;
 }
 
 export function createModeBRoutes(runtime: ModeBAppRuntime): Hono {
@@ -65,6 +66,19 @@ export function createModeBRoutes(runtime: ModeBAppRuntime): Hono {
     if (!body.userId || typeof body.userId !== "string") {
       return c.json({ error: "userId is required" }, 400);
     }
+
+    // Validate optional context: must be a plain non-array object with string values
+    if (body.context !== undefined) {
+      if (typeof body.context !== "object" || Array.isArray(body.context) || body.context === null) {
+        return c.json({ error: "context must be a plain object" }, 400);
+      }
+      for (const val of Object.values(body.context)) {
+        if (typeof val !== "string") {
+          return c.json({ error: "context values must be strings" }, 400);
+        }
+      }
+    }
+    const userContext = body.context;
 
     // Tier enforcement (Mode B specific -- not in the pipeline)
     if (runtime.billing?.tiers && body.plan) {
@@ -105,9 +119,14 @@ export function createModeBRoutes(runtime: ModeBAppRuntime): Hono {
         userId: body.userId,
         systemPrompt: "",
       });
+      // Apply user context before agent resolution so persona interpolation uses current context
+      if (userContext && Object.keys(userContext).length > 0) {
+        session.updateUserContext(userContext);
+      }
       const agentCtx = await resolveAgentContextAsync(
         runtime.tenant, userParts, session,
         { handoffSummarizer: runtime.handoffSummarizer, eventBus: runtime.eventBus },
+        undefined, undefined, session.userContext,
       );
       systemPrompt = agentCtx.systemPrompt;
       activeAgentId = agentCtx.activeAgentId;
@@ -136,6 +155,7 @@ export function createModeBRoutes(runtime: ModeBAppRuntime): Hono {
         billing: runtime.billing,
         channel: "api",
         knowledgeContext,
+        userContext,
         groundingMode: runtime.tenant?.groundingMode,
         groundingDeps: runtime.groundingDeps,
         activeAgentId,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -182,6 +182,10 @@ export { LocalCredentialResolver } from "./gateway/local-credential-resolver.js"
 export { configureIntegrationDeps, clearIntegrationDeps } from "./gateway/tenant-tool-factory.js";
 export type { IntegrationDeps } from "./gateway/tenant-tool-factory.js";
 
+// MCP Server
+export { GatewayMcpServer, GATEWAY_MCP_TOOLS } from "./mcp/index.js";
+export type { GatewayMcpServerOptions, GatewayMcpDeps, GatewayMcpToolName } from "./mcp/index.js";
+
 // Auth
 export { requireApiKey, requireBearer, requireWebhookSignature, isOriginAllowed } from "./gateway/auth-middleware.js";
 

--- a/packages/runtime/src/mcp/gateway-mcp-server.ts
+++ b/packages/runtime/src/mcp/gateway-mcp-server.ts
@@ -1,0 +1,251 @@
+// MCP server: exposes gateway capabilities as MCP tools via Streamable HTTP
+// Uses the low-level Server class with raw JSON Schema (no Zod dependency)
+// @modelcontextprotocol/sdk is an optional peer dep — dynamically imported
+
+import type { GatewayMcpDeps } from "./gateway-mcp-types.js";
+import { GATEWAY_MCP_TOOLS } from "./tool-schemas.js";
+import type { GatewayMcpToolName } from "./tool-schemas.js";
+
+const SERVER_NAME = "kilnai-gateway";
+const SERVER_VERSION = "0.1.0";
+
+export interface GatewayMcpServerOptions {
+  readonly deps: GatewayMcpDeps;
+  /** Optional API key for authentication (resolved from config.auth.keyEnv by the gateway) */
+  readonly apiKey?: string;
+}
+
+// Dynamically-resolved SDK types (set once during initialize)
+interface SdkModules {
+  Server: new (
+    info: { name: string; version: string },
+    opts: { capabilities: Record<string, unknown> },
+  ) => McpServerInstance;
+  WebStandardStreamableHTTPServerTransport: new (opts: {
+    sessionIdGenerator?: (() => string) | undefined;
+    enableJsonResponse?: boolean;
+  }) => McpTransport;
+  ListToolsRequestSchema: unknown;
+  CallToolRequestSchema: unknown;
+}
+
+interface McpServerInstance {
+  setRequestHandler(schema: unknown, handler: (request: { params: Record<string, unknown> }) => unknown): void;
+  connect(transport: McpTransport): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface McpTransport {
+  handleRequest(req: Request): Promise<Response>;
+  close?(): Promise<void>;
+}
+
+/**
+ * MCP server that exposes gateway capabilities (memory, knowledge, cost, safety)
+ * as tools for external agents via Streamable HTTP transport.
+ *
+ * Each request creates a fresh Server+Transport pair (stateless mode) to comply with
+ * the MCP Streamable HTTP spec. Handler registration is amortized via a shared setup fn.
+ *
+ * Dynamic-imports @modelcontextprotocol/sdk at startup — fails gracefully if not installed.
+ */
+export class GatewayMcpServer {
+  private readonly deps: GatewayMcpDeps;
+  private readonly apiKey?: string;
+  private sdk: SdkModules | undefined;
+
+  constructor(options: GatewayMcpServerOptions) {
+    this.deps = options.deps;
+    this.apiKey = options.apiKey;
+  }
+
+  /** Load SDK modules. Must be called before handleRequest(). */
+  async initialize(): Promise<void> {
+    const { Server } = await import("@modelcontextprotocol/sdk/server/index.js");
+    const { WebStandardStreamableHTTPServerTransport } = await import(
+      "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
+    );
+    const { ListToolsRequestSchema, CallToolRequestSchema } = await import("@modelcontextprotocol/sdk/types.js");
+
+    this.sdk = {
+      Server: Server as unknown as SdkModules["Server"],
+      WebStandardStreamableHTTPServerTransport:
+        WebStandardStreamableHTTPServerTransport as unknown as SdkModules["WebStandardStreamableHTTPServerTransport"],
+      ListToolsRequestSchema,
+      CallToolRequestSchema,
+    };
+  }
+
+  /** Route an incoming HTTP request to a per-request MCP server. */
+  async handleRequest(req: Request): Promise<Response> {
+    if (!this.sdk) {
+      return new Response(JSON.stringify({ error: "MCP server not initialized" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (this.apiKey) {
+      const auth = req.headers.get("Authorization");
+      if (!auth || auth !== `Bearer ${this.apiKey}`) {
+        return new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    // Stateless mode: fresh Server + Transport per request (MCP Streamable HTTP spec)
+    const server = this.createServer();
+    const transport = new this.sdk.WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    await server.connect(transport);
+
+    try {
+      return await transport.handleRequest(req);
+    } finally {
+      await server.close();
+    }
+  }
+
+  /** Shut down (no-op for stateless mode, kept for interface symmetry). */
+  async close(): Promise<void> {
+    this.sdk = undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Server factory (creates a configured Server per request)
+  // ---------------------------------------------------------------------------
+
+  private createServer(): McpServerInstance {
+    const { Server, ListToolsRequestSchema, CallToolRequestSchema } = this.sdk!;
+    const server = new Server({ name: SERVER_NAME, version: SERVER_VERSION }, { capabilities: { tools: {} } });
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: GATEWAY_MCP_TOOLS.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    }));
+
+    server.setRequestHandler(CallToolRequestSchema, async (request: { params: Record<string, unknown> }) => {
+      const params = request.params as { name: string; arguments?: Record<string, unknown> };
+      return this.dispatch(params.name as GatewayMcpToolName, params.arguments ?? {});
+    });
+
+    return server;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tool dispatch
+  // ---------------------------------------------------------------------------
+
+  private async dispatch(
+    toolName: GatewayMcpToolName,
+    args: Record<string, unknown>,
+  ): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
+    try {
+      switch (toolName) {
+        case "memory_recall":
+          return await this.handleMemoryRecall(args);
+        case "memory_store":
+          return await this.handleMemoryStore(args);
+        case "memory_delete":
+          return await this.handleMemoryDelete(args);
+        case "knowledge_search":
+          return await this.handleKnowledgeSearch(args);
+        case "knowledge_sources":
+          return await this.handleKnowledgeSources(args);
+        case "cost_summary":
+          return this.handleCostSummary();
+        case "safety_metrics":
+          return this.handleSafetyMetrics();
+        default:
+          return this.errorResult(`Unknown tool: ${toolName}`);
+      }
+    } catch (err) {
+      return this.errorResult(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tool handlers
+  // ---------------------------------------------------------------------------
+
+  private async handleMemoryRecall(
+    args: Record<string, unknown>,
+  ): Promise<{ content: { type: "text"; text: string }[] }> {
+    if (!this.deps.getMemoryByScope) return this.errorResult("Memory recall not available");
+    const scope = args["scope"] as string;
+    const query = args["query"] as string | undefined;
+    const tags = args["tags"] as string | undefined;
+    const entries = await this.deps.getMemoryByScope(scope, query, tags);
+    return this.jsonResult(entries);
+  }
+
+  private async handleMemoryStore(
+    args: Record<string, unknown>,
+  ): Promise<{ content: { type: "text"; text: string }[] }> {
+    if (!this.deps.createMemoryEntry) return this.errorResult("Memory store not available");
+    const result = await this.deps.createMemoryEntry({
+      scope: args["scope"],
+      key: args["key"],
+      content: args["content"],
+      ...(args["tags"] ? { tags: args["tags"] } : {}),
+    });
+    return this.jsonResult(result);
+  }
+
+  private async handleMemoryDelete(
+    args: Record<string, unknown>,
+  ): Promise<{ content: { type: "text"; text: string }[] }> {
+    if (!this.deps.deleteMemoryEntry) return this.errorResult("Memory delete not available");
+    const deleted = await this.deps.deleteMemoryEntry(args["id"] as string);
+    return this.jsonResult({ deleted });
+  }
+
+  private async handleKnowledgeSearch(
+    args: Record<string, unknown>,
+  ): Promise<{ content: { type: "text"; text: string }[] }> {
+    if (!this.deps.searchKnowledge) return this.errorResult("Knowledge search not available");
+    const result = await this.deps.searchKnowledge(
+      args["appName"] as string,
+      args["query"] as string,
+      args["limit"] as number | undefined,
+    );
+    return this.jsonResult(result);
+  }
+
+  private async handleKnowledgeSources(
+    args: Record<string, unknown>,
+  ): Promise<{ content: { type: "text"; text: string }[] }> {
+    if (!this.deps.listKnowledgeSources) return this.errorResult("Knowledge sources not available");
+    const result = this.deps.listKnowledgeSources(args["appName"] as string);
+    return this.jsonResult(result);
+  }
+
+  private handleCostSummary(): { content: { type: "text"; text: string }[] } {
+    if (!this.deps.getCostSummary) return this.errorResult("Cost summary not available");
+    return this.jsonResult(this.deps.getCostSummary());
+  }
+
+  private handleSafetyMetrics(): { content: { type: "text"; text: string }[] } {
+    if (!this.deps.getSafetyMetrics) return this.errorResult("Safety metrics not available");
+    return this.jsonResult(this.deps.getSafetyMetrics());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Result helpers
+  // ---------------------------------------------------------------------------
+
+  private jsonResult(data: unknown): { content: { type: "text"; text: string }[] } {
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  private errorResult(message: string): { content: { type: "text"; text: string }[]; isError: true } {
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+}

--- a/packages/runtime/src/mcp/gateway-mcp-types.ts
+++ b/packages/runtime/src/mcp/gateway-mcp-types.ts
@@ -1,0 +1,38 @@
+// MCP server: dependency injection interface for gateway capabilities
+// Decouples tool handlers from concrete gateway wiring
+
+import type { CostSummary } from "@kilnai/core";
+
+/** Dependencies injected into the MCP server from the gateway */
+export interface GatewayMcpDeps {
+  /** Recall memory entries by scope, with optional FTS query and tag filter */
+  readonly getMemoryByScope?: (
+    scope: string,
+    query?: string,
+    tags?: string,
+  ) => Record<string, unknown>[] | Promise<Record<string, unknown>[]>;
+
+  /** Create a memory entry; returns the new entry ID */
+  readonly createMemoryEntry?: (
+    entry: Record<string, unknown>,
+  ) => { id: string } | Promise<{ id: string }>;
+
+  /** Delete a memory entry by ID; returns true if found and deleted */
+  readonly deleteMemoryEntry?: (id: string) => boolean | Promise<boolean>;
+
+  /** Search the knowledge base via the retrieval pipeline */
+  readonly searchKnowledge?: (
+    appName: string,
+    query: string,
+    limit?: number,
+  ) => Promise<{ results: readonly { content: string; score: number; source?: string }[] }>;
+
+  /** List knowledge sources for an app */
+  readonly listKnowledgeSources?: (appName: string) => { sources: readonly Record<string, unknown>[] };
+
+  /** Get the current cost summary */
+  readonly getCostSummary?: () => CostSummary;
+
+  /** Get safety pipeline metrics */
+  readonly getSafetyMetrics?: () => Record<string, unknown>;
+}

--- a/packages/runtime/src/mcp/index.ts
+++ b/packages/runtime/src/mcp/index.ts
@@ -1,0 +1,7 @@
+// MCP server: barrel exports
+
+export type { GatewayMcpDeps } from "./gateway-mcp-types.js";
+export { GATEWAY_MCP_TOOLS } from "./tool-schemas.js";
+export type { GatewayMcpToolName } from "./tool-schemas.js";
+export { GatewayMcpServer } from "./gateway-mcp-server.js";
+export type { GatewayMcpServerOptions } from "./gateway-mcp-server.js";

--- a/packages/runtime/src/mcp/tool-schemas.ts
+++ b/packages/runtime/src/mcp/tool-schemas.ts
@@ -1,0 +1,138 @@
+// MCP server: tool input schemas for the 7 gateway MCP tools
+// JSON Schema objects used by @modelcontextprotocol/sdk CallToolRequest validation
+
+export const MEMORY_RECALL_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    scope: {
+      type: "string",
+      description: "Memory scope to recall from (user, agent, team, project, org)",
+    },
+    query: {
+      type: "string",
+      description: "Optional FTS5 search query to filter entries",
+    },
+    tags: {
+      type: "string",
+      description: "Optional comma-separated tag filter",
+    },
+  },
+  required: ["scope"],
+};
+
+export const MEMORY_STORE_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    scope: {
+      type: "string",
+      description: "Memory scope (user, agent, team, project, org)",
+    },
+    key: {
+      type: "string",
+      description: "Unique key for the memory entry",
+    },
+    content: {
+      type: "string",
+      description: "Content to store",
+    },
+    tags: {
+      type: "string",
+      description: "Optional comma-separated tags",
+    },
+  },
+  required: ["scope", "key", "content"],
+};
+
+export const MEMORY_DELETE_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    id: {
+      type: "string",
+      description: "ID of the memory entry to delete",
+    },
+  },
+  required: ["id"],
+};
+
+export const KNOWLEDGE_SEARCH_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    appName: {
+      type: "string",
+      description: "Name of the app whose knowledge base to search",
+    },
+    query: {
+      type: "string",
+      description: "Natural language search query",
+    },
+    limit: {
+      type: "number",
+      description: "Maximum number of results to return (default: 5)",
+    },
+  },
+  required: ["appName", "query"],
+};
+
+export const KNOWLEDGE_SOURCES_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    appName: {
+      type: "string",
+      description: "Name of the app whose knowledge sources to list",
+    },
+  },
+  required: ["appName"],
+};
+
+export const COST_SUMMARY_SCHEMA = {
+  type: "object" as const,
+  properties: {},
+  required: [] as string[],
+};
+
+export const SAFETY_METRICS_SCHEMA = {
+  type: "object" as const,
+  properties: {},
+  required: [] as string[],
+};
+
+/** All tool definitions for the gateway MCP server */
+export const GATEWAY_MCP_TOOLS = [
+  {
+    name: "memory_recall",
+    description: "Recall memory entries by scope with optional FTS search query and tag filter",
+    inputSchema: MEMORY_RECALL_SCHEMA,
+  },
+  {
+    name: "memory_store",
+    description: "Store a new memory entry with scope, key, content, and optional tags",
+    inputSchema: MEMORY_STORE_SCHEMA,
+  },
+  {
+    name: "memory_delete",
+    description: "Delete a memory entry by its ID",
+    inputSchema: MEMORY_DELETE_SCHEMA,
+  },
+  {
+    name: "knowledge_search",
+    description: "Search the knowledge base using natural language. Returns ranked results with content and relevance scores.",
+    inputSchema: KNOWLEDGE_SEARCH_SCHEMA,
+  },
+  {
+    name: "knowledge_sources",
+    description: "List all knowledge sources registered for an app",
+    inputSchema: KNOWLEDGE_SOURCES_SCHEMA,
+  },
+  {
+    name: "cost_summary",
+    description: "Get the current cost summary including total tokens, cost in USD, and per-role:model breakdown",
+    inputSchema: COST_SUMMARY_SCHEMA,
+  },
+  {
+    name: "safety_metrics",
+    description: "Get safety pipeline metrics including PII detections, content classifications, and rail triggers",
+    inputSchema: SAFETY_METRICS_SCHEMA,
+  },
+] as const;
+
+export type GatewayMcpToolName = (typeof GATEWAY_MCP_TOOLS)[number]["name"];

--- a/packages/runtime/src/session/mode-b-session.ts
+++ b/packages/runtime/src/session/mode-b-session.ts
@@ -29,6 +29,7 @@ export interface SerializedSessionData {
   readonly totalTokens?: number;
   readonly userTurnCount?: number;
   readonly lastHumanMessageAt?: number | null;
+  readonly userContext?: Record<string, string>;
 }
 
 export interface ModeBSessionConfig {
@@ -60,6 +61,7 @@ export class ModeBSession {
   private _totalTokens = 0;
   private _userTurnCount = 0;
   private _lastHumanMessageAt: number | null = null;
+  private _userContext: Record<string, string> | undefined = undefined;
 
   constructor(config: ModeBSessionConfig) {
     this.appName = config.appName;
@@ -139,6 +141,10 @@ export class ModeBSession {
     // Restore coexistence timestamp
     if (data.lastHumanMessageAt != null) {
       (session as unknown as { _lastHumanMessageAt: number | null })._lastHumanMessageAt = data.lastHumanMessageAt;
+    }
+    // Restore user context
+    if (data.userContext) {
+      (session as unknown as { _userContext: Record<string, string> })._userContext = data.userContext;
     }
     // Restore version and record loaded version for conflict detection
     const storedVersion = data.version;
@@ -237,5 +243,22 @@ export class ModeBSession {
   injectOperatorMessage(parts: readonly ContentPart[]): void {
     this._history.push({ role: "assistant", parts });
     this.touch();
+  }
+
+  get userContext(): Record<string, string> | undefined {
+    return this._userContext;
+  }
+
+  /** Merges keys from ctx into the stored user context. Empty object is a no-op. */
+  updateUserContext(ctx: Record<string, string>): void {
+    if (Object.keys(ctx).length === 0) return;
+    this._userContext = { ...this._userContext, ...ctx };
+    this._version++;
+  }
+
+  /** Replaces user context entirely. Pass undefined to clear. */
+  setUserContext(ctx: Record<string, string> | undefined): void {
+    this._userContext = ctx;
+    this._version++;
   }
 }

--- a/packages/runtime/src/session/session-serializer.ts
+++ b/packages/runtime/src/session/session-serializer.ts
@@ -22,6 +22,7 @@ export function serializeSession(session: ModeBSession): string {
     totalTokens: session.totalTokens,
     userTurnCount: session.userTurnCount,
     lastHumanMessageAt: session.lastHumanMessageAt,
+    userContext: session.userContext,
   };
   return JSON.stringify(data);
 }

--- a/packages/runtime/src/tenant/agent-resolver.ts
+++ b/packages/runtime/src/tenant/agent-resolver.ts
@@ -1,7 +1,8 @@
 // Agent resolver: single integration point for multi-agent routing in all channel handlers.
 // Resolves which agent handles a message, builds the agent-specific system prompt and tool context.
 
-import type { ContentPart, TenantConfig, TenantAgentConfig, EventBus, HandoffRequestedEvent, HandoffCompletedEvent, AgentRAG } from "@kilnai/core";
+import type { ContentPart, TenantConfig, TenantAgentConfig, EventBus, HandoffRequestedEvent, HandoffCompletedEvent, AgentRAG, UserContext } from "@kilnai/core";
+import { interpolateUserTokens } from "./interpolate-user-tokens.js";
 import { buildTenantSystemPrompt } from "./system-prompt-builder.js";
 import { buildTenantToolContext } from "../gateway/tenant-tool-factory.js";
 import type { TenantToolContext } from "../gateway/tenant-tool-factory.js";
@@ -30,22 +31,27 @@ export interface AsyncAgentResolverDeps {
   readonly agentRag?: AgentRAG;
 }
 
-export function buildAgentSystemPrompt(basePrompt: string, agent: TenantAgentConfig): string {
+export function buildAgentSystemPrompt(
+  basePrompt: string,
+  agent: TenantAgentConfig,
+  userContext?: UserContext,
+): string {
+  const interp = (s: string) => interpolateUserTokens(s, userContext);
   const parts: string[] = [basePrompt];
 
   parts.push("");
   parts.push("## Your Agent Identity");
-  parts.push(`You are "${agent.name}" — ${agent.role}.`);
-  parts.push(`Your primary goal: ${agent.goal}`);
+  parts.push(`You are "${agent.name}" — ${interp(agent.role)}.`);
+  parts.push(`Your primary goal: ${interp(agent.goal)}`);
 
   if (agent.backstory) {
-    parts.push(`Background: ${agent.backstory}`);
+    parts.push(`Background: ${interp(agent.backstory)}`);
   }
 
   if (agent.instructions) {
     parts.push("");
     parts.push("## Operating Instructions");
-    parts.push(agent.instructions);
+    parts.push(interp(agent.instructions));
   }
 
   return parts.join("\n");
@@ -57,6 +63,7 @@ export function resolveAgentContext(
   channel?: "web" | "whatsapp" | "instagram" | "messenger" | "email",
   session?: ModeBSession,
   existingBuiltins?: ReadonlyMap<string, (input: Record<string, unknown>) => Promise<unknown>>,
+  userContext?: UserContext,
 ): ResolvedAgentContext {
   const basePrompt = buildTenantSystemPrompt(tenant, channel);
 
@@ -71,7 +78,7 @@ export function resolveAgentContext(
 
   if (tenant.agents.length === 1) {
     const agent = tenant.agents[0]!;
-    const systemPrompt = buildAgentSystemPrompt(basePrompt, agent);
+    const systemPrompt = buildAgentSystemPrompt(basePrompt, agent, userContext);
     const toolCtx = buildAgentToolContext(tenant, agent, existingBuiltins);
     return {
       systemPrompt,
@@ -86,7 +93,7 @@ export function resolveAgentContext(
   if (!tenant.routing) {
     // No routing config → fall back to first agent
     const agent = tenant.agents[0]!;
-    const systemPrompt = buildAgentSystemPrompt(basePrompt, agent);
+    const systemPrompt = buildAgentSystemPrompt(basePrompt, agent, userContext);
     const toolCtx = buildAgentToolContext(tenant, agent, existingBuiltins);
     return {
       systemPrompt,
@@ -107,7 +114,7 @@ export function resolveAgentContext(
       // Keep current agent
       const currentAgent = tenant.agents.find((a) => a.id === session.activeAgentId)
         ?? tenant.agents.find((a) => a.isDefault) ?? tenant.agents[0]!;
-      const systemPrompt = buildAgentSystemPrompt(basePrompt, currentAgent);
+      const systemPrompt = buildAgentSystemPrompt(basePrompt, currentAgent, userContext);
       const toolCtx = buildAgentToolContext(tenant, currentAgent, existingBuiltins);
       return {
         systemPrompt,
@@ -132,7 +139,7 @@ export function resolveAgentContext(
 
   const previousAgentId = session?.activeAgentId ?? undefined;
   const isHandoff = previousAgentId !== undefined && previousAgentId !== selectedAgent.id;
-  const systemPrompt = buildAgentSystemPrompt(basePrompt, selectedAgent);
+  const systemPrompt = buildAgentSystemPrompt(basePrompt, selectedAgent, userContext);
   const toolCtx = buildAgentToolContext(tenant, selectedAgent, existingBuiltins);
 
   return {
@@ -153,13 +160,14 @@ export async function resolveAgentContextAsync(
   deps?: AsyncAgentResolverDeps,
   channel?: "web" | "whatsapp" | "instagram" | "messenger" | "email",
   existingBuiltins?: ReadonlyMap<string, (input: Record<string, unknown>) => Promise<unknown>>,
+  userContext?: UserContext,
 ): Promise<ResolvedAgentContext> {
   // If agentRag is provided and tenant has multi-agent routing, use async Tier 2 routing
   let result: ResolvedAgentContext;
   if (deps?.agentRag && tenant.agents && tenant.agents.length > 1 && tenant.routing) {
-    result = await resolveAgentContextWithEmbedding(tenant, userParts, channel, session, deps.agentRag, existingBuiltins);
+    result = await resolveAgentContextWithEmbedding(tenant, userParts, channel, session, deps.agentRag, existingBuiltins, userContext);
   } else {
-    result = resolveAgentContext(tenant, userParts, channel, session, existingBuiltins);
+    result = resolveAgentContext(tenant, userParts, channel, session, existingBuiltins, userContext);
   }
 
   // No handoff or blocked by guard or no summarizer → return as-is
@@ -223,6 +231,7 @@ async function resolveAgentContextWithEmbedding(
   session: ModeBSession,
   agentRag: AgentRAG,
   existingBuiltins?: ReadonlyMap<string, (input: Record<string, unknown>) => Promise<unknown>>,
+  userContext?: UserContext,
 ): Promise<ResolvedAgentContext> {
   const basePrompt = buildTenantSystemPrompt(tenant, channel);
   const agents = tenant.agents!;
@@ -236,7 +245,7 @@ async function resolveAgentContextWithEmbedding(
   if (guardResult.blocked) {
     const currentAgent = agents.find((a) => a.id === session.activeAgentId)
       ?? agents.find((a) => a.isDefault) ?? agents[0]!;
-    const systemPrompt = buildAgentSystemPrompt(basePrompt, currentAgent);
+    const systemPrompt = buildAgentSystemPrompt(basePrompt, currentAgent, userContext);
     const toolCtx = buildAgentToolContext(tenant, currentAgent, existingBuiltins);
     return {
       systemPrompt,
@@ -258,7 +267,7 @@ async function resolveAgentContextWithEmbedding(
 
   const previousAgentId = session.activeAgentId ?? undefined;
   const isHandoff = previousAgentId !== undefined && previousAgentId !== selectedAgent.id;
-  const systemPrompt = buildAgentSystemPrompt(basePrompt, selectedAgent);
+  const systemPrompt = buildAgentSystemPrompt(basePrompt, selectedAgent, userContext);
   const toolCtx = buildAgentToolContext(tenant, selectedAgent, existingBuiltins);
 
   return {

--- a/packages/runtime/src/tenant/interpolate-user-tokens.ts
+++ b/packages/runtime/src/tenant/interpolate-user-tokens.ts
@@ -1,0 +1,13 @@
+import type { UserContext } from "@kilnai/core";
+
+/**
+ * Resolves {{user.*}} tokens in a template string using the provided UserContext.
+ * Unknown keys resolve to empty string (fail-open).
+ * If userContext is undefined, the template is returned unchanged.
+ */
+export function interpolateUserTokens(template: string, userContext: UserContext | undefined): string {
+  if (!userContext) return template;
+  return template.replace(/\{\{user\.([a-zA-Z_][a-zA-Z0-9_]*)\}\}/g, (_match, key: string) => {
+    return Object.prototype.hasOwnProperty.call(userContext, key) ? (userContext[key] ?? "") : "";
+  });
+}

--- a/packages/runtime/tests/gateway/context-formatter.test.ts
+++ b/packages/runtime/tests/gateway/context-formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatKnowledgeContext, formatContactContext, mergeContextSources, appendGroundingDirective } from "../../src/gateway/context-formatter.js";
+import { formatKnowledgeContext, formatContactContext, mergeContextSources, appendGroundingDirective, formatUserContext } from "../../src/gateway/context-formatter.js";
 import type { VectorResult, ContactFact } from "@kilnai/core";
 
 describe("formatKnowledgeContext", () => {
@@ -52,6 +52,26 @@ describe("mergeContextSources", () => {
 
   it("skips undefined sources", () => {
     expect(mergeContextSources("a", undefined, "b")).toBe("a\n\nb");
+  });
+});
+
+describe("formatUserContext", () => {
+  it("formats populated context as key-value lines under [User Context] header", () => {
+    const result = formatUserContext({ role: "admin", name: "John" });
+    expect(result).toBe("[User Context]:\nrole: admin\nname: John");
+  });
+
+  it("returns undefined for empty object", () => {
+    expect(formatUserContext({})).toBeUndefined();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(formatUserContext(undefined)).toBeUndefined();
+  });
+
+  it("preserves multi-key insertion order", () => {
+    const result = formatUserContext({ locale: "es", plan: "pro", company: "Acme" });
+    expect(result).toBe("[User Context]:\nlocale: es\nplan: pro\ncompany: Acme");
   });
 });
 

--- a/packages/runtime/tests/gateway/message-pipeline.test.ts
+++ b/packages/runtime/tests/gateway/message-pipeline.test.ts
@@ -11,7 +11,8 @@ import type { BillingConfig } from "../../src/gateway/budget-middleware.js";
 const originalFetch = globalThis.fetch;
 
 function makeMockSession(): ModeBSession {
-  return {
+  let _userContext: Record<string, string> | undefined;
+  const session = {
     id: "test-app:test-tenant:user-1:12345",
     appName: "test-app",
     tenantId: "test-tenant",
@@ -21,7 +22,12 @@ function makeMockSession(): ModeBSession {
     userTurnCount: 0,
     conversationHistory: [],
     accumulateTokens: vi.fn(),
+    get userContext() { return _userContext; },
+    updateUserContext(ctx: Record<string, string>) {
+      _userContext = { ..._userContext, ...ctx };
+    },
   } as unknown as ModeBSession;
+  return session;
 }
 
 function makeMockOrchestrator(): ModeBOrchestrator {
@@ -234,6 +240,41 @@ describe("processInboundMessage", () => {
       builtinTools,
       undefined,
     );
+  });
+
+  it("prepends [User Context] block first in mergedMemory when userContext is present", async () => {
+    const orchestrator = makeMockOrchestrator();
+    const sessionRegistry = makeMockSessionRegistry();
+    const ctx = makeBaseContext({
+      orchestrator,
+      sessionRegistry,
+      userContext: { role: "admin" },
+      recalledMemory: "Previous context here.",
+    });
+
+    await processInboundMessage(ctx);
+
+    const callArgs = (orchestrator.processMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    const mergedMemoryArg: string | undefined = callArgs[2];
+    expect(mergedMemoryArg).toBeDefined();
+    expect(mergedMemoryArg!.startsWith("[User Context]:")).toBe(true);
+    expect(mergedMemoryArg).toContain("Previous context here.");
+  });
+
+  it("omits [User Context] block from mergedMemory when userContext is absent", async () => {
+    const orchestrator = makeMockOrchestrator();
+    const sessionRegistry = makeMockSessionRegistry();
+    const ctx = makeBaseContext({
+      orchestrator,
+      sessionRegistry,
+      recalledMemory: "Previous context here.",
+    });
+
+    await processInboundMessage(ctx);
+
+    const callArgs = (orchestrator.processMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    const mergedMemoryArg: string | undefined = callArgs[2];
+    expect(mergedMemoryArg).not.toContain("[User Context]");
   });
 
   it("uses tenantId for billing", async () => {

--- a/packages/runtime/tests/gateway/mode-b-routes.test.ts
+++ b/packages/runtime/tests/gateway/mode-b-routes.test.ts
@@ -196,6 +196,68 @@ describe("createModeBRoutes", () => {
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
+    it("accepts context object and returns 200", async () => {
+      const runtime = makeRuntime();
+      const app = createModeBRoutes(runtime);
+
+      const res = await app.request("/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "hello", userId: "user-1", context: { role: "admin" } }),
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 400 when context is a number", async () => {
+      const runtime = makeRuntime();
+      const app = createModeBRoutes(runtime);
+
+      const res = await app.request("/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "hello", userId: "user-1", context: 123 }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when context is an array", async () => {
+      const runtime = makeRuntime();
+      const app = createModeBRoutes(runtime);
+
+      const res = await app.request("/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "hello", userId: "user-1", context: [1, 2, 3] }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("retains context from first turn when second POST omits context", async () => {
+      const runtime = makeRuntime();
+      const app = createModeBRoutes(runtime);
+
+      // First turn sets context
+      await app.request("/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "hello", userId: "user-ctx-persist", context: { role: "admin" } }),
+      });
+
+      // Second turn omits context — session must still have it
+      await app.request("/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "follow up", userId: "user-ctx-persist" }),
+      });
+
+      const session = await runtime.sessionRegistry.get("test-app", "user-ctx-persist", "_default");
+      expect(session).toBeDefined();
+      expect(session!.userContext).toEqual({ role: "admin" });
+    });
+
     it("rejects disallowed tier", async () => {
       const billing = {
         ...makeBillingConfig(),

--- a/packages/runtime/tests/mcp/gateway-mcp-server.test.ts
+++ b/packages/runtime/tests/mcp/gateway-mcp-server.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GatewayMcpServer } from "../../src/mcp/gateway-mcp-server.js";
+import type { GatewayMcpDeps } from "../../src/mcp/gateway-mcp-types.js";
+import { GATEWAY_MCP_TOOLS } from "../../src/mcp/tool-schemas.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+};
+
+function jsonRpc(method: string, params: Record<string, unknown> = {}, id = 1): string {
+  return JSON.stringify({ jsonrpc: "2.0", id, method, params });
+}
+
+function mcpRequest(method: string, params: Record<string, unknown> = {}, extraHeaders?: Record<string, string>): Request {
+  return new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: { ...MCP_HEADERS, ...extraHeaders },
+    body: jsonRpc(method, params),
+  });
+}
+
+function makeDeps(overrides?: Partial<GatewayMcpDeps>): GatewayMcpDeps {
+  return {
+    getMemoryByScope: vi.fn(async () => [{ id: "m1", content: "test memory" }]),
+    createMemoryEntry: vi.fn(async () => ({ id: "new-1" })),
+    deleteMemoryEntry: vi.fn(async () => true),
+    searchKnowledge: vi.fn(async () => ({
+      results: [{ content: "knowledge chunk", score: 0.95, source: "docs.md" }],
+    })),
+    listKnowledgeSources: vi.fn(() => ({
+      sources: [{ id: "s1", name: "docs", type: "file" }],
+    })),
+    getCostSummary: vi.fn(() => ({
+      totalInputTokens: 1000,
+      totalOutputTokens: 500,
+      totalCacheReadTokens: 0,
+      totalCacheWriteTokens: 0,
+      totalToolCalls: 3,
+      totalCostUsd: 0.015,
+      byRoleModel: {},
+    })),
+    getSafetyMetrics: vi.fn(() => ({ enabled: true, piiDetections: 2 })),
+    ...overrides,
+  };
+}
+
+async function callTool(
+  server: GatewayMcpServer,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ result: { content: { type: string; text: string }[]; isError?: boolean } }> {
+  const res = await server.handleRequest(mcpRequest("tools/call", { name, arguments: args }));
+  return res.json();
+}
+
+async function listTools(server: GatewayMcpServer): Promise<{ result: { tools: { name: string }[] } }> {
+  const res = await server.handleRequest(mcpRequest("tools/list"));
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GatewayMcpServer", () => {
+  describe("before initialization", () => {
+    it("returns 503 when not initialized", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps() });
+      const res = await server.handleRequest(mcpRequest("tools/list"));
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.error).toBe("MCP server not initialized");
+    });
+  });
+
+  describe("authentication", () => {
+    it("returns 401 when apiKey is set but request has no auth header", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps(), apiKey: "secret-123" });
+      await server.initialize();
+      const res = await server.handleRequest(mcpRequest("tools/list"));
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 when apiKey does not match", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps(), apiKey: "secret-123" });
+      await server.initialize();
+      const res = await server.handleRequest(
+        mcpRequest("tools/list", {}, { Authorization: "Bearer wrong-key" }),
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("allows request when apiKey matches", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps(), apiKey: "secret-123" });
+      await server.initialize();
+      const res = await server.handleRequest(
+        mcpRequest("tools/list", {}, { Authorization: "Bearer secret-123" }),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("allows request when no apiKey is configured", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps() });
+      await server.initialize();
+      const res = await server.handleRequest(mcpRequest("tools/list"));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("tool schemas", () => {
+    it("defines 7 tools", () => {
+      expect(GATEWAY_MCP_TOOLS).toHaveLength(7);
+    });
+
+    it("all tools have name, description, and inputSchema", () => {
+      for (const tool of GATEWAY_MCP_TOOLS) {
+        expect(tool.name).toBeTruthy();
+        expect(tool.description).toBeTruthy();
+        expect(tool.inputSchema).toBeDefined();
+        expect(tool.inputSchema.type).toBe("object");
+      }
+    });
+
+    it("tool names are unique", () => {
+      const names = GATEWAY_MCP_TOOLS.map((t) => t.name);
+      expect(new Set(names).size).toBe(names.length);
+    });
+  });
+
+  describe("tools/list", () => {
+    it("returns all 7 tools", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps() });
+      await server.initialize();
+      const response = await listTools(server);
+      expect(response.result.tools).toHaveLength(7);
+      const names = response.result.tools.map((t) => t.name);
+      expect(names).toContain("memory_recall");
+      expect(names).toContain("memory_store");
+      expect(names).toContain("memory_delete");
+      expect(names).toContain("knowledge_search");
+      expect(names).toContain("knowledge_sources");
+      expect(names).toContain("cost_summary");
+      expect(names).toContain("safety_metrics");
+    });
+  });
+
+  describe("tool dispatch", () => {
+    let server: GatewayMcpServer;
+    let deps: GatewayMcpDeps;
+
+    beforeEach(async () => {
+      deps = makeDeps();
+      server = new GatewayMcpServer({ deps });
+      await server.initialize();
+    });
+
+    it("memory_recall calls getMemoryByScope with correct args", async () => {
+      const response = await callTool(server, "memory_recall", { scope: "user", query: "test" });
+      expect(deps.getMemoryByScope).toHaveBeenCalledWith("user", "test", undefined);
+      const parsed = JSON.parse(response.result.content[0]!.text);
+      expect(parsed).toEqual([{ id: "m1", content: "test memory" }]);
+    });
+
+    it("memory_store calls createMemoryEntry", async () => {
+      const response = await callTool(server, "memory_store", {
+        scope: "project", key: "k1", content: "hello", tags: "a,b",
+      });
+      expect(deps.createMemoryEntry).toHaveBeenCalledWith({
+        scope: "project", key: "k1", content: "hello", tags: "a,b",
+      });
+      const parsed = JSON.parse(response.result.content[0]!.text);
+      expect(parsed.id).toBe("new-1");
+    });
+
+    it("memory_delete calls deleteMemoryEntry", async () => {
+      const response = await callTool(server, "memory_delete", { id: "m1" });
+      expect(deps.deleteMemoryEntry).toHaveBeenCalledWith("m1");
+      const parsed = JSON.parse(response.result.content[0]!.text);
+      expect(parsed.deleted).toBe(true);
+    });
+
+    it("knowledge_search calls searchKnowledge", async () => {
+      const response = await callTool(server, "knowledge_search", {
+        appName: "my-app", query: "how to deploy", limit: 3,
+      });
+      expect(deps.searchKnowledge).toHaveBeenCalledWith("my-app", "how to deploy", 3);
+      const parsed = JSON.parse(response.result.content[0]!.text);
+      expect(parsed.results[0].content).toBe("knowledge chunk");
+    });
+
+    it("knowledge_sources calls listKnowledgeSources", async () => {
+      const response = await callTool(server, "knowledge_sources", { appName: "my-app" });
+      expect(deps.listKnowledgeSources).toHaveBeenCalledWith("my-app");
+      const parsed = JSON.parse(response.result.content[0]!.text);
+      expect(parsed.sources).toHaveLength(1);
+    });
+
+    it("cost_summary returns cost data", async () => {
+      const response = await callTool(server, "cost_summary");
+      const parsed = JSON.parse(response.result.content[0]!.text);
+      expect(parsed.totalCostUsd).toBe(0.015);
+      expect(parsed.totalInputTokens).toBe(1000);
+    });
+
+    it("safety_metrics returns safety data", async () => {
+      const response = await callTool(server, "safety_metrics");
+      const parsed = JSON.parse(response.result.content[0]!.text);
+      expect(parsed.enabled).toBe(true);
+      expect(parsed.piiDetections).toBe(2);
+    });
+
+    it("handles multiple sequential requests (stateless transport)", async () => {
+      const r1 = await callTool(server, "cost_summary");
+      const r2 = await callTool(server, "safety_metrics");
+      expect(JSON.parse(r1.result.content[0]!.text).totalCostUsd).toBe(0.015);
+      expect(JSON.parse(r2.result.content[0]!.text).enabled).toBe(true);
+    });
+  });
+
+  describe("missing deps", () => {
+    let server: GatewayMcpServer;
+
+    beforeEach(async () => {
+      server = new GatewayMcpServer({ deps: {} });
+      await server.initialize();
+    });
+
+    it("memory_recall returns error when dep missing", async () => {
+      const response = await callTool(server, "memory_recall", { scope: "user" });
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]!.text).toBe("Memory recall not available");
+    });
+
+    it("memory_store returns error when dep missing", async () => {
+      const response = await callTool(server, "memory_store", { scope: "user", key: "k", content: "c" });
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]!.text).toBe("Memory store not available");
+    });
+
+    it("memory_delete returns error when dep missing", async () => {
+      const response = await callTool(server, "memory_delete", { id: "m1" });
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]!.text).toBe("Memory delete not available");
+    });
+
+    it("knowledge_search returns error when dep missing", async () => {
+      const response = await callTool(server, "knowledge_search", { appName: "a", query: "q" });
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]!.text).toBe("Knowledge search not available");
+    });
+
+    it("knowledge_sources returns error when dep missing", async () => {
+      const response = await callTool(server, "knowledge_sources", { appName: "a" });
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]!.text).toBe("Knowledge sources not available");
+    });
+
+    it("cost_summary returns error when dep missing", async () => {
+      const response = await callTool(server, "cost_summary");
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]!.text).toBe("Cost summary not available");
+    });
+
+    it("safety_metrics returns error when dep missing", async () => {
+      const response = await callTool(server, "safety_metrics");
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]!.text).toBe("Safety metrics not available");
+    });
+  });
+
+  describe("error handling", () => {
+    it("catches exceptions from deps and returns error result", async () => {
+      const deps = makeDeps({
+        getMemoryByScope: vi.fn(async () => { throw new Error("DB connection lost"); }),
+      });
+      const server = new GatewayMcpServer({ deps });
+      await server.initialize();
+
+      const response = await callTool(server, "memory_recall", { scope: "user" });
+      expect(response.result.isError).toBe(true);
+      expect(response.result.content[0]!.text).toBe("DB connection lost");
+    });
+  });
+
+  describe("close", () => {
+    it("can close without initialization", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps() });
+      await expect(server.close()).resolves.toBeUndefined();
+    });
+
+    it("can close after initialization", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps() });
+      await server.initialize();
+      await expect(server.close()).resolves.toBeUndefined();
+    });
+
+    it("returns 503 after close", async () => {
+      const server = new GatewayMcpServer({ deps: makeDeps() });
+      await server.initialize();
+      await server.close();
+      const res = await server.handleRequest(mcpRequest("tools/list"));
+      expect(res.status).toBe(503);
+    });
+  });
+});

--- a/packages/runtime/tests/session/mode-b-session.test.ts
+++ b/packages/runtime/tests/session/mode-b-session.test.ts
@@ -303,6 +303,39 @@ describe("ModeBSession", () => {
     });
   });
 
+  describe("updateUserContext", () => {
+    it("stores context and increments version", () => {
+      const session = new ModeBSession({ appName: "app", tenantId: "t1", userId: "u1", systemPrompt: "sys" });
+      const versionBefore = session.version;
+      session.updateUserContext({ role: "admin" });
+      expect(session.userContext).toEqual({ role: "admin" });
+      expect(session.version).toBe(versionBefore + 1);
+    });
+
+    it("merges new keys into existing context", () => {
+      const session = new ModeBSession({ appName: "app", tenantId: "t1", userId: "u1", systemPrompt: "sys" });
+      session.updateUserContext({ role: "admin" });
+      session.updateUserContext({ locale: "es" });
+      expect(session.userContext).toEqual({ role: "admin", locale: "es" });
+    });
+
+    it("leaves existing context unchanged when called with empty object", () => {
+      const session = new ModeBSession({ appName: "app", tenantId: "t1", userId: "u1", systemPrompt: "sys" });
+      session.updateUserContext({ role: "admin" });
+      const versionBefore = session.version;
+      session.updateUserContext({});
+      expect(session.userContext).toEqual({ role: "admin" });
+      expect(session.version).toBe(versionBefore);
+    });
+
+    it("setUserContext(undefined) clears context and getter returns undefined", () => {
+      const session = new ModeBSession({ appName: "app", tenantId: "t1", userId: "u1", systemPrompt: "sys" });
+      session.updateUserContext({ role: "admin" });
+      session.setUserContext(undefined);
+      expect(session.userContext).toBeUndefined();
+    });
+  });
+
   describe("coexistence: recordHumanMessage", () => {
     it("lastHumanMessageAt is null by default", () => {
       const session = new ModeBSession({

--- a/packages/runtime/tests/session/session-serializer.test.ts
+++ b/packages/runtime/tests/session/session-serializer.test.ts
@@ -127,4 +127,23 @@ describe("serializeSession / deserializeSession", () => {
     // Default is 30 * 60 * 1000 = 1800000
     expect(restored.idleTimeoutMs).toBe(1800000);
   });
+
+  it("roundtrips a session with userContext", () => {
+    const session = makeSession();
+    session.updateUserContext({ role: "admin", locale: "es" });
+
+    const json = serializeSession(session);
+    const restored = deserializeSession(json);
+
+    expect(restored.userContext).toEqual({ role: "admin", locale: "es" });
+  });
+
+  it("roundtrips a session without userContext — backward compat", () => {
+    const session = makeSession();
+
+    const json = serializeSession(session);
+    const restored = deserializeSession(json);
+
+    expect(restored.userContext).toBeUndefined();
+  });
 });

--- a/packages/runtime/tests/tenant/agent-resolver.test.ts
+++ b/packages/runtime/tests/tenant/agent-resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { TenantConfig } from "@kilnai/core";
+import type { TenantConfig, UserContext } from "@kilnai/core";
 import { textParts } from "@kilnai/core";
 import { resolveAgentContext, buildAgentSystemPrompt } from "../../src/tenant/agent-resolver.js";
 import { ModeBSession } from "../../src/session/mode-b-session.js";
@@ -55,6 +55,46 @@ describe("buildAgentSystemPrompt", () => {
   it("omits instructions section when not present", () => {
     const prompt = buildAgentSystemPrompt("Base.", salesAgent);
     expect(prompt).not.toContain("## Operating Instructions");
+  });
+});
+
+describe("buildAgentSystemPrompt — user token interpolation", () => {
+  it("replaces {{user.role}} in agent role field", () => {
+    const agent = { ...salesAgent, role: "{{user.role}} specialist" };
+    const userContext: UserContext = { role: "admin" };
+    const prompt = buildAgentSystemPrompt("Base.", agent, userContext);
+    expect(prompt).toContain("admin specialist");
+    expect(prompt).not.toContain("{{user.role}}");
+  });
+
+  it("replaces {{user.name}} in agent backstory", () => {
+    const agent = { ...salesAgent, backstory: "Serving {{user.name}} since 2020." };
+    const userContext: UserContext = { name: "John" };
+    const prompt = buildAgentSystemPrompt("Base.", agent, userContext);
+    expect(prompt).toContain("Serving John since 2020.");
+    expect(prompt).not.toContain("{{user.name}}");
+  });
+
+  it("replaces {{user.locale}} in agent instructions", () => {
+    const agent = { ...salesAgent, instructions: "Respond in {{user.locale}}." };
+    const userContext: UserContext = { locale: "es" };
+    const prompt = buildAgentSystemPrompt("Base.", agent, userContext);
+    expect(prompt).toContain("Respond in es.");
+    expect(prompt).not.toContain("{{user.locale}}");
+  });
+
+  it("resolves unknown token to empty string", () => {
+    const agent = { ...salesAgent, role: "{{user.unknown}} role" };
+    const userContext: UserContext = { role: "admin" };
+    const prompt = buildAgentSystemPrompt("Base.", agent, userContext);
+    expect(prompt).toContain(" role");
+    expect(prompt).not.toContain("{{user.unknown}}");
+  });
+
+  it("leaves {{user.role}} untouched when userContext is undefined", () => {
+    const agent = { ...salesAgent, role: "{{user.role}} specialist" };
+    const prompt = buildAgentSystemPrompt("Base.", agent, undefined);
+    expect(prompt).toContain("{{user.role}}");
   });
 });
 

--- a/packages/runtime/tests/tenant/interpolate-user-tokens.test.ts
+++ b/packages/runtime/tests/tenant/interpolate-user-tokens.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { interpolateUserTokens } from "../../src/tenant/interpolate-user-tokens.js";
+
+describe("interpolateUserTokens", () => {
+  it("replaces {{user.role}} with the context value", () => {
+    expect(interpolateUserTokens("Role: {{user.role}}", { role: "admin" })).toBe("Role: admin");
+  });
+
+  it("replaces {{user.name}} with the context value", () => {
+    expect(interpolateUserTokens("Hi {{user.name}}", { name: "John" })).toBe("Hi John");
+  });
+
+  it("replaces unknown token with empty string", () => {
+    expect(interpolateUserTokens("{{user.unknown}}", { role: "admin" })).toBe("");
+  });
+
+  it("returns string unchanged when no tokens present", () => {
+    expect(interpolateUserTokens("no tokens", { role: "admin" })).toBe("no tokens");
+  });
+
+  it("returns template unchanged when userContext is undefined", () => {
+    expect(interpolateUserTokens("{{user.role}}", undefined)).toBe("{{user.role}}");
+  });
+
+  it("does not replace non-user namespaced tokens like {{payload.event}}", () => {
+    expect(interpolateUserTokens("{{payload.event}}", { role: "admin" })).toBe("{{payload.event}}");
+  });
+});


### PR DESCRIPTION
## Summary

- Expose gateway capabilities (memory, knowledge, cost, safety) as 7 MCP tools via Streamable HTTP transport
- `@modelcontextprotocol/sdk` as optional peer dep with dynamic import — zero impact when unused
- Stateless per-request Server+Transport pattern per MCP Streamable HTTP spec, Bearer auth, YAML-configurable (`gateway.mcp` block)
- New bounded context `packages/runtime/src/mcp/` with full barrel exports
- Domain types + validation in `packages/core/src/engine/gateway/mcp-config.ts` following existing auth/observability patterns
- Gateway wiring: memory (all 5 scopes), knowledge (retrieve + list sources), cost summary, safety metrics

## Test plan

- [x] 9 domain validation tests (mcp-config)
- [x] 28 MCP server tests (auth, tool schemas, dispatch, missing deps, error handling, lifecycle)
- [x] `bun run typecheck` passes (zero errors)
- [x] `bun run test` passes (4,180 tests, zero failures)
- [x] No `@temper` references
- [x] CLAUDE.md and changelog updated