### PR TITLE
fix(runtime): restore Ubuntu CI portability

### DIFF
--- a/packages/runtime/src/gateway/gateway-server.ts
+++ b/packages/runtime/src/gateway/gateway-server.ts
@@ -411,6 +411,7 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
     whatsapp: whatsappConfig,
     tenantAdmin: tenantAdminConfig,
   });
+  const guiDistPath = resolveGuiDistPath(options?.guiDistPath);
 
   // Initialize OTel exporter if observability is configured
   // @opentelemetry/sdk-trace-base and @opentelemetry/exporter-trace-otlp-http are user-installed
@@ -1051,7 +1052,6 @@ export async function startGateway(configPath: string, options?: StartGatewayOpt
     : undefined;
 
   const studioDistPath = options?.studioDistPath ?? (options?.devMode ? resolveStudioDist() : undefined);
-  const guiDistPath = resolveGuiDistPath(options?.guiDistPath);
 
   // Initialize dev-mode swarm coordination store.
   let swarmMemoryRepository: SqliteMemoryRepository | undefined;

--- a/packages/runtime/src/model-gateway/model-gateway-autostart.ts
+++ b/packages/runtime/src/model-gateway/model-gateway-autostart.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
-import { dirname, join } from "node:path";
+import { dirname, win32 } from "node:path";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import type { ModelGatewayLaunchDescriptor } from "./model-gateway-supervisor.js";
 
@@ -64,7 +64,7 @@ export class WindowsModelGatewayAutostartAdapter {
     const current = await this.status();
     if (current.state === "foreign") return current;
     if (current.state === "installed" && current.digest === digest) return current;
-    const xmlPath = join(this.#runtimeDir, "autostart-task.xml");
+    const xmlPath = win32.join(this.#runtimeDir, "autostart-task.xml");
     await this.#writeXml(xmlPath, createTaskXml({ launch, digest, userId: this.#userId }));
     try {
       const result = await this.#run(["/Create", "/TN", this.#taskName, "/XML", xmlPath, "/F"]);

--- a/packages/runtime/tests/gateway/claude-cli-model-discovery.test.ts
+++ b/packages/runtime/tests/gateway/claude-cli-model-discovery.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it, vi } from "vitest";
 
+const { execSync } = vi.hoisted(() => ({
+  execSync: vi.fn((command: string) => {
+    if (command === '"claude" --version') {
+      return Buffer.from("");
+    }
+    throw new Error("executable unavailable");
+  }),
+}));
 const supportedModels = vi.fn(async () => [{ value: "claude-live-exact" }]);
 const close = vi.fn();
 const next = vi.fn();
 const query = vi.fn(() => ({ supportedModels, close, next }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({ query }));
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execSync,
+}));
 
 import { discoverClaudeCliModelDiscovery } from "../../src/gateway/gui-provider-models.js";
 
@@ -13,7 +25,14 @@ describe("discoverClaudeCliModelDiscovery", () => {
   it("reads the SDK control catalog without consuming the response iterator", async () => {
     const discovery = await discoverClaudeCliModelDiscovery();
 
-    expect(query).toHaveBeenCalledWith(expect.objectContaining({ prompt: "" }));
+    expect(query).toHaveBeenCalledWith({
+      prompt: "",
+      options: {
+        permissionMode: "plan",
+        pathToClaudeCodeExecutable: "claude",
+      },
+    });
+    expect(execSync).toHaveBeenCalledWith('"claude" --version', { stdio: "ignore" });
     expect(supportedModels).toHaveBeenCalledOnce();
     expect(next).not.toHaveBeenCalled();
     expect(close).toHaveBeenCalledOnce();

--- a/packages/runtime/tests/model-gateway/local-model-gateway-store.bun.ts
+++ b/packages/runtime/tests/model-gateway/local-model-gateway-store.bun.ts
@@ -97,15 +97,47 @@ modelGateway:
       - { id: model, displayName: Model, contextTokens: 1000, outputTokens: 100, providerId: codex-oauth, providerModelId: model, accountIds: [account], capabilities: [text], affinity: { continuity: none } }
 `, "utf8");
     process.env.REPLAY_SECRET = secret; process.env.BEARER_TOKEN = "synthetic-bearer-token-at-least-32-bytes";
-    let watcherStopped = false; let dedupClosed = false;
+    const missingGuiDist = join(root, "missing-gui-dist");
+    let watcherStartCalls = 0; let modelListenerCallsBeforeGuiValidation = 0; let intervalCreationCalls = 0; let watcherStopsBeforeGuiValidation = 0; let dedupClosesBeforeGuiValidation = 0;
+    const originalWatcherStart = CredentialWatcher.prototype.start; const originalWatcherStopBeforeGuiValidation = CredentialWatcher.prototype.stop; const originalDedupCloseBeforeGuiValidation = WebhookDedup.prototype.close;
+    const originalSetInterval = globalThis.setInterval;
+    CredentialWatcher.prototype.start = async function () { watcherStartCalls += 1; };
+    CredentialWatcher.prototype.stop = function () { watcherStopsBeforeGuiValidation += 1; return originalWatcherStopBeforeGuiValidation.call(this); };
+    WebhookDedup.prototype.close = function () { dedupClosesBeforeGuiValidation += 1; return originalDedupCloseBeforeGuiValidation.call(this); };
+    globalThis.setInterval = (() => { intervalCreationCalls += 1; return 0 as unknown as ReturnType<typeof setInterval>; }) as typeof setInterval;
+    let guiValidationError: unknown;
+    try {
+      await startGateway(startupConfig, { guiDistPath: missingGuiDist, modelGatewayListener: () => { modelListenerCallsBeforeGuiValidation += 1; throw new Error("Model listener must not run before GUI validation."); } });
+    } catch (error) {
+      guiValidationError = error;
+    } finally {
+      CredentialWatcher.prototype.start = originalWatcherStart;
+      CredentialWatcher.prototype.stop = originalWatcherStopBeforeGuiValidation;
+      WebhookDedup.prototype.close = originalDedupCloseBeforeGuiValidation;
+      globalThis.setInterval = originalSetInterval;
+    }
+    const expectedGuiValidationError = `GUI bundle missing at ${join(missingGuiDist, "index.html")}. Install @kilnai/gui or provide a built GUI dist path.`;
+    if (!(guiValidationError instanceof Error) || guiValidationError.message !== expectedGuiValidationError) throw new Error(`Expected missing GUI bundle error "${expectedGuiValidationError}", observed "${guiValidationError instanceof Error ? guiValidationError.message : String(guiValidationError)}".`);
+    if (watcherStartCalls !== 0) throw new Error(`CredentialWatcher started ${watcherStartCalls} time(s) before GUI validation; observed error "${guiValidationError.message}".`);
+    if (modelListenerCallsBeforeGuiValidation !== 0) throw new Error(`Model Gateway listener ran ${modelListenerCallsBeforeGuiValidation} time(s) before GUI validation; observed error "${guiValidationError.message}".`);
+    if (intervalCreationCalls !== 0) throw new Error(`Startup created ${intervalCreationCalls} timer(s) before GUI validation; observed error "${guiValidationError.message}".`);
+    if (watcherStopsBeforeGuiValidation !== 0 || dedupClosesBeforeGuiValidation !== 0) throw new Error(`Missing GUI validation required rollback (watcher stops: ${watcherStopsBeforeGuiValidation}, deduplicator closes: ${dedupClosesBeforeGuiValidation}); observed error "${guiValidationError.message}".`);
+
+    const guiDist = join(root, "gui-dist");
+    await mkdir(guiDist);
+    await writeFile(join(guiDist, "index.html"), "<!doctype html><title>Kiln</title>", "utf8");
+    let modelListenerCalls = 0; let lateFailureObserved = false; let watcherStopCalls = 0; let dedupCloseCalls = 0; let lateFailureError: unknown;
     const originalWatcherStop = CredentialWatcher.prototype.stop; const originalDedupClose = WebhookDedup.prototype.close;
-    CredentialWatcher.prototype.stop = function () { watcherStopped = true; return originalWatcherStop.call(this); };
-    WebhookDedup.prototype.close = function () { dedupClosed = true; return originalDedupClose.call(this); };
-    let lateFailureObserved = false;
-    try { await startGateway(startupConfig, { modelGatewayListener: () => { throw new Error("synthetic model bind failure"); } }); }
-    catch (error) { lateFailureObserved = error instanceof Error && error.message.includes("synthetic model bind failure"); }
+    CredentialWatcher.prototype.stop = function () { watcherStopCalls += 1; return originalWatcherStop.call(this); };
+    WebhookDedup.prototype.close = function () { dedupCloseCalls += 1; return originalDedupClose.call(this); };
+    try { await startGateway(startupConfig, { guiDistPath: guiDist, modelGatewayListener: () => { modelListenerCalls += 1; throw new Error("synthetic model bind failure"); } }); }
+    catch (error) { lateFailureError = error; lateFailureObserved = error instanceof Error && error.message.includes("synthetic model bind failure"); }
     finally { CredentialWatcher.prototype.stop = originalWatcherStop; WebhookDedup.prototype.close = originalDedupClose; }
-    if (!lateFailureObserved || !watcherStopped || !dedupClosed) throw new Error("Late model-listener startup failure did not close all initialized resources.");
+    const observedLateFailure = lateFailureError instanceof Error ? lateFailureError.message : String(lateFailureError);
+    if (modelListenerCalls !== 1) throw new Error(`Expected Model Gateway listener to run once, observed ${modelListenerCalls} call(s); observed error "${observedLateFailure}".`);
+    if (!lateFailureObserved) throw new Error(`Expected synthetic model bind failure, observed error "${observedLateFailure}".`);
+    if (watcherStopCalls !== 1) throw new Error(`Expected CredentialWatcher.stop once after late startup failure, observed ${watcherStopCalls} call(s); observed error "${observedLateFailure}".`);
+    if (dedupCloseCalls !== 1) throw new Error(`Expected WebhookDedup.close once after late startup failure, observed ${dedupCloseCalls} call(s); observed error "${observedLateFailure}".`);
     console.log("real Bun SQLite durability, fencing, recovery, permissions, and startup cleanup checks passed");
   } finally { await rm(root, { recursive: true, force: true }); }
 }

--- a/vitest-bun-sqlite-mock.ts
+++ b/vitest-bun-sqlite-mock.ts
@@ -4,9 +4,18 @@
  * File-path databases share a single in-memory better-sqlite3 instance keyed by
  * path, avoiding OS file locks that cause EBUSY on Windows during test cleanup.
  */
+import { closeSync, constants, mkdirSync, openSync } from "node:fs";
+import { dirname } from "node:path";
 import BetterSqlite3 from "better-sqlite3";
 
 const shared = new Map<string, { db: BetterSqlite3.Database; refs: number }>();
+
+function materializeFilePath(path: string): void {
+  const parent = dirname(path);
+  if (parent !== ".") mkdirSync(parent, { recursive: true });
+  const descriptor = openSync(path, constants.O_CREAT | constants.O_WRONLY, 0o600);
+  closeSync(descriptor);
+}
 
 export class Database {
   private db: BetterSqlite3.Database;
@@ -19,6 +28,7 @@ export class Database {
       this.db = new BetterSqlite3(":memory:");
       return;
     }
+    materializeFilePath(path);
     // For non-":memory:" paths, use shared instances with ref-counting
     // to avoid EBUSY on Windows during test cleanup.
     // ":memory:" always gets a fresh instance since there's no

--- a/vitest-bun-sqlite-mock.ts
+++ b/vitest-bun-sqlite-mock.ts
@@ -4,15 +4,12 @@
  * File-path databases share a single in-memory better-sqlite3 instance keyed by
  * path, avoiding OS file locks that cause EBUSY on Windows during test cleanup.
  */
-import { closeSync, constants, mkdirSync, openSync } from "node:fs";
-import { dirname } from "node:path";
+import { closeSync, constants, openSync } from "node:fs";
 import BetterSqlite3 from "better-sqlite3";
 
 const shared = new Map<string, { db: BetterSqlite3.Database; refs: number }>();
 
 function materializeFilePath(path: string): void {
-  const parent = dirname(path);
-  if (parent !== ".") mkdirSync(parent, { recursive: true });
   const descriptor = openSync(path, constants.O_CREAT | constants.O_WRONLY, 0o600);
   closeSync(descriptor);
 }


### PR DESCRIPTION
## Summary

- Make the Claude CLI model-discovery fixture independent of whether Claude is installed on the test host.
- Materialize physical placeholder files for file-backed SQLite test-double paths while retaining in-memory SQL state.
- Use Windows path semantics for the Windows autostart task XML path.
- Validate GUI assets before gateway resource allocation and make the real-Bun startup cleanup test hermetic.

## Motivation

PR #10 enabled CI for pull requests targeting `codex/cross-harness-gateway` and exposed deterministic pre-existing portability failures in `@kilnai/runtime`.

This slice corrects those failures without weakening the production contracts for:

- Claude CLI availability checks;
- SQLite `0600` permissions and fail-closed behavior;
- Windows Task Scheduler path semantics;
- gateway startup rollback.

## Scope

Exactly five files are changed:

- `packages/runtime/tests/gateway/claude-cli-model-discovery.test.ts`
- `vitest-bun-sqlite-mock.ts`
- `packages/runtime/src/model-gateway/model-gateway-autostart.ts`
- `packages/runtime/src/gateway/gateway-server.ts`
- `packages/runtime/tests/model-gateway/local-model-gateway-store.bun.ts`

No workflow, roadmap, manifest, lockfile, dependency, publishing or release files are changed.

## Commits

1. `test(runtime): make Claude discovery fixture platform-independent`
2. `test(sqlite): materialize file-backed mock paths`
3. `fix(runtime): use Windows path semantics for autostart`
4. `fix(runtime): validate GUI assets before gateway resources`

## Validation

- Claude focused test passed.
- Runtime SQLite/listener/ingress focused tests passed.
- Core SQLite consumers passed.
- Real Bun SQLite durability, permissions and startup cleanup test passed repeatedly.
- Runtime Vitest passed: 219 files and 2,953 tests.
- `@kilnai/runtime` test passed.
- Runtime typecheck passed.
- Repository typecheck passed.
- `git diff --check` passed.
- Base-to-head diff check passed.

## Independent review

Reviewed head:

`23553fa1fa06bc8e82a859f256eb9c26bc5c7387`

Result:

- No actionable regressions found.
- `findings: []`
- `overall_correctness: patch is correct`
- confidence: `0.91`

### Non-blocking residual observation

The late-listener regression verifies the propagated error through its message rather than strict object identity. The production implementation currently rethrows the same error object, so this is a low-severity coverage-strength observation rather than a demonstrated product defect.

## Promotion requirements

- The complete GitHub Actions workflow must pass on the reviewed head.
- Any head change invalidates the existing independent review.
- Merge requires a separate explicit Gate 2 authorization.
- Branch and worktree cleanup require separate authorization.