### PR TITLE
docs(roadmap): define governed web-to-PR workflow

### DIFF
--- a/docs/roadmap/04-cross-harness-integration.md
+++ b/docs/roadmap/04-cross-harness-integration.md
@@ -6,34 +6,47 @@ Created: 2026-07-23
 
 ## Objective
 
-Make Codex App/CLI, OpenCode, Claude Code, Kiln GUI/TUI/CLI interchangeable
-operator entrypoints into the same governed Kiln tools, agents, status, and
-replay. An operator should be able to develop Kiln using Kiln from any
-supported harness, without hand-written routing doctrine in `AGENTS.md` or
-`CLAUDE.md` and without falling back to `codex exec` / `opencode run` shell
-workarounds for a governed route.
+Make Codex App/CLI, OpenCode, Claude Code, Kiln GUI/TUI/CLI, and connected
+operator surfaces interchangeable entrypoints into the same governed Kiln tools,
+agents, status, and replay. An operator should be able to originate intent from a
+web or connector-enabled surface, delegate bounded repository work to an
+admitted local harness, and carry the same governed work through branch,
+worktree, commit, pull request, CI, review, approval, merge, and closeout without
+manual context reconstruction or a harness-local source of truth.
+
+The operator should be able to develop Kiln using Kiln from any supported
+harness, without hand-written routing doctrine in `AGENTS.md` or `CLAUDE.md` and
+without falling back to `codex exec` / `opencode run` shell workarounds for a
+governed route.
 
 ## Ownership
 
 This track owns harness identity, adapters, native projection, protocol parity,
-control-plane MCP discovery, migration/restore, and live conformance. Runtime
-job state belongs to Roadmap 02; gateway service lifecycle, provider identity,
-and entitlement evidence belong to Roadmap 03. This track maps harness-native
-observations onto that shared contract; it does not create a second identity,
-account-selection, or lifecycle owner.
+control-plane MCP discovery, migration/restore, live conformance, and the
+cross-harness delivery proof that binds an originating operator surface to local
+repository execution and durable pull-request evidence. Runtime job state
+belongs to Roadmap 02; gateway service lifecycle, provider identity, and
+entitlement evidence belong to Roadmap 03. This track maps harness-native and
+connector-native observations onto those shared contracts; it does not create a
+second identity, account-selection, lifecycle, approval, or repository owner.
 
 ## Scope
 
 - Harness-neutral `kiln-control-plane` MCP bridge, migrated off the legacy
   `kiln` identity and live-called from Codex CLI, OpenCode, and Claude Code.
+- Governed web/connector-to-local delivery flow: operator intent may originate
+  from a connected web surface, while admitted local harnesses perform
+  filesystem, process, test, and Git work in bounded branches and worktrees.
+- Durable repository handoff through commits, pull requests, CI checks, review
+  evidence, human authorization gates, merge, and residual-risk closeout.
 - Additive OpenCode provider projection and live proof of the additive vertical.
 - Claude Code entitlement adapter and strict live proof (Ready; reprioritized
   2026-07-24 ahead of the Codex picker now that a real configured Claude
   subscription exists).
 - Codex native-plus-Kiln composite picker, gated behind Responses protocol
   parity, native catalog-template inspection, and Claude entitlement proof.
-- Unified setup/status projection over shared lifecycle, auth, and route
-  eligibility contracts.
+- Unified setup/status projection over shared lifecycle, auth, route
+  eligibility, repository-delivery, and proof-age contracts.
 - Deferred thin/dynamic federation research after measured need.
 
 ## Non-Goals
@@ -42,7 +55,13 @@ account-selection, or lifecycle owner.
 - No native config import without provenance and approval.
 - No lowest-common-denominator compatibility plane.
 - No hidden `codex exec`, `opencode run`, or manual gateway process workaround.
-- No adapter-local route, permission, job, or replay owner.
+- No adapter-local route, permission, job, replay, approval, branch, or pull
+  request owner.
+- No requirement for a web surface to access the operator filesystem directly;
+  local execution remains local and durable handoff occurs through governed
+  evidence and repository objects.
+- No treating a connector action, chat transcript, branch, commit, PR, or CI
+  check alone as proof that the governed lifecycle completed.
 - No compatibility shims for obsolete harness configs or Codex-named source
   files once every consumer uses the harness-neutral contract.
 - No promoting a harness or provider choice from anecdote instead of measured,
@@ -58,7 +77,7 @@ documentation, not assumption:
   `developers.openai.com/codex/pricing`).
 - Anthropic documents Claude Code Pro/Max subscription access as distinct from
   separately billed Console/API usage (`support.anthropic.com/en/articles/11145838`,
-  `support.anthropic.com/en/articles/9876003`). This is why Slice 4 models
+  `support.anthropic.com/en/articles/9876003`). This is why Slice 3 models
   Claude as a native-harness entitlement adapter, never as a direct Anthropic
   provider.
 - OpenCode documents Go/Zen provider routes with distinct subscription/credit
@@ -96,21 +115,53 @@ fallback while the gateway is stopped, restart/autostart, drift repair, update,
 and exact uninstall restore that leaves native providers/defaults/allowlists
 untouched.
 
-### Slice 2 - Cross-Harness Dogfood
+### Slice 2 - Governed Web-To-PR Dogfood
 
 Status: Queued behind Roadmaps 02 and 03 plus Slices 0-1.
 
-Re-sync and live-prove the harness-neutral bridge from all three harnesses,
-then run a real bounded implementation slice through the completed per-job
-managed-lease path (Roadmap 02 Slice 1) rather than the legacy static adapter
-path. Preserve status, cancellation, timeout, result, usage, account
-selection, and replay from every participating surface, and verify that no
-step falls back to `opencode run`, `codex exec`, or a manual HTTP gateway
-process as a hidden workaround.
+Run one real, bounded repository implementation from end to end through the
+completed governed path. The initiating operator surface may be ChatGPT web or
+another connected surface with repository connectors, but it must materialize a
+canonical Kiln goal and bounded work items rather than relying on chat prose as
+the workflow record. Kiln must select an admitted local harness for repository
+execution, use a managed branch and worktree, and preserve intent, authority,
+route selection, status, cancellation, timeout, result, usage, account
+selection, evidence, residual risk, and replay.
 
-Exit gate: the operator can work primarily from Codex App without burning
-Codex quota for every delegated task, and no workflow step uses a native-CLI
-shell workaround for a Kiln-managed route.
+The local harness must perform the filesystem, process, test, and Git work. The
+web or connector-enabled surface may inspect and update repository objects only
+within explicit authority. Commits, pull requests, CI checks, review findings,
+and approvals are durable evidence and handoff boundaries, but they do not
+replace the canonical goal, work item, execution attempt, or closeout state.
+
+The proof must cover this complete lifecycle:
+
+1. originate and clarify operator intent from the initiating surface;
+2. materialize a bounded governed plan and work items;
+3. select an admitted local harness and route without hidden native-CLI shell
+   delegation;
+4. create or use an isolated managed worktree and feature branch;
+5. implement and verify the bounded change locally;
+6. produce intentional commits and a pull request against the declared
+   integration target;
+7. bind CI results and independent review findings to the same work evidence;
+8. require explicit human authorization for remote publication, readiness,
+   merge, destructive restore, and cleanup gates;
+9. merge the exact reviewed candidate; and
+10. record residual risk, delivery evidence, and closeout without manual context
+    reconstruction between surfaces.
+
+Acceptance requires at least one successful feature delivered through the full
+flow and a second proof that changes the participating local harness without
+changing canonical work ownership or repository policy. No step may fall back
+to `opencode run`, `codex exec`, a manual HTTP gateway process, copied prompt
+state, or an adapter-local lifecycle as a hidden workaround.
+
+Exit gate: an operator can coordinate from a connected web surface, delegate
+bounded repository work to admitted local CLIs, and complete PR, CI, review,
+approval, merge, and closeout with one replayable Kiln work identity. Replacing
+one supported harness with another does not change the governed workflow,
+authority model, or durable repository evidence.
 
 ### Slice 3 - Claude Entitlement Adapter
 
@@ -155,13 +206,15 @@ recovery, and exact uninstall.
 Status: Queued.
 
 Project gateway lifecycle, auth bootstrap, native projection, MCP bridge,
-route eligibility, and proof age through one shared status contract. Add
-repair only for state Kiln owns; drift-sensitive or review-only actions stay
-blocked until the operator explicitly reviews them.
+route eligibility, delivery-flow stage, repository evidence, and proof age
+through one shared status contract. Add repair only for state Kiln owns;
+drift-sensitive or review-only actions stay blocked until the operator
+explicitly reviews them.
 
 Exit gate: `kiln status` can explain why a given harness cannot see Kiln tools
-or agents, and setup recommendations carry target-specific snapshots instead
-of bare action strings.
+or agents, where a governed web-to-PR delivery is blocked, which repository or
+human gate is pending, and why. Setup and repair recommendations carry
+target-specific snapshots instead of bare action strings.
 
 ### Slice 6 - Federation Research
 
@@ -180,14 +233,18 @@ assumptions, and unsupported-proof gaps.
 
 ## Dependencies
 
-- Roadmap 02 owns per-job account leases, selection reason, and replay
-  evidence; Slice 2 consumes that completed path and must not reimplement
-  leasing or reintroduce ambient round-robin.
-- Roadmap 03 owns the Model Gateway process, configuration, and token
-  bootstrap; Slices 1, 3, and 5 depend on a live, operator-configured gateway
-  and must not duplicate its lifecycle or provider-identity contract.
+- Roadmap 02 owns per-job account leases, selection reason, execution lifecycle,
+  result, and replay evidence; Slice 2 consumes that completed path and must not
+  reimplement leasing or reintroduce ambient round-robin.
+- Roadmap 03 owns the Model Gateway process, configuration, and token bootstrap;
+  Slices 1, 3, and 5 depend on a live, operator-configured gateway and must not
+  duplicate its lifecycle or provider-identity contract.
 - Roadmap 03 also owns provider identity/access/entitlement projection; this
   track only maps harness-native observations onto it.
+- Work Governance owns canonical intent, goal, work-item, attempt, evidence,
+  approval, and closeout semantics. Connectors, harnesses, Git branches, commits,
+  pull requests, and CI systems project or contribute evidence to that lifecycle;
+  they never replace it.
 - Provider model discovery remains the runtime-owned availability and
   eligibility plane; this track's adapters project that evidence and never
   weaken fail-closed admission.
@@ -197,6 +254,16 @@ assumptions, and unsupported-proof gaps.
 - Direct-provider and native-entitlement boundaries remain explicit.
 - Every projection preserves unmanaged fields and exact restore.
 - All adapters consume shared authority and lifecycle contracts.
+- Web and connector surfaces do not require direct access to the local
+  filesystem and cannot silently acquire local execution authority.
+- Local harnesses cannot publish, mark ready, merge, delete branches/worktrees,
+  or perform destructive restore without the explicit authority required by the
+  owning gate.
+- Repository objects and CI results are bound to canonical work and evidence;
+  chat prose or a successful connector call alone is insufficient closeout.
+- The full web/connector-to-local-PR acceptance flow is proven with one exact
+  reviewed and merged candidate, then repeated with a different admitted local
+  harness without changing canonical policy.
 - OpenCode closes before Codex picker takeover.
 - Claude entitlement proof (Slice 3) is admitted ahead of the Codex composite
   picker (Slice 4) per the 2026-07-24 reprioritization; it still requires the
@@ -210,13 +277,24 @@ assumptions, and unsupported-proof gaps.
 ## Verification
 
 Protocol fixtures, isolated-home projection tests, live opt-in harness tests,
-workspace typecheck/build, affected suites, `git diff --check`, restore
-proofs, and adversarial authority review.
+one bounded web/connector-to-local-PR delivery, a second cross-harness replay of
+the same governance contract, workspace typecheck/build, affected suites,
+`git diff --check`, CI evidence, independent review, authorization-gate proof,
+merge evidence, restore proofs, and adversarial authority review.
 
 ## Completion Criteria
 
-Supported harnesses discover and invoke the same governed Kiln capabilities
-with consistent status and replay, direct providers are preferred where
-official and governed, native harnesses are used only where product
-entitlement or terms require them, and unsupported or unproven paths fail
+Supported web, connector, native harness, GUI, TUI, and CLI surfaces participate
+in one governed delivery lifecycle with consistent intent, authority, status,
+repository evidence, review, approval, and replay. Supported harnesses discover
+and invoke the same governed Kiln capabilities; direct providers are preferred
+where official and governed; native harnesses are used only where product
+entitlement or terms require them; and unsupported or unproven paths fail
 closed.
+
+The track is not complete until an operator can originate a bounded feature from
+a connected surface, delegate local repository execution, deliver the exact
+reviewed candidate through PR and CI, merge under explicit authority, and close
+the work with replayable evidence without manual context reconstruction. The
+same proof must remain valid when one admitted local harness is replaced by
+another.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -18,6 +18,23 @@ are promoted. File numbers do not need to be renumbered solely to fill a removed
 slot; ordering is defined by this queue and changed only through an explicit
 roadmap reorganization.
 
+## Product Delivery Outcome
+
+Kiln's cross-harness product objective is a governed delivery flow from operator
+intent to durable repository closeout. An operator may originate and coordinate
+work from a web or connector-enabled surface, while admitted local harnesses
+perform bounded filesystem, process, test, and Git execution. The shared Kiln
+control plane must preserve one canonical goal, work-item, authority, execution,
+evidence, approval, and replay identity across branch, worktree, commit, pull
+request, CI, review, merge, and cleanup boundaries.
+
+This outcome is owned by [04 - Cross-Harness Integration](./04-cross-harness-integration.md),
+which must prove the complete web/connector-to-local-PR lifecycle and repeat the
+proof with another admitted local harness. Work Governance remains the canonical
+lifecycle contract; connectors, native harnesses, and repository systems are
+adapters or durable evidence surfaces, never independent policy or lifecycle
+owners.
+
 ## Execution Queue
 
 | Order | Track | State | Next bounded work |
@@ -25,7 +42,7 @@ roadmap reorganization.
 | 1 | [01 - External Runtime Governance](./01-external-runtime-governance.md) | Ready | Encode the deterministic MCP-only failing trace before policy changes. |
 | 2 | [02 - Managed Invocation Routing](./02-managed-invocation-routing.md) | Ready | Complete per-job account leases and lifecycle evidence. |
 | 3 | [03 - Model Gateway Lifecycle](./03-model-gateway-lifecycle.md) | Blocked | Fix deterministic teardown, then apply and live-prove the reviewed user-scoped gateway configuration on an operator machine. |
-| 4 | [04 - Cross-Harness Integration](./04-cross-harness-integration.md) | Blocked | Close OpenCode live parity, then migrate and prove the harness-neutral control-plane bridge. |
+| 4 | [04 - Cross-Harness Integration](./04-cross-harness-integration.md) | Blocked | Close shared gateway and lease blockers, complete live adapter parity, then prove the governed web/connector-to-local-PR delivery flow. |
 | 5 | [05 - Skill Capability Plane](./05-skill-capability-plane.md) | Research | Define the provider-neutral skill evidence and admission contract. |
 | 6 | [06 - Prompt Governance Plane](./06-prompt-governance-plane.md) | Queued | Persist one content-free effective-prompt observation after higher-priority Ready work. |
 | 7 | [07 - Stack Governance Plane](./07-stack-governance-plane.md) | Research | Define read-only fixtures and the typed stack-policy contract. |
@@ -38,7 +55,7 @@ roadmap reorganization.
 - `01` owns provider-neutral external-runtime evidence realization and closeout consistency.
 - `02` owns managed-job routing, leases, account selection, lifecycle, result, and replay.
 - `03` owns the user-scoped Model Gateway process, configuration, authentication, and supervision.
-- `04` owns harness adapters, native projection, protocol parity, live cross-harness proof, and deferred federation research.
+- `04` owns harness adapters, native projection, protocol parity, live cross-harness proof, the governed web/connector-to-local-PR acceptance flow, and deferred federation research.
 - `05` decides whether a skill is healthy, compatible, trusted, and admitted.
 - `06` decides how admitted instructions and skill content enter provider prompts and become replayable evidence.
 - `07` owns desired stack policy and drift evidence; skills may consume its result but never own versions.
@@ -60,7 +77,10 @@ Every implementation track distinguishes:
 4. **Release ready** — exact committed candidate passes the release runbook and registry checks.
 
 A track must not describe live validation as incomplete code or describe passing
-source tests as release evidence.
+source tests as release evidence. For cross-harness repository delivery, neither
+a successful local edit nor a green pull request alone proves completion: the
+exact reviewed candidate, explicit authority gates, merge, replayable evidence,
+and closeout must all bind to the same governed work identity.
 
 ## Roadmap File Standard
 
@@ -77,7 +97,8 @@ that already belongs in architecture or release history.
 - Record dependencies as `Blocked`; do not hide them in prose.
 - No dead code, duplicate owners, prompt-only fixes, hidden fallbacks, or unsupported compatibility shims.
 - Live tests require explicit authority for credentials, quota, subscription, machine configuration, and destructive restore operations.
-- Update this index and the owning track atomically when state or priority changes.
+- Remote publication, readiness, merge, destructive restore, and cleanup remain separately authorized gates when the owning workflow requires them.
+- Update this index and the owning track atomically when state, priority, or the declared product delivery outcome changes.
 
 ## Release Position
 


### PR DESCRIPTION
## Summary

Documents the explicit product objective for Kiln's governed web/connector-to-local repository delivery workflow.

## What changed

- Adds a top-level roadmap product-delivery outcome covering operator intent through local harness execution, branch/worktree, commit, PR, CI, review, approval, merge, and closeout.
- Expands Roadmap 04 ownership and scope to include connector-originated intent and durable repository handoff.
- Replaces the generic cross-harness dogfood slice with a bounded, testable Governed Web-To-PR Dogfood slice.
- Defines the full lifecycle, authority boundaries, acceptance criteria, promotion gates, verification, and completion criteria.
- Requires a second proof using a different admitted local harness without changing canonical governance or repository policy.

## Boundaries

- Documentation only.
- No roadmap priority or state changes.
- No production, test, workflow, manifest, or dependency changes.
- Does not modify or depend on the runtime Ubuntu CI portability PR.

## Product outcome

A connected operator surface can originate and coordinate bounded work; admitted local harnesses execute repository operations; GitHub objects and CI provide durable evidence; and Kiln preserves one canonical work identity and explicit human authorization gates through merge and closeout.