### PR TITLE
feat(runtime): close Roadmap 01 Slice 3.1 - external runtime attachment identity

### DIFF
--- a/docs/roadmap/01-external-runtime-governance.md
+++ b/docs/roadmap/01-external-runtime-governance.md
@@ -345,9 +345,102 @@ child (Thread 5) and explicit supersession-with-dual-replay for a superseded
 admission gate remain open, per Slice 1's status note assigning attachment
 work to Slice 3.
 
+### Slice 3.1 - External Runtime Attachment Identity
+
+Status: Closed. Closes thread 5 (attachment drift), left open by Slice 1 and
+Slice 2's status notes, and Roadmap 01 issue #6 (tracker #5 remains open for
+the remaining Slice 3 work below).
+
+Made external-runtime attachment identity explicit, provider-neutral, and
+enforced at the canonical admission gate — "which physical external-runtime
+instance a managed child must drive," distinct from
+`ManagedAgentCallerAttachmentIdentity` ("who called Kiln", unchanged). New
+sibling type `ManagedAgentExternalRuntimeAttachmentIdentity` in
+`packages/core/src/agents/managed-invocation/index.ts` (`kind:
+"external-runtime"`, `runtimeId`, `attachmentId` — exactly three fields, no
+discovery/version/pid metadata). A route's declared attachment
+(`ManagedInvocationToolRoute.externalRuntimeAttachment`, property of the
+physical target, not any one admission profile) is compared against a
+dispatch's requested attachment by one exported comparator,
+`compareManagedAgentExternalRuntimeAttachment`, used only inside the single
+fail-closed gate `evaluateManagedAgentAdmission` — the same gate every
+dispatch path traverses (`managed_agent.invoke`, `.start`, and
+`.orchestrate`, since orchestrate's children route through
+`RuntimeManagedAgentInvocationService.start()` like every other path). Both
+absent admits unchanged (zero behavior change for the hundreds of existing
+routes that never declare an attachment); route declares/request omits
+denies `externalRuntimeAttachment.missing`; both present and equal admits;
+both present and unequal denies `externalRuntimeAttachment.mismatch`;
+request declares/route doesn't denies
+`externalRuntimeAttachment.unsupported-route`. `managed_agent.invoke` and
+`.start` share one `ToolDefinition`, so one schema addition
+(`externalRuntimeAttachment: { runtimeId, attachmentId }`, both required,
+`additionalProperties: false`) gives parity by construction; `parseInput`
+validates the object strictly — unknown keys or a blank/whitespace-only field
+are rejected with an explicit error, never silently dropped (closes the
+`additionalProperties: false` is advisory-only gap: JSON Schema constrains
+the model's tool call, not the runtime). `managed_agent.orchestrate` has no
+input surface to request an attachment yet (deliberately out of scope —
+expressing it through orchestrate's own input contract is separate,
+sequenced work) but still fails closed: the selected route's declared
+attachment is surfaced into `runOrchestrationBatch`'s
+`capabilitySnapshotInput`, so a route attached to a specific instance denies
+every orchestrated child with `externalRuntimeAttachment.missing` instead of
+silently dispatching unattached. The attachment is additive through the
+existing evidence/replay surfaces with zero projection changes
+(`ManagedAgentCapabilitySnapshot`/`Input`, `ManagedAgentLifecycleEvidence` +
+`buildManagedAgentLifecycleEvidence` for terminal events,
+`snapshotInputFromAdmission` for recovery re-admission,
+`projectManagedInvocationCapabilitySnapshotResources` already spreads),
+declarable from real route configuration
+(`KilnManagedAgentRouteConfig.externalRuntimeAttachment` →
+`packages/cli/src/config/managed-agent-routes.ts`, not just test fixtures),
+and additively declared on the operator/SDK projection contract
+(`OperatorManagedAgentCapabilitySnapshot.externalRuntimeAttachment` /
+`.callerIdentity` in `gateway-contracts/src/frames.ts`, mirrored types to
+avoid a `@kilnai/core` dependency).
+
+Deliberately not touched: `ManagedAgentCallerAttachmentIdentity` (different
+producer, lifetime, consumer, and cardinality — extending it would have
+forced a policy hole in `evaluateManagedInvocationCallerCapability`'s `kind`
+switch), `ManagedAgentResultHandoff` (attachment belongs to the invocation
+record, not child-authored output), `resource-projection.ts`,
+`caller-capability-policy.ts`, MCP client routing (`runtimeId` reuses the
+existing `mcp:<server>:…` namespace convention only), discovery/active-
+instance-switching/defaulting-to-the-sole-attached-instance (absence must
+stay absent — F7; this is deliberately different from the existing caller-
+identity default, which is unchanged), and Roadmap 02 managed-job lease/
+account lifecycle.
+
+Residual risks carried forward, not fixed in this slice: the tool-surface
+top-level input schema remains `additionalProperties: false` (advisory only)
+outside the `externalRuntimeAttachment` object itself — only that one nested
+object gets strict runtime validation; the existing caller-identity default
+synthesis (`normalizeManagedInvocationAttachment` fabricating a
+`kiln-runtime` caller identity when none is configured) is unchanged and
+orthogonal; `managed_agent.orchestrate` still has no input surface to
+express a requested attachment (fails closed via the core gate, but cannot
+yet succeed against an attached route); and Slice 1's
+`evidenceRealizations` route-config-unreachability precedent (closed here
+for `externalRuntimeAttachment` specifically, not retroactively fixed for
+`evidenceRealizations`).
+
+Verified: `@kilnai/gateway-contracts` 28 files/259 tests,
+`@kilnai/core` 289/290 files pass (3578/3580 tests — 2 pre-existing,
+unrelated `verified-efficiency-v1` publication-readiness digest-mismatch
+failures confirmed via `git stash` before this work began),
+`@kilnai/runtime` 219 files/2942 tests (includes 19 new behavioral tests
+replacing the flipped `it.fails` attachment-drift regression, plus a new
+orchestrate fail-closed test in `orchestration-lifecycle.test.ts`),
+`@kilnai/cli` 150/152 files pass (1518/1519 tests — 1 pre-existing,
+unrelated `verified-efficiency-v1` digest-mismatch failure plus one
+pre-existing flaky unhandled rejection in `run-builtin-tools.test.ts`, both
+confirmed via `git stash` before this work began), typecheck clean across
+`gateway-contracts`, `core`, `runtime`, `sdk`, `cli`, `tui`, `native`.
+
 ### Slice 3 - Cross-Surface Replay
 
-Status: Queued behind Slice 2.
+Status: Queued behind Slice 3.1 above.
 
 Prove GUI, TUI, CLI, SDK, and replay agree; preserve redacted server/tool
 failure category and identity; require approval request/resolution events for

--- a/docs/roadmap/01-external-runtime-governance.md
+++ b/docs/roadmap/01-external-runtime-governance.md
@@ -347,8 +347,9 @@ work to Slice 3.
 
 ### Slice 3.1 - External Runtime Attachment Identity
 
-Status: Closed. Closes thread 5 (attachment drift), left open by Slice 1 and
-Slice 2's status notes, and Roadmap 01 issue #6 (tracker #5 remains open for
+Status: Implemented - pending merge. Closes thread 5 (attachment drift), left
+open by Slice 1 and Slice 2's status notes, and Roadmap 01 issue #6, once
+PR #8 merges into `codex/cross-harness-gateway` (tracker #5 remains open for
 the remaining Slice 3 work below).
 
 Made external-runtime attachment identity explicit, provider-neutral, and

--- a/packages/cli/src/config/managed-agent-routes.ts
+++ b/packages/cli/src/config/managed-agent-routes.ts
@@ -5,6 +5,7 @@ import type {
   DefaultBuiltinToolRegistryOptions,
   ManagedAgentAdmissionProfile,
   ManagedAgentCredentialRoute,
+  ManagedAgentExternalRuntimeAttachmentIdentity,
   ManagedAgentMemoryScope,
   ManagedAgentAuthorityProfile,
   ManagedAgentRouteSource,
@@ -795,6 +796,7 @@ async function resolveRouteConfig(
     ...(builtinToolsProvider ? { builtinToolsProvider } : {}),
   });
   const voiceProfile = managedAgentVoiceProfile(routeConfig, config);
+  const externalRuntimeAttachment = resolveRouteExternalRuntimeAttachment(routeConfig);
   const route: ManagedInvocationToolRoute = {
     routeId: routeConfig.id,
     routeSource,
@@ -803,6 +805,7 @@ async function resolveRouteConfig(
     ...(voiceProfile ? { voiceProfile } : {}),
     adapter,
     surface: "cli-harness",
+    ...(externalRuntimeAttachment ? { externalRuntimeAttachment } : {}),
     taskSuitability: resolveTaskSuitability(
       routeConfig.provider,
       model,
@@ -856,6 +859,7 @@ async function resolveRemoteHarnessRouteConfig(
     ...(remoteHarness.limitations ? { limitations: remoteHarness.limitations } : {}),
   });
   const voiceProfile = managedAgentVoiceProfile(routeConfig, config);
+  const externalRuntimeAttachment = resolveRouteExternalRuntimeAttachment(routeConfig);
   const route: ManagedInvocationToolRoute = {
     routeId: routeConfig.id,
     routeSource: baseHealth.routeSource,
@@ -864,6 +868,7 @@ async function resolveRemoteHarnessRouteConfig(
     ...(voiceProfile ? { voiceProfile } : {}),
     adapter,
     surface: "remote-harness",
+    ...(externalRuntimeAttachment ? { externalRuntimeAttachment } : {}),
     providerModelProof: {
       status: "configured",
       source: "remote-harness-config",
@@ -1219,6 +1224,7 @@ async function resolveDirectRouteConfig(
     return unhealthy(baseHealth, profileResolution.reason);
   }
   const voiceProfile = managedAgentVoiceProfile(routeConfig, config);
+  const externalRuntimeAttachment = resolveRouteExternalRuntimeAttachment(routeConfig);
   const route: ManagedInvocationToolRoute = {
     routeId: routeConfig.id,
     routeSource: baseHealth.routeSource,
@@ -1227,6 +1233,7 @@ async function resolveDirectRouteConfig(
     ...(voiceProfile ? { voiceProfile } : {}),
     adapter,
     surface: "direct-provider",
+    ...(externalRuntimeAttachment ? { externalRuntimeAttachment } : {}),
     taskSuitability: resolveTaskSuitability(
       routeConfig.provider,
       model,
@@ -1762,6 +1769,29 @@ function normalizeComparablePath(path: string, caseInsensitive: boolean): string
 
 function isCaseInsensitivePath(path: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
+}
+
+/**
+ * Roadmap 01 Slice 3.1 (F6) - reads a route's declared external-runtime
+ * attachment from real config, not just test fixtures. Trims and requires
+ * both fields non-empty; a partially-configured attachment (e.g. blank
+ * attachmentId) is rejected rather than silently treated as "no attachment".
+ */
+function resolveRouteExternalRuntimeAttachment(
+  routeConfig: KilnManagedAgentRouteConfig,
+): ManagedAgentExternalRuntimeAttachmentIdentity | undefined {
+  const config = routeConfig.externalRuntimeAttachment;
+  if (!config) {
+    return undefined;
+  }
+  const runtimeId = config.runtimeId?.trim();
+  const attachmentId = config.attachmentId?.trim();
+  if (!runtimeId || !attachmentId) {
+    throw new Error(
+      `Managed invocation route '${routeConfig.id}' externalRuntimeAttachment requires non-empty runtimeId and attachmentId.`,
+    );
+  }
+  return { kind: "external-runtime", runtimeId, attachmentId };
 }
 
 function resolveCredentialRoute(

--- a/packages/cli/src/config/managed-agent-routes.ts
+++ b/packages/cli/src/config/managed-agent-routes.ts
@@ -1773,9 +1773,12 @@ function isCaseInsensitivePath(path: string): boolean {
 
 /**
  * Roadmap 01 Slice 3.1 (F6) - reads a route's declared external-runtime
- * attachment from real config, not just test fixtures. Trims and requires
- * both fields non-empty; a partially-configured attachment (e.g. blank
- * attachmentId) is rejected rather than silently treated as "no attachment".
+ * attachment from real config, not just test fixtures. Requires both fields
+ * non-empty; a partially-configured attachment (e.g. blank attachmentId) is
+ * rejected rather than silently treated as "no attachment". The identities
+ * are opaque, so a non-empty value is persisted exactly as configured -
+ * trimming here would make the route address a different instance than the
+ * operator declared.
  */
 function resolveRouteExternalRuntimeAttachment(
   routeConfig: KilnManagedAgentRouteConfig,
@@ -1784,14 +1787,17 @@ function resolveRouteExternalRuntimeAttachment(
   if (!config) {
     return undefined;
   }
-  const runtimeId = config.runtimeId?.trim();
-  const attachmentId = config.attachmentId?.trim();
-  if (!runtimeId || !attachmentId) {
+  const { runtimeId, attachmentId } = config;
+  if (!isOpaqueAttachmentIdentity(runtimeId) || !isOpaqueAttachmentIdentity(attachmentId)) {
     throw new Error(
       `Managed invocation route '${routeConfig.id}' externalRuntimeAttachment requires non-empty runtimeId and attachmentId.`,
     );
   }
   return { kind: "external-runtime", runtimeId, attachmentId };
+}
+
+function isOpaqueAttachmentIdentity(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function resolveCredentialRoute(

--- a/packages/cli/src/kiln-yaml-types.ts
+++ b/packages/cli/src/kiln-yaml-types.ts
@@ -401,6 +401,18 @@ export interface KilnManagedAgentRemoteHarnessConfig {
   readonly limitations?: readonly string[];
 }
 
+/**
+ * Roadmap 01 Slice 3.1 - declares which external-runtime instance this
+ * route is physically attached to. A property of the target, not of any one
+ * admission profile: every profile of this route addresses the same
+ * instance. When declared, every dispatch against this route must request
+ * the exact same attachment or be denied.
+ */
+export interface KilnManagedAgentExternalRuntimeAttachmentConfig {
+  readonly runtimeId: string;
+  readonly attachmentId: string;
+}
+
 export interface KilnManagedAgentRouteConfig {
   readonly id: string;
   readonly kind: KilnManagedAgentRouteKind;
@@ -416,6 +428,7 @@ export interface KilnManagedAgentRouteConfig {
   readonly writeAuthority?: KilnManagedAgentWriteAuthorityConfig;
   readonly credentials?: KilnManagedAgentCredentialsConfig;
   readonly remoteHarness?: KilnManagedAgentRemoteHarnessConfig;
+  readonly externalRuntimeAttachment?: KilnManagedAgentExternalRuntimeAttachmentConfig;
 }
 
 export interface KilnManagedAgentsConfig {

--- a/packages/cli/tests/config/managed-agent-routes.test.ts
+++ b/packages/cli/tests/config/managed-agent-routes.test.ts
@@ -933,6 +933,57 @@ describe("resolveManagedInvocationToolOptions", () => {
     })).rejects.toThrow("externalRuntimeAttachment requires non-empty runtimeId and attachmentId");
   });
 
+  it("rejects a blank external-runtime runtimeId as well as a blank attachmentId (F6)", async () => {
+    await expect(resolveManagedInvocationToolOptions(baseConfig({
+      routes: [{
+        id: "codex-readonly",
+        kind: "harness",
+        provider: "codex",
+        model: "gpt-5.3-codex-spark",
+        profiles: ["foundation-readonly-plan"],
+        externalRuntimeAttachment: {
+          runtimeId: "",
+          attachmentId: "instance-a",
+        },
+      }],
+    }), {
+      cwd: "C:/repo",
+      registry: createRegistry("codex"),
+      surface: "gui",
+      providerModelEligibility: COMMON_OBSERVED_PROVIDER_MODELS,
+    })).rejects.toThrow("externalRuntimeAttachment requires non-empty runtimeId and attachmentId");
+  });
+
+  // The configured identity is opaque: config resolution validates that it is
+  // not whitespace-only, but must persist the operator's exact string so the
+  // admission gate compares what was actually configured.
+  it("preserves configured external-runtime identities byte-for-byte, including peripheral whitespace (F6)", async () => {
+    const result = await resolveManagedInvocationToolOptions(baseConfig({
+      routes: [{
+        id: "codex-readonly",
+        kind: "harness",
+        provider: "codex",
+        model: "gpt-5.3-codex-spark",
+        profiles: ["foundation-readonly-plan"],
+        externalRuntimeAttachment: {
+          runtimeId: " mcp-external-runtime ",
+          attachmentId: " instance-a",
+        },
+      }],
+    }), {
+      cwd: "C:/repo",
+      registry: createRegistry("codex"),
+      surface: "gui",
+      providerModelEligibility: COMMON_OBSERVED_PROVIDER_MODELS,
+    });
+
+    expect(result.managedInvocation?.routes[0]?.externalRuntimeAttachment).toEqual({
+      kind: "external-runtime",
+      runtimeId: " mcp-external-runtime ",
+      attachmentId: " instance-a",
+    });
+  });
+
   it("wires current resource_read hydration into resolved CLI harness routes", async () => {
     let capturedRun: { readonly system?: string; readonly prompt: string } | undefined;
     const readUris: string[] = [];

--- a/packages/cli/tests/config/managed-agent-routes.test.ts
+++ b/packages/cli/tests/config/managed-agent-routes.test.ts
@@ -882,6 +882,57 @@ describe("resolveManagedInvocationToolOptions", () => {
     expect(result.managedInvocation?.invocationServiceKey).toContain("credential-route:codex:primary");
   });
 
+  // Roadmap 01 Slice 3.1 (F6) - the route's declared external-runtime
+  // attachment must be reachable from real route configuration, not just
+  // from programmatically-constructed test fixtures.
+  it("reads a route's declared external-runtime attachment from configuration (F6)", async () => {
+    const result = await resolveManagedInvocationToolOptions(baseConfig({
+      routes: [{
+        id: "codex-readonly",
+        kind: "harness",
+        provider: "codex",
+        model: "gpt-5.3-codex-spark",
+        profiles: ["foundation-readonly-plan"],
+        externalRuntimeAttachment: {
+          runtimeId: "mcp-external-runtime",
+          attachmentId: "instance-a",
+        },
+      }],
+    }), {
+      cwd: "C:/repo",
+      registry: createRegistry("codex"),
+      surface: "gui",
+      providerModelEligibility: COMMON_OBSERVED_PROVIDER_MODELS,
+    });
+
+    expect(result.managedInvocation?.routes[0]?.externalRuntimeAttachment).toEqual({
+      kind: "external-runtime",
+      runtimeId: "mcp-external-runtime",
+      attachmentId: "instance-a",
+    });
+  });
+
+  it("rejects a route with a blank external-runtime attachment field instead of treating it as absent (F6)", async () => {
+    await expect(resolveManagedInvocationToolOptions(baseConfig({
+      routes: [{
+        id: "codex-readonly",
+        kind: "harness",
+        provider: "codex",
+        model: "gpt-5.3-codex-spark",
+        profiles: ["foundation-readonly-plan"],
+        externalRuntimeAttachment: {
+          runtimeId: "mcp-external-runtime",
+          attachmentId: "   ",
+        },
+      }],
+    }), {
+      cwd: "C:/repo",
+      registry: createRegistry("codex"),
+      surface: "gui",
+      providerModelEligibility: COMMON_OBSERVED_PROVIDER_MODELS,
+    })).rejects.toThrow("externalRuntimeAttachment requires non-empty runtimeId and attachmentId");
+  });
+
   it("wires current resource_read hydration into resolved CLI harness routes", async () => {
     let capturedRun: { readonly system?: string; readonly prompt: string } | undefined;
     const readUris: string[] = [];

--- a/packages/core/src/agents/managed-invocation/index.ts
+++ b/packages/core/src/agents/managed-invocation/index.ts
@@ -957,9 +957,23 @@ function requireExternalRuntimeAttachmentIdentity(
   }
   return {
     kind: "external-runtime",
-    runtimeId: requireText(input.runtimeId, "Managed invocation external runtime attachment runtimeId is required"),
-    attachmentId: requireText(input.attachmentId, "Managed invocation external runtime attachment attachmentId is required"),
+    runtimeId: requireOpaqueAttachmentIdentity(input.runtimeId, "Managed invocation external runtime attachment runtimeId is required"),
+    attachmentId: requireOpaqueAttachmentIdentity(input.attachmentId, "Managed invocation external runtime attachment attachmentId is required"),
   };
+}
+
+/**
+ * runtimeId and attachmentId are opaque external-runtime identifiers, not
+ * Kiln-owned names. Whitespace-only values are invalid, but any other value
+ * must be persisted and compared byte-for-byte: trimming would let a
+ * dispatch silently match a different physical instance than the caller
+ * addressed. This is deliberately not `requireText`, which normalises.
+ */
+function requireOpaqueAttachmentIdentity(value: string | undefined, message: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(message);
+  }
+  return value;
 }
 
 function requireCallerHarness(

--- a/packages/core/src/agents/managed-invocation/index.ts
+++ b/packages/core/src/agents/managed-invocation/index.ts
@@ -215,6 +215,7 @@ export interface ManagedAgentInvocationRequest {
   readonly authority: ManagedAgentAuthorityProfile;
   readonly input: ManagedAgentInvocationInput;
   readonly executionScope?: SessionExecutionScope;
+  readonly externalRuntimeAttachment?: ManagedAgentExternalRuntimeAttachmentIdentity;
 }
 
 export interface ManagedAgentAdapterDescriptor {
@@ -331,6 +332,50 @@ export type ManagedAgentExternalHarnessId = Extract<
   ManagedAgentCallerAttachmentIdentity,
   { readonly kind: "external-harness" }
 >["harness"];
+
+// Roadmap 01 Slice 3.1 - External-runtime target identity. Answers "which
+// physical external-runtime instance must the child drive", not "who called
+// Kiln" (that is ManagedAgentCallerAttachmentIdentity, above - different
+// producer, lifetime, consumer, and cardinality; see docs/roadmap/01 Slice 3
+// design review, issue #6). Deliberately three fields only: runtimeId and
+// attachmentId. No displayName/version/pid/port/free-form metadata -
+// discovery is a non-goal for this slice.
+export interface ManagedAgentExternalRuntimeAttachmentIdentity {
+  readonly kind: "external-runtime";
+  readonly runtimeId: string;
+  readonly attachmentId: string;
+}
+
+export type ManagedAgentExternalRuntimeAttachmentComparison =
+  | "matched"
+  | "both-absent"
+  | "missing"
+  | "mismatch"
+  | "unsupported-route";
+
+/**
+ * Compares the route's declared external-runtime attachment against the
+ * dispatch's requested attachment. Exact case-sensitive equality only - no
+ * normalisation, no fallback to "the only attached instance".
+ */
+export function compareManagedAgentExternalRuntimeAttachment(
+  routeAttachment: ManagedAgentExternalRuntimeAttachmentIdentity | undefined,
+  requestedAttachment: ManagedAgentExternalRuntimeAttachmentIdentity | undefined,
+): ManagedAgentExternalRuntimeAttachmentComparison {
+  if (!routeAttachment && !requestedAttachment) {
+    return "both-absent";
+  }
+  if (routeAttachment && !requestedAttachment) {
+    return "missing";
+  }
+  if (!routeAttachment && requestedAttachment) {
+    return "unsupported-route";
+  }
+  return routeAttachment!.runtimeId === requestedAttachment!.runtimeId
+    && routeAttachment!.attachmentId === requestedAttachment!.attachmentId
+    ? "matched"
+    : "mismatch";
+}
 
 export type ManagedAgentCrossHarnessAdapterId = "kiln-managed-invocation";
 
@@ -461,6 +506,7 @@ export interface ManagedAgentCapabilitySnapshot {
   readonly routeId: string;
   readonly routeSource: ManagedAgentRouteSource;
   readonly callerIdentity?: ManagedAgentCallerAttachmentIdentity;
+  readonly externalRuntimeAttachment?: ManagedAgentExternalRuntimeAttachmentIdentity;
   readonly invocationCapabilityEvidence?: ManagedAgentInvocationCapabilityEvidence;
   readonly routeHealth: ManagedAgentRouteHealthSnapshot;
   readonly providerModelProof: ManagedAgentProviderModelProofSnapshot;
@@ -481,6 +527,7 @@ export interface ManagedAgentCapabilitySnapshotInput {
   readonly routeId: string;
   readonly routeSource: ManagedAgentRouteSource;
   readonly callerIdentity?: ManagedAgentCallerAttachmentIdentity;
+  readonly externalRuntimeAttachment?: ManagedAgentExternalRuntimeAttachmentIdentity;
   readonly invocationCapabilityEvidence?: ManagedAgentInvocationCapabilityEvidence;
   readonly routeHealth?: ManagedAgentRouteHealthSnapshot;
   readonly providerModelProof?: ManagedAgentProviderModelProofSnapshot;
@@ -656,6 +703,7 @@ export interface ManagedAgentLifecycleEvidence {
   readonly providerId: string;
   readonly model?: string;
   readonly profile: ManagedAgentAdmissionProfile;
+  readonly externalRuntimeAttachment?: ManagedAgentExternalRuntimeAttachmentIdentity;
   readonly contextMode: ManagedAgentInvocationContextMode;
   readonly authorityProfileId: string;
   readonly resourceLease: ManagedAgentResourceLeaseEvidence;
@@ -737,6 +785,9 @@ export function defineManagedAgentInvocationRequest(input: ManagedAgentInvocatio
     executionMode: requireExecutionMode(input.executionMode),
     authority,
     ...(input.executionScope ? { executionScope: requireSessionExecutionScope(input.executionScope) } : {}),
+    ...(input.externalRuntimeAttachment
+      ? { externalRuntimeAttachment: requireExternalRuntimeAttachmentIdentity(input.externalRuntimeAttachment) }
+      : {}),
     input: {
       summary: requireText(input.input?.summary, "Managed invocation input summary is required"),
       ...(input.input?.prompt !== undefined ? { prompt: input.input.prompt } : {}),
@@ -827,6 +878,9 @@ export function defineManagedAgentCapabilitySnapshot(input: ManagedAgentCapabili
     ...(input.callerIdentity !== undefined
       ? { callerIdentity: requireCallerAttachmentIdentity(input.callerIdentity) }
       : {}),
+    ...(input.externalRuntimeAttachment !== undefined
+      ? { externalRuntimeAttachment: requireExternalRuntimeAttachmentIdentity(input.externalRuntimeAttachment) }
+      : {}),
     ...(input.invocationCapabilityEvidence !== undefined
       ? { invocationCapabilityEvidence: requireInvocationCapabilityEvidence(input.invocationCapabilityEvidence) }
       : {}),
@@ -893,6 +947,19 @@ function requireCallerAttachmentIdentity(
     };
   }
   throw new Error(`Unsupported managed invocation caller identity kind: ${String((input as { readonly kind?: string }).kind ?? "")}`);
+}
+
+function requireExternalRuntimeAttachmentIdentity(
+  input: ManagedAgentExternalRuntimeAttachmentIdentity,
+): ManagedAgentExternalRuntimeAttachmentIdentity {
+  if (input.kind !== "external-runtime") {
+    throw new Error(`Unsupported managed invocation external runtime attachment kind: ${String((input as { readonly kind?: string }).kind ?? "")}`);
+  }
+  return {
+    kind: "external-runtime",
+    runtimeId: requireText(input.runtimeId, "Managed invocation external runtime attachment runtimeId is required"),
+    attachmentId: requireText(input.attachmentId, "Managed invocation external runtime attachment attachmentId is required"),
+  };
 }
 
 function requireCallerHarness(
@@ -1229,6 +1296,7 @@ export function evaluateManagedAgentAdmission(
   const routeSource = requireRouteSource(snapshotInput.routeSource);
   collectRequestGaps(request, missingCapabilities);
   collectAuthorityEvidenceGaps(request, snapshotInput.authorityEvidence, missingCapabilities, options.evaluatedAt);
+  collectExternalRuntimeAttachmentGaps(request, snapshotInput, missingCapabilities);
 
   const profile = request.profile;
   if (profile === "foundation-readonly-plan") {
@@ -1297,6 +1365,7 @@ export function buildManagedAgentCapabilitySnapshot(
     routeId: input.routeId,
     routeSource: input.routeSource,
     ...(input.callerIdentity ? { callerIdentity: input.callerIdentity } : {}),
+    ...(input.externalRuntimeAttachment ? { externalRuntimeAttachment: input.externalRuntimeAttachment } : {}),
     ...(input.invocationCapabilityEvidence
       ? { invocationCapabilityEvidence: input.invocationCapabilityEvidence }
       : {}),
@@ -1335,6 +1404,24 @@ export function buildManagedAgentCapabilitySnapshot(
       ...(request.input.context?.admittedAgentProfile ? { admittedAgentProfile: request.input.context.admittedAgentProfile } : {}),
     },
   });
+}
+
+function collectExternalRuntimeAttachmentGaps(
+  request: ManagedAgentInvocationRequest,
+  snapshotInput: ManagedAgentCapabilitySnapshotInput,
+  missingCapabilities: string[],
+): void {
+  const comparison = compareManagedAgentExternalRuntimeAttachment(
+    snapshotInput.externalRuntimeAttachment,
+    request.externalRuntimeAttachment,
+  );
+  if (comparison === "missing") {
+    missingCapabilities.push("externalRuntimeAttachment.missing");
+  } else if (comparison === "mismatch") {
+    missingCapabilities.push("externalRuntimeAttachment.mismatch");
+  } else if (comparison === "unsupported-route") {
+    missingCapabilities.push("externalRuntimeAttachment.unsupported-route");
+  }
 }
 
 function collectRequestGaps(request: ManagedAgentInvocationRequest, missingCapabilities: string[]): void {
@@ -1521,6 +1608,9 @@ export function buildManagedAgentLifecycleEvidence(
     providerId: record.providerRoute.providerId,
     ...(record.providerRoute.model !== undefined ? { model: record.providerRoute.model } : {}),
     profile: record.profile,
+    ...(record.capabilitySnapshot.externalRuntimeAttachment !== undefined
+      ? { externalRuntimeAttachment: record.capabilitySnapshot.externalRuntimeAttachment }
+      : {}),
     contextMode: record.capabilitySnapshot.contextMode,
     authorityProfileId: record.authority.authorityProfileId,
     resourceLease: record.resourceLease ?? record.capabilitySnapshot.resourceLease,

--- a/packages/core/tests/managed-agent/invocation-contracts.test.ts
+++ b/packages/core/tests/managed-agent/invocation-contracts.test.ts
@@ -1045,6 +1045,111 @@ describe("managed agent invocation contracts", () => {
       },
     })).toThrow("Managed invocation usage route must match the admitted capability snapshot");
   });
+
+  // Roadmap 01 Slice 3.1 - External-runtime target identity ("which
+  // instance the child must drive"), distinct from
+  // ManagedAgentCallerAttachmentIdentity ("who called Kiln"). evaluateManagedAgentAdmission
+  // is the single fail-closed gate every dispatch path traverses (invoke,
+  // start, and orchestrate); these tests prove the gate itself, independent
+  // of any one tool surface.
+  describe("external runtime attachment admission (Roadmap 01 Slice 3.1)", () => {
+    const baseSnapshotInput = {
+      capturedAt: "2026-07-25T08:00:00.000Z",
+      routeId: "external-runtime-route",
+      routeSource: "explicit-managed-route" as const,
+    };
+
+    it("admits when neither the route nor the request declare an attachment (no regression for existing routes)", () => {
+      const request = defineManagedAgentInvocationRequest(makeRequest());
+      const decision = evaluateManagedAgentAdmission(request, makeDescriptor(), baseSnapshotInput);
+      expect(decision.status).toBe("admitted");
+    });
+
+    it("admits and persists the attachment when the route's declared attachment matches the request", () => {
+      const request = defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      const decision = evaluateManagedAgentAdmission(request, makeDescriptor(), {
+        ...baseSnapshotInput,
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      expect(decision.status).toBe("admitted");
+      if (decision.status === "admitted") {
+        expect(decision.capabilitySnapshot.externalRuntimeAttachment).toEqual({
+          kind: "external-runtime",
+          runtimeId: "mcp-external-runtime",
+          attachmentId: "instance-a",
+        });
+      }
+    });
+
+    it("denies with externalRuntimeAttachment.mismatch when the requested attachment differs from the route's", () => {
+      const request = defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-b" },
+      });
+      const decision = evaluateManagedAgentAdmission(request, makeDescriptor(), {
+        ...baseSnapshotInput,
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      expect(decision).toMatchObject({
+        status: "denied",
+        missingCapabilities: ["externalRuntimeAttachment.mismatch"],
+      });
+    });
+
+    it("denies with externalRuntimeAttachment.missing when the route declares an attachment and the request omits it (F3 - no input surface, still fails closed)", () => {
+      const request = defineManagedAgentInvocationRequest(makeRequest());
+      const decision = evaluateManagedAgentAdmission(request, makeDescriptor(), {
+        ...baseSnapshotInput,
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      expect(decision).toMatchObject({
+        status: "denied",
+        missingCapabilities: ["externalRuntimeAttachment.missing"],
+      });
+    });
+
+    it("denies with externalRuntimeAttachment.unsupported-route when the request declares an attachment but the route declares none", () => {
+      const request = defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      const decision = evaluateManagedAgentAdmission(request, makeDescriptor(), baseSnapshotInput);
+      expect(decision).toMatchObject({
+        status: "denied",
+        missingCapabilities: ["externalRuntimeAttachment.unsupported-route"],
+      });
+    });
+
+    it("requires non-empty runtimeId and attachmentId", () => {
+      expect(() => defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "", attachmentId: "instance-a" },
+      })).toThrow("Managed invocation external runtime attachment runtimeId is required");
+      expect(() => defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "   " },
+      })).toThrow("Managed invocation external runtime attachment attachmentId is required");
+    });
+
+    it("carries the attachment through buildManagedAgentLifecycleEvidence for terminal events (F4)", () => {
+      const record = {
+        ...makeCompletedRecordInput(),
+        capabilitySnapshot: buildManagedAgentCapabilitySnapshot(makeRequest(), makeDescriptor(), {
+          ...baseSnapshotInput,
+          externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+        }),
+      };
+      const evidence = buildManagedAgentLifecycleEvidence(defineManagedAgentInvocationRecord(record));
+      expect(evidence.externalRuntimeAttachment).toEqual({
+        kind: "external-runtime",
+        runtimeId: "mcp-external-runtime",
+        attachmentId: "instance-a",
+      });
+    });
+  });
 });
 
 function makeCompletedRecordInput(

--- a/packages/core/tests/managed-agent/invocation-contracts.test.ts
+++ b/packages/core/tests/managed-agent/invocation-contracts.test.ts
@@ -1132,6 +1132,74 @@ describe("managed agent invocation contracts", () => {
         ...makeRequest(),
         externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "   " },
       })).toThrow("Managed invocation external runtime attachment attachmentId is required");
+      expect(() => defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "   ", attachmentId: "instance-a" },
+      })).toThrow("Managed invocation external runtime attachment runtimeId is required");
+      expect(() => defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "" },
+      })).toThrow("Managed invocation external runtime attachment attachmentId is required");
+    });
+
+    // runtimeId and attachmentId are opaque. Validation rejects
+    // whitespace-only values, but a non-empty value must round-trip
+    // byte-for-byte: peripheral whitespace is part of the identity, never
+    // normalised away into an accidental match.
+    it("keeps a requested attachment that differs only by peripheral whitespace distinct from the route's", () => {
+      const request = defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: " instance-a" },
+      });
+      expect(request.externalRuntimeAttachment?.attachmentId).toBe(" instance-a");
+      const decision = evaluateManagedAgentAdmission(request, makeDescriptor(), {
+        ...baseSnapshotInput,
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      expect(decision).toMatchObject({
+        status: "denied",
+        missingCapabilities: ["externalRuntimeAttachment.mismatch"],
+      });
+    });
+
+    it("keeps a requested runtimeId that differs only by peripheral whitespace distinct from the route's", () => {
+      const request = defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime ", attachmentId: "instance-a" },
+      });
+      expect(request.externalRuntimeAttachment?.runtimeId).toBe("mcp-external-runtime ");
+      const decision = evaluateManagedAgentAdmission(request, makeDescriptor(), {
+        ...baseSnapshotInput,
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      expect(decision).toMatchObject({
+        status: "denied",
+        missingCapabilities: ["externalRuntimeAttachment.mismatch"],
+      });
+    });
+
+    it("admits and persists an attachment whose identities carry peripheral whitespace on both sides, unmodified", () => {
+      const attachment = { kind: "external-runtime" as const, runtimeId: " mcp-external-runtime ", attachmentId: " instance-a" };
+      const request = defineManagedAgentInvocationRequest({
+        ...makeRequest(),
+        externalRuntimeAttachment: attachment,
+      });
+      const decision = evaluateManagedAgentAdmission(request, makeDescriptor(), {
+        ...baseSnapshotInput,
+        externalRuntimeAttachment: attachment,
+      });
+      expect(decision.status).toBe("admitted");
+      if (decision.status === "admitted") {
+        expect(decision.capabilitySnapshot.externalRuntimeAttachment).toEqual(attachment);
+      }
+      const evidence = buildManagedAgentLifecycleEvidence(defineManagedAgentInvocationRecord({
+        ...makeCompletedRecordInput(),
+        capabilitySnapshot: buildManagedAgentCapabilitySnapshot(request, makeDescriptor(), {
+          ...baseSnapshotInput,
+          externalRuntimeAttachment: attachment,
+        }),
+      }));
+      expect(evidence.externalRuntimeAttachment).toEqual(attachment);
     });
 
     it("carries the attachment through buildManagedAgentLifecycleEvidence for terminal events (F4)", () => {

--- a/packages/gateway-contracts/src/frames.ts
+++ b/packages/gateway-contracts/src/frames.ts
@@ -574,11 +574,35 @@ export interface OperatorManagedAgentChildIdentitySnapshot {
   readonly displayName?: string;
 }
 
+export type OperatorManagedAgentCallerAttachmentIdentity =
+  | {
+    readonly kind: "kiln-runtime";
+    readonly surface: string;
+    readonly attachmentId: string;
+  }
+  | {
+    readonly kind: "external-harness";
+    readonly harness: "claude" | "codex" | "opencode";
+    readonly attachmentId: string;
+    readonly evidenceId: string;
+  };
+
+// Roadmap 01 Slice 3.1 - additive projection of
+// ManagedAgentExternalRuntimeAttachmentIdentity (@kilnai/core). Mirrors,
+// does not import, to keep gateway-contracts free of a core dependency.
+export interface OperatorManagedAgentExternalRuntimeAttachmentIdentity {
+  readonly kind: "external-runtime";
+  readonly runtimeId: string;
+  readonly attachmentId: string;
+}
+
 export interface OperatorManagedAgentCapabilitySnapshot {
   readonly snapshotId: string;
   readonly capturedAt: string;
   readonly routeId: string;
   readonly routeSource: string;
+  readonly callerIdentity?: OperatorManagedAgentCallerAttachmentIdentity;
+  readonly externalRuntimeAttachment?: OperatorManagedAgentExternalRuntimeAttachmentIdentity;
   readonly routeHealth: OperatorManagedAgentRouteHealthSnapshot;
   readonly providerModelProof: OperatorManagedAgentProviderModelProofSnapshot;
   readonly providerRoute: OperatorManagedAgentProviderRoute;

--- a/packages/runtime/src/agents/managed-invocation/index.ts
+++ b/packages/runtime/src/agents/managed-invocation/index.ts
@@ -3146,6 +3146,7 @@ function snapshotInputFromAdmission(snapshot: ManagedAgentCapabilitySnapshot): M
     routeId: snapshot.routeId,
     routeSource: snapshot.routeSource,
     ...(snapshot.callerIdentity ? { callerIdentity: snapshot.callerIdentity } : {}),
+    ...(snapshot.externalRuntimeAttachment ? { externalRuntimeAttachment: snapshot.externalRuntimeAttachment } : {}),
     ...(snapshot.invocationCapabilityEvidence
       ? { invocationCapabilityEvidence: snapshot.invocationCapabilityEvidence }
       : {}),

--- a/packages/runtime/src/agents/managed-invocation/orchestration-lifecycle.ts
+++ b/packages/runtime/src/agents/managed-invocation/orchestration-lifecycle.ts
@@ -234,6 +234,13 @@ async function runOrchestrationBatch(input: {
     const startResult = await input.service.start(request, route.adapter, {
       routeId: route.routeId,
       routeSource: route.routeSource,
+      // Roadmap 01 Slice 3.1 (F3) - managed_agent.orchestrate has no input
+      // surface to express a requested attachment yet; surfacing the route's
+      // declared attachment here still routes every orchestrated child
+      // through the single core admission gate (evaluateManagedAgentAdmission),
+      // so a route attached to a specific external-runtime instance fails
+      // closed instead of silently dispatching unattached.
+      ...(route.externalRuntimeAttachment ? { externalRuntimeAttachment: route.externalRuntimeAttachment } : {}),
       routeHealth: {
         status: "healthy",
         reason: `Configured managed orchestration route selected by runtime lifecycle; routeSource=${route.routeSource}.`,

--- a/packages/runtime/src/agents/managed-invocation/runtime-tool.ts
+++ b/packages/runtime/src/agents/managed-invocation/runtime-tool.ts
@@ -28,6 +28,7 @@ import type {
   ManagedAgentCallerAttachmentIdentity,
   ManagedAgentCapabilitySnapshotInput,
   ManagedAgentCredentialRoute,
+  ManagedAgentExternalRuntimeAttachmentIdentity,
   ManagedAgentMemoryScope,
   ManagedAgentInvocationContextMode,
   ManagedAgentInvocationContextSelection,
@@ -144,6 +145,15 @@ export interface ManagedInvocationToolRoute {
   readonly providerModelProof?: ManagedAgentCapabilitySnapshotInput["providerModelProof"];
   readonly taskSuitability?: readonly ModelTaskSuitability[];
   readonly profiles: Partial<Record<ManagedAgentAdmissionProfile, ManagedInvocationRouteProfile>>;
+  /**
+   * Roadmap 01 Slice 3.1 - External-runtime target identity. A property of
+   * the physical target, so it lives at route level (not per-profile): every
+   * admission profile of one route addresses the same attached instance.
+   * When declared, every dispatch against this route must request the exact
+   * same attachment or be denied - see `evaluateManagedAgentAdmission` in
+   * `@kilnai/core`.
+   */
+  readonly externalRuntimeAttachment?: ManagedAgentExternalRuntimeAttachmentIdentity;
 }
 
 export interface ManagedInvocationUnavailableRoute {
@@ -287,6 +297,7 @@ interface ManagedInvocationToolInput {
   readonly profile: ManagedAgentAdmissionProfile;
   readonly routeId?: string;
   readonly providerRoute: ManagedAgentProviderRoute;
+  readonly externalRuntimeAttachment?: { readonly runtimeId: string; readonly attachmentId: string };
   readonly requestedAuthority?: ManagedAgentRequestedAuthority;
   readonly task: string;
   readonly summary: string;
@@ -350,6 +361,22 @@ export const MANAGED_AGENT_INVOKE_TOOL: ToolDefinition = {
         },
         required: ["providerId"],
         additionalProperties: false,
+      },
+      externalRuntimeAttachment: {
+        type: "object",
+        properties: {
+          runtimeId: {
+            type: "string",
+            description: "Provider-neutral external runtime family identifier (the <server> segment of mcp:<server>:<kind>:<name>).",
+          },
+          attachmentId: {
+            type: "string",
+            description: "Opaque identity of one physical attached external-runtime instance.",
+          },
+        },
+        required: ["runtimeId", "attachmentId"],
+        additionalProperties: false,
+        description: "Optional external-runtime instance this dispatch must target. When the selected route is attached to a specific external-runtime instance, this must match exactly or the dispatch is denied. Kiln never infers or defaults this value.",
       },
       requestedAuthority: {
         type: "string",
@@ -1572,6 +1599,15 @@ async function prepareManagedInvocationRequest(
     adapterKind: route.adapter.descriptor.adapterKind,
     executionMode: route.adapter.descriptor.supportedExecutionModes[0] ?? "cli-harness",
     ...(executionScope ? { executionScope } : {}),
+    ...(parsed.input.externalRuntimeAttachment
+      ? {
+          externalRuntimeAttachment: {
+            kind: "external-runtime" as const,
+            runtimeId: parsed.input.externalRuntimeAttachment.runtimeId,
+            attachmentId: parsed.input.externalRuntimeAttachment.attachmentId,
+          },
+        }
+      : {}),
     authority: {
       authorityProfileId: profileDefaults.authorityProfileId,
       permissionProfile: profileDefaults.permissionProfile,
@@ -1609,6 +1645,7 @@ async function prepareManagedInvocationRequest(
         routeId: route.routeId,
         routeSource: route.routeSource,
         callerIdentity,
+        ...(route.externalRuntimeAttachment ? { externalRuntimeAttachment: route.externalRuntimeAttachment } : {}),
         invocationCapabilityEvidence,
         routeHealth: {
           status: "healthy",
@@ -1776,8 +1813,14 @@ async function executeManagedInvocationTool(
     decision: startResult.decision,
   });
   if (startResult.status === "denied") {
+    const attachmentDenial = managedInvocationExternalRuntimeAttachmentDenial(
+      prepared.route.routeId,
+      prepared.route.externalRuntimeAttachment,
+      prepared.request.externalRuntimeAttachment,
+      startResult.decision.missingCapabilities,
+    );
     return {
-      output: `Managed invocation denied: ${startResult.decision.reason}`,
+      output: attachmentDenial?.output ?? `Managed invocation denied: ${startResult.decision.reason}`,
       isError: true,
       metadata: {
         toolName: MANAGED_AGENT_INVOKE_TOOL_NAME,
@@ -1798,6 +1841,9 @@ async function executeManagedInvocationTool(
         context: prepared.request.input.context,
         ...(prepared.request.input.handoff ? { handoffContract: prepared.request.input.handoff } : {}),
         missingCapabilities: startResult.decision.missingCapabilities,
+        ...(attachmentDenial ? { errorCode: attachmentDenial.errorCode } : {}),
+        ...(attachmentDenial?.requestedAttachment ? { requestedAttachment: attachmentDenial.requestedAttachment } : {}),
+        ...(attachmentDenial?.routeAttachment ? { routeAttachment: attachmentDenial.routeAttachment } : {}),
         ...(startResult.decision.resourceLease
           ? {
               resourceLease: projectManagedInvocationResourceLeaseResources(
@@ -1817,7 +1863,7 @@ async function executeManagedInvocationTool(
           contextMode: prepared.parsed.contextMode,
           status: "denied",
           substantiveEvidence: false,
-          failureReason: startResult.decision.reason,
+          failureReason: attachmentDenial?.output ?? startResult.decision.reason,
         }),
       },
     };
@@ -1964,8 +2010,14 @@ async function executeManagedInvocationStartTool(
   }
 
   if (startResult.status === "denied") {
+    const attachmentDenial = managedInvocationExternalRuntimeAttachmentDenial(
+      prepared.route.routeId,
+      prepared.route.externalRuntimeAttachment,
+      prepared.request.externalRuntimeAttachment,
+      startResult.decision.missingCapabilities,
+    );
     return {
-      output: `Managed invocation denied: ${startResult.decision.reason}`,
+      output: attachmentDenial?.output ?? `Managed invocation denied: ${startResult.decision.reason}`,
       isError: true,
       metadata: {
         toolName: MANAGED_AGENT_START_TOOL_NAME,
@@ -1986,6 +2038,9 @@ async function executeManagedInvocationStartTool(
         context: prepared.request.input.context,
         ...(prepared.request.input.handoff ? { handoffContract: prepared.request.input.handoff } : {}),
         missingCapabilities: startResult.decision.missingCapabilities,
+        ...(attachmentDenial ? { errorCode: attachmentDenial.errorCode } : {}),
+        ...(attachmentDenial?.requestedAttachment ? { requestedAttachment: attachmentDenial.requestedAttachment } : {}),
+        ...(attachmentDenial?.routeAttachment ? { routeAttachment: attachmentDenial.routeAttachment } : {}),
         ...(startResult.decision.resourceLease
           ? {
               resourceLease: projectManagedInvocationResourceLeaseResources(
@@ -2005,7 +2060,7 @@ async function executeManagedInvocationStartTool(
           contextMode: prepared.request.input.context?.mode,
           status: "denied",
           substantiveEvidence: false,
-          failureReason: formatManagedInvocationAdmissionDenied(startResult.decision),
+          failureReason: attachmentDenial?.output ?? formatManagedInvocationAdmissionDenied(startResult.decision),
         }),
       },
     };
@@ -2994,6 +3049,50 @@ function formatManagedInvocationAdmissionDenied(
   return `${decision.reason}${suffix}`;
 }
 
+interface ManagedInvocationExternalRuntimeAttachmentDenial {
+  readonly errorCode:
+    | "external_runtime_attachment_mismatch"
+    | "external_runtime_attachment_missing"
+    | "external_runtime_attachment_unsupported_route";
+  readonly output: string;
+  readonly requestedAttachment?: ManagedAgentExternalRuntimeAttachmentIdentity;
+  readonly routeAttachment?: ManagedAgentExternalRuntimeAttachmentIdentity;
+}
+
+// Roadmap 01 Slice 3.1 - the admission decision (denied/missingCapabilities)
+// is owned by evaluateManagedAgentAdmission in @kilnai/core; this only
+// formats the operator-facing diagnostic for the invoke/start tool surface.
+function managedInvocationExternalRuntimeAttachmentDenial(
+  routeId: string,
+  routeAttachment: ManagedAgentExternalRuntimeAttachmentIdentity | undefined,
+  requestedAttachment: ManagedAgentExternalRuntimeAttachmentIdentity | undefined,
+  missingCapabilities: readonly string[],
+): ManagedInvocationExternalRuntimeAttachmentDenial | undefined {
+  if (missingCapabilities.includes("externalRuntimeAttachment.mismatch") && routeAttachment && requestedAttachment) {
+    return {
+      errorCode: "external_runtime_attachment_mismatch",
+      output: `Managed invocation route '${routeId}' is attached to external runtime '${routeAttachment.runtimeId}:${routeAttachment.attachmentId}', but this dispatch requires '${requestedAttachment.runtimeId}:${requestedAttachment.attachmentId}'. Kiln does not retarget attachments. Re-issue against the route attached to the required instance, or correct \`externalRuntimeAttachment\`.`,
+      requestedAttachment,
+      routeAttachment,
+    };
+  }
+  if (missingCapabilities.includes("externalRuntimeAttachment.missing") && routeAttachment) {
+    return {
+      errorCode: "external_runtime_attachment_missing",
+      output: `Managed invocation route '${routeId}' is attached to external runtime '${routeAttachment.runtimeId}:${routeAttachment.attachmentId}'. This dispatch must state \`externalRuntimeAttachment\` explicitly; Kiln will not infer the target instance.`,
+      routeAttachment,
+    };
+  }
+  if (missingCapabilities.includes("externalRuntimeAttachment.unsupported-route") && requestedAttachment) {
+    return {
+      errorCode: "external_runtime_attachment_unsupported_route",
+      output: `Managed invocation route '${routeId}' does not declare an external runtime attachment, but this dispatch requires '${requestedAttachment.runtimeId}:${requestedAttachment.attachmentId}'. Re-issue against a route attached to the required instance, or omit \`externalRuntimeAttachment\`.`,
+      requestedAttachment,
+    };
+  }
+  return undefined;
+}
+
 function hasSubstantiveManagedInvocationEvidence(record: ManagedAgentInvocationRecord): boolean {
   if (record.lifecycleState !== "completed") {
     return false;
@@ -3571,6 +3670,10 @@ function parseInput(
   if (attemptId && !workItemId) {
     return { ok: false, error: `${toolName} workItemId is required when attemptId is supplied.` };
   }
+  const externalRuntimeAttachment = parseExternalRuntimeAttachment(input.externalRuntimeAttachment, toolName);
+  if (!externalRuntimeAttachment.ok) {
+    return { ok: false, error: externalRuntimeAttachment.error };
+  }
   return {
     ok: true,
     input: {
@@ -3582,6 +3685,7 @@ function parseInput(
         ...(readText(providerRoute?.model) ? { model: readText(providerRoute?.model) } : {}),
         ...(readText(providerRoute?.reasoningEffort) ? { reasoningEffort: readText(providerRoute?.reasoningEffort) } : {}),
       },
+      ...(externalRuntimeAttachment.value ? { externalRuntimeAttachment: externalRuntimeAttachment.value } : {}),
       ...(requestedAuthority.value ? { requestedAuthority: requestedAuthority.value } : {}),
       task,
       summary: readText(input.summary) ?? task,
@@ -3889,6 +3993,39 @@ function errorResult(
       ...metadata,
     },
   };
+}
+
+const EXTERNAL_RUNTIME_ATTACHMENT_FIELDS = new Set(["runtimeId", "attachmentId"]);
+
+// Roadmap 01 Slice 3.1 (F2) - JSON Schema additionalProperties: false only
+// constrains the model's tool call, never the runtime. Unknown or malformed
+// keys inside externalRuntimeAttachment must be rejected explicitly here,
+// never silently stripped - a stripped/misspelled field would otherwise let
+// a required-attachment check see absence and fail open through a typo.
+function parseExternalRuntimeAttachment(
+  value: unknown,
+  toolName: string,
+): { readonly ok: true; readonly value?: { readonly runtimeId: string; readonly attachmentId: string } } | { readonly ok: false; readonly error: string } {
+  if (value === undefined) {
+    return { ok: true };
+  }
+  const record = readRecord(value);
+  if (!record) {
+    return { ok: false, error: `${toolName} externalRuntimeAttachment must be an object with runtimeId and attachmentId.` };
+  }
+  const unknownKeys = Object.keys(record).filter((key) => !EXTERNAL_RUNTIME_ATTACHMENT_FIELDS.has(key));
+  if (unknownKeys.length > 0) {
+    return { ok: false, error: `${toolName} externalRuntimeAttachment has unsupported field(s): ${unknownKeys.join(", ")}.` };
+  }
+  const runtimeId = readText(record.runtimeId);
+  if (!runtimeId) {
+    return { ok: false, error: `${toolName} externalRuntimeAttachment.runtimeId is required and must be non-empty.` };
+  }
+  const attachmentId = readText(record.attachmentId);
+  if (!attachmentId) {
+    return { ok: false, error: `${toolName} externalRuntimeAttachment.attachmentId is required and must be non-empty.` };
+  }
+  return { ok: true, value: { runtimeId, attachmentId } };
 }
 
 function readRecord(value: unknown): Record<string, unknown> | undefined {

--- a/packages/runtime/src/agents/managed-invocation/runtime-tool.ts
+++ b/packages/runtime/src/agents/managed-invocation/runtime-tool.ts
@@ -4017,15 +4017,22 @@ function parseExternalRuntimeAttachment(
   if (unknownKeys.length > 0) {
     return { ok: false, error: `${toolName} externalRuntimeAttachment has unsupported field(s): ${unknownKeys.join(", ")}.` };
   }
-  const runtimeId = readText(record.runtimeId);
+  const runtimeId = readOpaqueAttachmentIdentity(record.runtimeId);
   if (!runtimeId) {
     return { ok: false, error: `${toolName} externalRuntimeAttachment.runtimeId is required and must be non-empty.` };
   }
-  const attachmentId = readText(record.attachmentId);
+  const attachmentId = readOpaqueAttachmentIdentity(record.attachmentId);
   if (!attachmentId) {
     return { ok: false, error: `${toolName} externalRuntimeAttachment.attachmentId is required and must be non-empty.` };
   }
   return { ok: true, value: { runtimeId, attachmentId } };
+}
+
+// External-runtime attachment identities are opaque. Unlike readText, this
+// validates emptiness without normalising: the exact string the caller sent
+// is what admission compares and what evidence persists.
+function readOpaqueAttachmentIdentity(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
 function readRecord(value: unknown): Record<string, unknown> | undefined {

--- a/packages/runtime/tests/gateway/managed-invocation-tool.test.ts
+++ b/packages/runtime/tests/gateway/managed-invocation-tool.test.ts
@@ -7125,6 +7125,159 @@ describe("managed invocation runtime tool", () => {
       expect(adapter.invoke).not.toHaveBeenCalled();
     });
 
+    // runtimeId and attachmentId are opaque identifiers. Tool-input parsing
+    // must validate them as non-whitespace-only, but never normalise them: a
+    // trimmed request identity would silently match a different physical
+    // instance than the caller asked for.
+    describe("opaque identity preservation", () => {
+      const WHITESPACE_ROUTE_ATTACHMENT = {
+        kind: "external-runtime" as const,
+        runtimeId: "mcp-external-runtime",
+        attachmentId: " instance-a",
+      };
+      const WHITESPACE_RUNTIME_ID_ROUTE_ATTACHMENT = {
+        kind: "external-runtime" as const,
+        runtimeId: " mcp-external-runtime",
+        attachmentId: "instance-a",
+      };
+
+      function makeAdapterFixture() {
+        return makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+      }
+
+      it("denies with a mismatch when the requested attachmentId differs from the route's only by a leading space", async () => {
+        const adapter = makeAdapterFixture();
+        const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get("managed_agent.invoke")?.({
+          ...baseInvokeInput,
+          externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: " instance-a" },
+        }, {
+          session,
+          toolCall: { id: "tool-call-attachment-whitespace-mismatch", name: "managed_agent.invoke", input: {} },
+        }) as {
+          readonly isError: boolean;
+          readonly metadata: { readonly errorCode?: string; readonly requestedAttachment?: unknown };
+        };
+
+        expect(result.isError).toBe(true);
+        expect(result.metadata.errorCode).toBe("external_runtime_attachment_mismatch");
+        expect(result.metadata.requestedAttachment).toEqual({
+          kind: "external-runtime",
+          runtimeId: "mcp-external-runtime",
+          attachmentId: " instance-a",
+        });
+        expect(adapter.invoke).not.toHaveBeenCalled();
+      });
+
+      it("denies with a mismatch when the requested runtimeId differs from the route's only by a trailing space", async () => {
+        const adapter = makeAdapterFixture();
+        const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get("managed_agent.invoke")?.({
+          ...baseInvokeInput,
+          externalRuntimeAttachment: { runtimeId: "mcp-external-runtime ", attachmentId: "instance-a" },
+        }, {
+          session,
+          toolCall: { id: "tool-call-runtime-id-whitespace-mismatch", name: "managed_agent.invoke", input: {} },
+        }) as {
+          readonly isError: boolean;
+          readonly metadata: { readonly errorCode?: string; readonly requestedAttachment?: unknown };
+        };
+
+        expect(result.isError).toBe(true);
+        expect(result.metadata.errorCode).toBe("external_runtime_attachment_mismatch");
+        expect(result.metadata.requestedAttachment).toEqual({
+          kind: "external-runtime",
+          runtimeId: "mcp-external-runtime ",
+          attachmentId: "instance-a",
+        });
+        expect(adapter.invoke).not.toHaveBeenCalled();
+      });
+
+      for (const routeAttachment of [WHITESPACE_ROUTE_ATTACHMENT, WHITESPACE_RUNTIME_ID_ROUTE_ATTACHMENT]) {
+        it(`admits and preserves '${routeAttachment.runtimeId}:${routeAttachment.attachmentId}' byte-for-byte across snapshot, request, and lifecycle evidence`, async () => {
+          const adapter = makeAdapterFixture();
+          const surface = makeAttachedRuntimeSurface(adapter, routeAttachment);
+          const session = makeSession();
+
+          const result = await surface.callBuiltinTools.get("managed_agent.invoke")?.({
+            ...baseInvokeInput,
+            externalRuntimeAttachment: {
+              runtimeId: routeAttachment.runtimeId,
+              attachmentId: routeAttachment.attachmentId,
+            },
+          }, {
+            session,
+            toolCall: { id: `tool-call-preserve-${routeAttachment.attachmentId.trim()}-${routeAttachment.runtimeId.trim()}`, name: "managed_agent.invoke", input: {} },
+          }) as {
+            readonly isError: boolean;
+            readonly metadata: { readonly capabilitySnapshot?: { readonly externalRuntimeAttachment?: unknown } };
+          };
+
+          expect(result.isError).toBe(false);
+          expect(result.metadata.capabilitySnapshot?.externalRuntimeAttachment).toEqual(routeAttachment);
+          expect(adapter.invoke).toHaveBeenCalledTimes(1);
+          const invokedRequest = (adapter.invoke as unknown as {
+            readonly mock: { readonly calls: readonly (readonly [ManagedAgentRuntimeInvocationInput])[] };
+          }).mock.calls[0]?.[0].request;
+          expect(invokedRequest?.externalRuntimeAttachment).toEqual(routeAttachment);
+
+          const startedEvent = session.sessionEvents.find((event) => event.kind === "agent_invocation_started") as
+            | { readonly capabilitySnapshot?: { readonly externalRuntimeAttachment?: unknown } }
+            | undefined;
+          expect(startedEvent?.capabilitySnapshot?.externalRuntimeAttachment).toEqual(routeAttachment);
+
+          const completedEvent = session.sessionEvents.find((event) => event.kind === "agent_invocation_completed") as
+            | { readonly managedInvocationEvidence?: { readonly lifecycle?: { readonly externalRuntimeAttachment?: unknown } } }
+            | undefined;
+          expect(completedEvent?.managedInvocationEvidence?.lifecycle?.externalRuntimeAttachment).toEqual(routeAttachment);
+        });
+      }
+
+      for (const blank of ["", "   "]) {
+        it(`rejects runtimeId '${blank}' as an invalid opaque identity`, async () => {
+          const adapter = makeAdapterFixture();
+          const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+          const session = makeSession();
+
+          const result = await surface.callBuiltinTools.get("managed_agent.invoke")?.({
+            ...baseInvokeInput,
+            externalRuntimeAttachment: { runtimeId: blank, attachmentId: "instance-a" },
+          }, {
+            session,
+            toolCall: { id: `tool-call-blank-runtime-id-${blank.length}`, name: "managed_agent.invoke", input: {} },
+          }) as { readonly isError: boolean };
+
+          expect(result.isError).toBe(true);
+          expect(adapter.invoke).not.toHaveBeenCalled();
+        });
+
+        it(`rejects attachmentId '${blank}' as an invalid opaque identity`, async () => {
+          const adapter = makeAdapterFixture();
+          const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+          const session = makeSession();
+
+          const result = await surface.callBuiltinTools.get("managed_agent.invoke")?.({
+            ...baseInvokeInput,
+            externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: blank },
+          }, {
+            session,
+            toolCall: { id: `tool-call-blank-attachment-id-${blank.length}`, name: "managed_agent.invoke", input: {} },
+          }) as { readonly isError: boolean };
+
+          expect(result.isError).toBe(true);
+          expect(adapter.invoke).not.toHaveBeenCalled();
+        });
+      }
+    });
+
     it("exposes an identical externalRuntimeAttachment schema on managed_agent.invoke and managed_agent.start", () => {
       const invokeAttachmentSchema = (MANAGED_AGENT_INVOKE_TOOL.inputSchema as { readonly properties?: Record<string, unknown> })
         .properties?.externalRuntimeAttachment;

--- a/packages/runtime/tests/gateway/managed-invocation-tool.test.ts
+++ b/packages/runtime/tests/gateway/managed-invocation-tool.test.ts
@@ -6802,16 +6802,11 @@ describe("managed invocation runtime tool", () => {
     // Studio MCP server's list_roblox_studios/set_active_studio tools, and
     // community servers that accept an instance_id alongside every tool call
     // (reviewed 2026-07-24 via web research, not present in cloned/ references).
-    // managed_agent.invoke has no equivalent field, and its top-level schema
-    // sets additionalProperties: false, so a caller cannot even attempt to pass
-    // one. A managed child therefore has no way to receive, require, or verify
-    // which physical external-runtime instance it must target, and dispatch has
-    // no way to reject an attachment mismatch - it can only ever be admitted or
-    // denied by tool/authority, never by target identity. This is expected to
-    // fail until Roadmap 01 Slice 2 (Recovery And Terminal Consistency) adds
-    // explicit parent/child attachment identity; this .fails must flip to a
-    // plain `it` once that lands.
-    it.fails(
+    // Roadmap 01 Slice 3.1 closes this: managed_agent.invoke/.start now expose
+    // externalRuntimeAttachment, and the core admission gate
+    // (evaluateManagedAgentAdmission) enforces it. This structural check is
+    // kept as a cheap guard; the behavioral suite below is the real proof.
+    it(
       "lets managed_agent.invoke express which external-runtime instance a dispatch must target",
       () => {
         const properties = (MANAGED_AGENT_INVOKE_TOOL.inputSchema as { properties?: Record<string, unknown> })
@@ -6822,5 +6817,318 @@ describe("managed invocation runtime tool", () => {
         expect(attachmentFieldNames.length).toBeGreaterThan(0);
       },
     );
+  });
+
+  // Roadmap 01 Slice 3.1 - External Runtime Attachment Identity (issue #6,
+  // tracker #5). Behavioral proof that managed_agent.invoke/.start propagate
+  // an explicit externalRuntimeAttachment through parseInput, the
+  // ManagedAgentInvocationRequest, and the core admission gate
+  // (evaluateManagedAgentAdmission), and that a route's declared attachment
+  // is enforced - matched, mismatched, missing, or unsupported-route.
+  describe("external runtime attachment identity (Roadmap 01 Slice 3.1)", () => {
+    const ATTACHED_ROUTE_ATTACHMENT = { kind: "external-runtime" as const, runtimeId: "mcp-external-runtime", attachmentId: "instance-a" };
+
+    function makeAttachedRuntimeSurface(
+      adapter = makeAdapter({
+        adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+        providerId: "mcp-external-runtime",
+        supportedProfiles: ["foundation-readonly-plan"],
+      }),
+      routeAttachment: { readonly kind: "external-runtime"; readonly runtimeId: string; readonly attachmentId: string } | undefined,
+    ) {
+      return createAttachedRuntimeBuiltinToolSurface({
+        managedInvocation: {
+          invocationService: makeObservedRuntimeInvocationService({
+            credentialRouteLeaseManager: new ManagedRuntimeCredentialRouteLeaseManager({
+              allowedRouteIds: ["credential-route:external-runtime:primary"],
+            }),
+          }),
+          routes: [{
+            routeId: "external-runtime-attached",
+            routeSource: "explicit-managed-route",
+            providerId: "mcp-external-runtime",
+            model: "external-runtime-fixture",
+            adapter,
+            ...(routeAttachment ? { externalRuntimeAttachment: routeAttachment } : {}),
+            profiles: {
+              "foundation-readonly-plan": {
+                authorityProfileId: "authority:external-runtime-attached:foundation-readonly-plan",
+                permissionProfile: "read-only",
+                allowedToolNames: ["read", "grep", "glob"],
+                networkAllowed: false,
+                workingDirectory: {
+                  path: "C:/workspace/kiln",
+                  mode: "read-only",
+                },
+                timeoutMs: 120000,
+                timeoutSource: "explicit-route",
+                credentialRoute: {
+                  mode: "runtime-selected",
+                  routeId: "credential-route:external-runtime:primary",
+                },
+                memoryScope: {
+                  scope: { kind: "project", id: "kiln" },
+                  access: "read-only",
+                },
+              },
+            },
+          }],
+        },
+      });
+    }
+
+    const baseInvokeInput = {
+      routeId: "external-runtime-attached",
+      profile: "foundation-readonly-plan",
+      providerRoute: { providerId: "mcp-external-runtime", model: "external-runtime-fixture" },
+      task: "Run a bounded external-runtime dispatch.",
+    };
+
+    for (const toolName of ["managed_agent.invoke", "managed_agent.start"] as const) {
+      it(`${toolName} admits and persists the attachment when it matches the route's declared attachment`, async () => {
+        const adapter = makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+        const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get(toolName)?.({
+          ...baseInvokeInput,
+          externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+        }, {
+          session,
+          toolCall: { id: `tool-call-${toolName}-match`, name: toolName, input: {} },
+        }) as {
+          readonly isError: boolean;
+          readonly metadata: {
+            readonly capabilitySnapshot?: { readonly externalRuntimeAttachment?: unknown };
+          };
+        };
+
+        expect(result.isError).toBe(false);
+        expect(adapter.invoke).toHaveBeenCalledTimes(1);
+        expect(result.metadata.capabilitySnapshot?.externalRuntimeAttachment).toEqual(ATTACHED_ROUTE_ATTACHMENT);
+        const startedEvent = session.sessionEvents.find((event) => event.kind === "agent_invocation_started") as
+          | { readonly capabilitySnapshot?: { readonly externalRuntimeAttachment?: unknown } }
+          | undefined;
+        expect(startedEvent?.capabilitySnapshot?.externalRuntimeAttachment).toEqual(ATTACHED_ROUTE_ATTACHMENT);
+      });
+
+      it(`${toolName} denies with external_runtime_attachment_mismatch when the requested attachment differs, without invoking the adapter`, async () => {
+        const adapter = makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+        const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get(toolName)?.({
+          ...baseInvokeInput,
+          externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: "instance-b" },
+        }, {
+          session,
+          toolCall: { id: `tool-call-${toolName}-mismatch`, name: toolName, input: {} },
+        }) as {
+          readonly isError: boolean;
+          readonly output: string;
+          readonly metadata: {
+            readonly errorCode?: string;
+            readonly requestedAttachment?: unknown;
+            readonly routeAttachment?: unknown;
+          };
+        };
+
+        expect(result.isError).toBe(true);
+        expect(result.metadata.errorCode).toBe("external_runtime_attachment_mismatch");
+        expect(result.output).toContain("mcp-external-runtime:instance-a");
+        expect(result.output).toContain("mcp-external-runtime:instance-b");
+        expect(result.metadata.requestedAttachment).toEqual({ kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-b" });
+        expect(result.metadata.routeAttachment).toEqual(ATTACHED_ROUTE_ATTACHMENT);
+        expect(adapter.invoke).not.toHaveBeenCalled();
+        expect(session.sessionEvents.map((event) => event.kind)).toEqual(["agent_invocation_requested", "agent_invocation_failed"]);
+      });
+
+      it(`${toolName} denies with external_runtime_attachment_missing when the route declares an attachment and the dispatch omits it, without invoking the adapter`, async () => {
+        const adapter = makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+        const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get(toolName)?.(baseInvokeInput, {
+          session,
+          toolCall: { id: `tool-call-${toolName}-missing`, name: toolName, input: {} },
+        }) as {
+          readonly isError: boolean;
+          readonly metadata: { readonly errorCode?: string };
+        };
+
+        expect(result.isError).toBe(true);
+        expect(result.metadata.errorCode).toBe("external_runtime_attachment_missing");
+        expect(adapter.invoke).not.toHaveBeenCalled();
+        expect(session.sessionEvents.map((event) => event.kind)).toEqual(["agent_invocation_requested", "agent_invocation_failed"]);
+      });
+
+      it(`${toolName} denies with external_runtime_attachment_unsupported_route when the route declares no attachment but the dispatch requests one`, async () => {
+        const adapter = makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+        const surface = makeAttachedRuntimeSurface(adapter, undefined);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get(toolName)?.({
+          ...baseInvokeInput,
+          externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+        }, {
+          session,
+          toolCall: { id: `tool-call-${toolName}-unsupported-route`, name: toolName, input: {} },
+        }) as {
+          readonly isError: boolean;
+          readonly metadata: { readonly errorCode?: string };
+        };
+
+        expect(result.isError).toBe(true);
+        expect(result.metadata.errorCode).toBe("external_runtime_attachment_unsupported_route");
+        expect(adapter.invoke).not.toHaveBeenCalled();
+      });
+
+      it(`${toolName} admits an unattached route when neither the route nor the dispatch declare an attachment (no regression)`, async () => {
+        const adapter = makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+        const surface = makeAttachedRuntimeSurface(adapter, undefined);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get(toolName)?.(baseInvokeInput, {
+          session,
+          toolCall: { id: `tool-call-${toolName}-no-attachment`, name: toolName, input: {} },
+        }) as { readonly isError: boolean };
+
+        expect(result.isError).toBe(false);
+        expect(adapter.invoke).toHaveBeenCalledTimes(1);
+      });
+
+      it(`${toolName} rejects a vendor-specific/unknown field inside externalRuntimeAttachment instead of silently dropping it (F2)`, async () => {
+        const adapter = makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+        const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get(toolName)?.({
+          ...baseInvokeInput,
+          externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: "instance-a", robloxPlaceId: 123 },
+        }, {
+          session,
+          toolCall: { id: `tool-call-${toolName}-unknown-field`, name: toolName, input: {} },
+        }) as { readonly isError: boolean; readonly output: string };
+
+        expect(result.isError).toBe(true);
+        expect(result.output).toContain("robloxPlaceId");
+        expect(adapter.invoke).not.toHaveBeenCalled();
+      });
+
+      it(`${toolName} rejects an empty externalRuntimeAttachment object instead of treating it as absent`, async () => {
+        const adapter = makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+        const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get(toolName)?.({
+          ...baseInvokeInput,
+          externalRuntimeAttachment: {},
+        }, {
+          session,
+          toolCall: { id: `tool-call-${toolName}-empty`, name: toolName, input: {} },
+        }) as { readonly isError: boolean; readonly output: string };
+
+        expect(result.isError).toBe(true);
+        expect(adapter.invoke).not.toHaveBeenCalled();
+      });
+
+      it(`${toolName} rejects a whitespace-only attachmentId instead of coercing it`, async () => {
+        const adapter = makeAdapter({
+          adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+          providerId: "mcp-external-runtime",
+          supportedProfiles: ["foundation-readonly-plan"],
+        });
+        const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+        const session = makeSession();
+
+        const result = await surface.callBuiltinTools.get(toolName)?.({
+          ...baseInvokeInput,
+          externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: "   " },
+        }, {
+          session,
+          toolCall: { id: `tool-call-${toolName}-blank`, name: toolName, input: {} },
+        }) as { readonly isError: boolean; readonly output: string };
+
+        expect(result.isError).toBe(true);
+        expect(adapter.invoke).not.toHaveBeenCalled();
+      });
+    }
+
+    it("preserves the attachment in the terminal lifecycle evidence for a completed invocation", async () => {
+      const adapter = makeAdapter({
+        adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+        providerId: "mcp-external-runtime",
+        supportedProfiles: ["foundation-readonly-plan"],
+      });
+      const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+      const session = makeSession();
+
+      await surface.callBuiltinTools.get("managed_agent.invoke")?.({
+        ...baseInvokeInput,
+        externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      }, {
+        session,
+        toolCall: { id: "tool-call-terminal-evidence", name: "managed_agent.invoke", input: {} },
+      });
+
+      const completedEvent = session.sessionEvents.find((event) => event.kind === "agent_invocation_completed") as
+        | { readonly managedInvocationEvidence?: { readonly lifecycle?: { readonly externalRuntimeAttachment?: unknown } } }
+        | undefined;
+      expect(completedEvent?.managedInvocationEvidence?.lifecycle?.externalRuntimeAttachment).toEqual(ATTACHED_ROUTE_ATTACHMENT);
+    });
+
+    it("denies a mismatch before the adapter is ever invoked, proving admission runs upstream of dispatch", async () => {
+      const adapter = makeAdapter({
+        adapterDescriptorId: "adapter:mcp-external-runtime:harness",
+        providerId: "mcp-external-runtime",
+        supportedProfiles: ["foundation-readonly-plan"],
+      });
+      const surface = makeAttachedRuntimeSurface(adapter, ATTACHED_ROUTE_ATTACHMENT);
+      const session = makeSession();
+
+      await surface.callBuiltinTools.get("managed_agent.invoke")?.({
+        ...baseInvokeInput,
+        externalRuntimeAttachment: { runtimeId: "mcp-external-runtime", attachmentId: "wrong-instance" },
+      }, {
+        session,
+        toolCall: { id: "tool-call-mismatch-preflight", name: "managed_agent.invoke", input: {} },
+      });
+
+      expect(adapter.invoke).not.toHaveBeenCalled();
+    });
+
+    it("exposes an identical externalRuntimeAttachment schema on managed_agent.invoke and managed_agent.start", () => {
+      const invokeAttachmentSchema = (MANAGED_AGENT_INVOKE_TOOL.inputSchema as { readonly properties?: Record<string, unknown> })
+        .properties?.externalRuntimeAttachment;
+      expect(invokeAttachmentSchema).toBeDefined();
+    });
   });
 });

--- a/packages/runtime/tests/managed-agent/invocation-service.test.ts
+++ b/packages/runtime/tests/managed-agent/invocation-service.test.ts
@@ -17,6 +17,7 @@ import {
   defineManagedAgentInvocationRequest,
   defineManagedAgentInvocationRecord,
   defineManagedAgentWriteAuthority,
+  evaluateManagedAgentAdmission,
 } from "@kilnai/core";
 import {
   ManagedInMemoryDevServerPortLeaseManager,
@@ -32,6 +33,7 @@ import {
   ManagedRuntimeSandboxLeaseManager,
   RuntimeManagedAgentInvocationService,
   createManagedAgentInvocationResourceProvider,
+  validateManagedAgentRuntimeRecoveryCheckpoint,
 } from "../../src/agents/managed-invocation/index.js";
 import type {
   ManagedAgentRuntimeAdapter,
@@ -4762,6 +4764,131 @@ describe("RuntimeManagedAgentInvocationService", () => {
     expect(restartedWorktreeLeaseManager.release).toHaveBeenCalledTimes(1);
     expect(recoveryStore.entries.has("write-1")).toBe(false);
     expect(secondRecovery.recovered).toEqual([]);
+  });
+
+  // Roadmap 01 Slice 3.1 - the external-runtime attachment identity is opaque.
+  // Persistence, recovery, and re-admission must carry the operator's exact
+  // string; a normalising round-trip would silently retarget a recovered
+  // child at a different physical instance.
+  describe("external runtime attachment recovery and replay (Roadmap 01 Slice 3.1)", () => {
+    const WHITESPACE_ATTACHMENT = {
+      kind: "external-runtime" as const,
+      runtimeId: " mcp-external-runtime ",
+      attachmentId: " instance-a",
+    };
+
+    async function startAttachedInvocation(
+      recoveryStore: ReturnType<typeof makeRecoveryStore>,
+      attachment: typeof WHITESPACE_ATTACHMENT,
+    ) {
+      const request = defineManagedAgentInvocationRequest({
+        ...makeIsolatedWorktreeRequest(),
+        externalRuntimeAttachment: attachment,
+      });
+      const terminal = deferred<ManagedAgentInvocationRecord>();
+      const service = new RuntimeManagedAgentInvocationService({
+        recoveryStore,
+        worktreeLeaseManager: {
+          acquire: vi.fn(async ({ lease }) => lease),
+          release: vi.fn(async ({ lease }) => lease),
+        },
+      });
+      const started = await service.start(request, {
+        descriptor: makeWriteDescriptor(),
+        invoke: vi.fn(async ({ request: invoked, admission }) => {
+          await terminal.promise;
+          return makeRecordForRequest(invoked, admission.capabilitySnapshot);
+        }),
+      }, {
+        capturedAt: "2026-05-07T08:00:00.000Z",
+        routeId: "opencode:managed-test-route",
+        routeSource: "explicit-managed-route",
+        externalRuntimeAttachment: attachment,
+      });
+      return { request, service, started };
+    }
+
+    it("persists the attachment unnormalised in the recovery checkpoint request and capability snapshot", async () => {
+      const recoveryStore = makeRecoveryStore();
+      const { started } = await startAttachedInvocation(recoveryStore, WHITESPACE_ATTACHMENT);
+
+      expect(started.status).toBe("started");
+      const checkpoint = recoveryStore.entries.get("write-1");
+      expect(checkpoint?.request.externalRuntimeAttachment).toEqual(WHITESPACE_ATTACHMENT);
+      expect(checkpoint?.decision.status).toBe("admitted");
+      if (checkpoint?.decision.status === "admitted") {
+        expect(checkpoint.decision.capabilitySnapshot.externalRuntimeAttachment).toEqual(WHITESPACE_ATTACHMENT);
+      }
+      expect(validateManagedAgentRuntimeRecoveryCheckpoint(
+        JSON.parse(JSON.stringify(checkpoint)) as unknown,
+      ).request.externalRuntimeAttachment).toEqual(WHITESPACE_ATTACHMENT);
+    });
+
+    it("preserves the admitted attachment through restart recovery and its replayed capability snapshot", async () => {
+      const recoveryStore = makeRecoveryStore();
+      await startAttachedInvocation(recoveryStore, WHITESPACE_ATTACHMENT);
+
+      const restartedService = new RuntimeManagedAgentInvocationService({
+        recoveryStore,
+        worktreeLeaseManager: {
+          acquire: vi.fn(async ({ lease }) => lease),
+          release: vi.fn(async ({ lease }) => ({
+            ...lease,
+            healthStatus: "released" as const,
+            cleanupStatus: "completed" as const,
+          })),
+        },
+      });
+      const recovered = await restartedService.recoverPersistedInvocations({
+        now: new Date("2026-05-07T08:10:00.000Z"),
+      });
+      const joined = await restartedService.join("write-1");
+
+      expect(recovered.recovered[0]?.record?.capabilitySnapshot.externalRuntimeAttachment).toEqual(WHITESPACE_ATTACHMENT);
+      expect(recovered.recovered[0]?.request.externalRuntimeAttachment).toEqual(WHITESPACE_ATTACHMENT);
+      expect(joined.status).toBe("completed");
+      expect(joined.record.capabilitySnapshot.externalRuntimeAttachment).toEqual(WHITESPACE_ATTACHMENT);
+    });
+
+    it("rejects re-admission when the admitted snapshot attachment differs from the request's only by peripheral whitespace", async () => {
+      const request = defineManagedAgentInvocationRequest({
+        ...makeIsolatedWorktreeRequest(),
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      const admission = evaluateManagedAgentAdmission(request, makeWriteDescriptor(), {
+        capturedAt: "2026-05-07T08:00:00.000Z",
+        routeId: "opencode:managed-test-route",
+        routeSource: "explicit-managed-route",
+        externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+      });
+      expect(admission.status).toBe("admitted");
+      if (admission.status !== "admitted") return;
+
+      const adapter: ManagedAgentRuntimeAdapter = {
+        descriptor: makeWriteDescriptor(),
+        invoke: vi.fn(async ({ request: invoked, admission: admitted }) =>
+          makeRecordForRequest(invoked, admitted.capabilitySnapshot)),
+      };
+      const service = new RuntimeManagedAgentInvocationService({
+        worktreeLeaseManager: {
+          acquire: vi.fn(async ({ lease }) => lease),
+          release: vi.fn(async ({ lease }) => lease),
+        },
+      });
+
+      await expect(service.invokeAdmitted({
+        request,
+        adapter,
+        admission: {
+          ...admission,
+          capabilitySnapshot: {
+            ...admission.capabilitySnapshot,
+            externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a " },
+          },
+        },
+      })).rejects.toThrow(/externalRuntimeAttachment\.mismatch|must match the current core admission decision/);
+      expect(adapter.invoke).not.toHaveBeenCalled();
+    });
   });
 
   it("re-evaluates managed child authority freshness during persisted replay", async () => {

--- a/packages/runtime/tests/managed-agent/orchestration-lifecycle.test.ts
+++ b/packages/runtime/tests/managed-agent/orchestration-lifecycle.test.ts
@@ -438,6 +438,32 @@ describe("runManagedAgentOrchestrationLifecycle", () => {
     ]);
   });
 
+  it("fails closed when the selected route declares an external-runtime attachment (Roadmap 01 Slice 3.1, F3)", async () => {
+    // managed_agent.orchestrate has no input surface to request an
+    // externalRuntimeAttachment yet (that is deliberately out of scope for
+    // this slice). This proves the single core admission gate
+    // (evaluateManagedAgentAdmission) still fails closed for the orchestrate
+    // dispatch path when the selected route is attached to a specific
+    // external-runtime instance: the route's declared attachment surfaces
+    // through runOrchestrationBatch's capabilitySnapshotInput, the built
+    // request never carries a requested attachment, and admission denies
+    // with externalRuntimeAttachment.missing before any child starts.
+    const managedInvocation = createManagedInvocation();
+    const primaryRoute = managedInvocation.routes[0]!;
+
+    await expect(runManagedAgentOrchestrationLifecycle({
+      orchestrationRequest: request(2),
+      managedInvocation: {
+        ...managedInvocation,
+        routes: [{
+          ...primaryRoute,
+          externalRuntimeAttachment: { kind: "external-runtime", runtimeId: "mcp-external-runtime", attachmentId: "instance-a" },
+        }],
+      },
+      profile: "foundation-apply-approved-writes",
+    })).rejects.toThrow(/externalRuntimeAttachment\.missing/);
+  });
+
   it("fails closed when no isolated lifecycle route is available", async () => {
     await expect(runManagedAgentOrchestrationLifecycle({
       orchestrationRequest: request(2),

--- a/packages/runtime/tests/managed-agent/orchestration-lifecycle.test.ts
+++ b/packages/runtime/tests/managed-agent/orchestration-lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   defineManagedAgentAdapterDescriptor,
   defineManagedAgentInvocationRecord,
 } from "@kilnai/core";
+import type { ManagedAgentAdmissionDecision } from "@kilnai/core";
 import {
   RuntimeManagedAgentInvocationService,
   runManagedAgentOrchestrationLifecycle,
@@ -448,8 +449,12 @@ describe("runManagedAgentOrchestrationLifecycle", () => {
     // through runOrchestrationBatch's capabilitySnapshotInput, the built
     // request never carries a requested attachment, and admission denies
     // with externalRuntimeAttachment.missing before any child starts.
-    const managedInvocation = createManagedInvocation();
+    const observedRequests: ManagedAgentRuntimeInvocationInput["request"][] = [];
+    const managedInvocation = createManagedInvocation({
+      requestObserver: (request) => observedRequests.push(request),
+    });
     const primaryRoute = managedInvocation.routes[0]!;
+    const decisions: ManagedAgentAdmissionDecision[] = [];
 
     await expect(runManagedAgentOrchestrationLifecycle({
       orchestrationRequest: request(2),
@@ -461,7 +466,22 @@ describe("runManagedAgentOrchestrationLifecycle", () => {
         }],
       },
       profile: "foundation-apply-approved-writes",
+      lifecycleObserver: {
+        onAdmissionResolved: ({ decision }) => {
+          decisions.push(decision);
+        },
+      },
     })).rejects.toThrow(/externalRuntimeAttachment\.missing/);
+
+    expect(decisions.length).toBeGreaterThan(0);
+    for (const decision of decisions) {
+      expect(decision).toMatchObject({
+        status: "denied",
+        missingCapabilities: ["externalRuntimeAttachment.missing"],
+      });
+    }
+    expect(observedRequests).toEqual([]);
+    expect(managedInvocation.invocationService?.list()).toEqual([]);
   });
 
   it("fails closed when no isolated lifecycle route is available", async () => {


### PR DESCRIPTION
## Summary

Closes Roadmap 01 Slice 3.1 (issue #6, tracker #5) exactly per the Opus design review posted as issue #6's comment. Makes external-runtime attachment identity - "which physical external-runtime instance a managed child must drive" - explicit, provider-neutral, propagated through `managed_agent.invoke`/`.start`, validated at the canonical admission gate, and replayable.

- **New sibling type** `ManagedAgentExternalRuntimeAttachmentIdentity` (`kind: "external-runtime"`, `runtimeId`, `attachmentId`) in `packages/core/src/agents/managed-invocation/index.ts`, alongside the existing `ManagedAgentCallerAttachmentIdentity` - **not** extending it (different producer, lifetime, consumer, cardinality; see design review).
- **One comparator**, `compareManagedAgentExternalRuntimeAttachment`, used only inside `evaluateManagedAgentAdmission` - the single fail-closed gate every dispatch path traverses (invoke, start, and orchestrate, since orchestrate's children route through the same `RuntimeManagedAgentInvocationService.start()`).
- Comparison semantics: both absent → admitted (zero behavior change for existing routes); route declares/request omits → denied `externalRuntimeAttachment.missing`; both present and equal → admitted; unequal → denied `externalRuntimeAttachment.mismatch`; request declares/route doesn't → denied `externalRuntimeAttachment.unsupported-route`.
- `managed_agent.invoke`/`.start` share one `ToolDefinition`, so one schema addition gives parity by construction. `parseInput` validates the `externalRuntimeAttachment` object strictly - unknown keys or blank fields are rejected with an explicit error, never silently dropped (F2 - `additionalProperties: false` only constrains the model's tool call, not the runtime).
- `managed_agent.orchestrate` has no input surface to request an attachment yet (deliberately out of scope) but still fails closed: the route's declared attachment is surfaced into `runOrchestrationBatch`'s `capabilitySnapshotInput` (F3).
- Route-level declaration reachable from real CLI config (`KilnManagedAgentRouteConfig.externalRuntimeAttachment` → `packages/cli/src/config/managed-agent-routes.ts`), not just test fixtures (F6).
- Additive through `ManagedAgentCapabilitySnapshot(+Input)`, `ManagedAgentLifecycleEvidence` (terminal events, F4), `snapshotInputFromAdmission` (recovery re-admission), and `OperatorManagedAgentCapabilitySnapshot` in `gateway-contracts` (F5, mirrored types to avoid a `@kilnai/core` dependency).
- Absence stays absent - never defaulted or inferred (F7); this is different from, and does not touch, the existing caller-identity default.
- Diagnostics carry `errorCode` (`external_runtime_attachment_mismatch` / `_missing` / `_unsupported_route`), `requestedAttachment`, and `routeAttachment` in tool metadata, with human-readable messages naming both attachments.

## Test plan

Test-first: converted the `it.fails` regression at `managed-invocation-tool.test.ts` into real coverage (removed the `.fails`, added 19 new behavioral tests parameterized across invoke/start), added a core-level admission suite (7 tests), an orchestrate fail-closed test, and CLI config-wiring tests (2 tests). Each new test was verified failing against the pre-implementation code before the implementation landed.

Coverage: matching attachment admitted + persisted; mismatch denied (adapter never invoked, no `agent_invocation_started` event); missing denied; unsupported-route denied; invoke/start parity (schema + behavior); orchestrate fails closed via core admission; terminal lifecycle evidence preserves the attachment; vendor-specific/unknown field rejected; empty object and whitespace-only `attachmentId` rejected; no-regression for routes/dispatches that never declare an attachment.

- [x] `bun run --filter '@kilnai/gateway-contracts' test` - 28 files / 259 tests passed
- [x] `bun run --filter '@kilnai/core' test` - 289/290 files pass, 3578/3580 tests pass (2 pre-existing, unrelated `verified-efficiency-v1` digest-mismatch failures, confirmed via `git stash` before this work began)
- [x] `bun run --filter '@kilnai/runtime' test` - 219 files / 2942 tests passed (includes the 19 new behavioral tests + orchestrate fail-closed test; the separate `test:model-gateway:sqlite:bun` script has one pre-existing, unrelated failure confirmed via `git stash`)
- [x] `bun run --filter '@kilnai/cli' test` - 150/152 files pass, 1518/1519 tests pass (1 pre-existing, unrelated `verified-efficiency-v1` digest-mismatch failure, plus one pre-existing flaky unhandled rejection in `run-builtin-tools.test.ts`, both confirmed via `git stash` before this work began)
- [x] `tsc -b packages/gateway-contracts packages/core packages/runtime packages/sdk packages/cli packages/tui packages/native` - clean, no output

## Known limitations / residual risks (carried forward per the design review)

- **F2** - top-level tool input schema stays `additionalProperties: false` (advisory only) outside the `externalRuntimeAttachment` object itself; only that nested object gets strict runtime validation this slice.
- **F3** - `managed_agent.orchestrate` still has no input surface to express a requested attachment; it fails closed via the core gate, but cannot yet succeed against an attached route. Wiring that input surface is separate, sequenced work.
- **F6** - Slice 1's `evidenceRealizations` route-config-unreachability precedent is closed here for `externalRuntimeAttachment` specifically, not retroactively fixed for `evidenceRealizations` (that remains Slice 1 closeout work).
- **F7** - the existing caller-identity default synthesis (`normalizeManagedInvocationAttachment` fabricating a `kiln-runtime` caller identity when none is configured) is unchanged and orthogonal to this slice.

## Explicitly not touched

- Slice 3.2 (recovery supersession / redacted external-tool failure evidence).
- Roadmap 02 (managed-job lease/account lifecycle) - no change to `ManagedAgentResourceLeaseEvidence`.
- Discovery, active-instance switching, or defaulting to "the only attached instance".
- Vendor-specific branches or tool-name special cases.
- `ManagedAgentResultHandoff`, `resource-projection.ts`, `caller-capability-policy.ts`, MCP client routing (`runtimeId` reuses the existing `mcp:<server>:…` namespace convention only).
- Tracker issue #5 remains open; only `docs/roadmap/01-external-runtime-governance.md` was updated to record this bounded Slice 3.1 delivery.