### PR TITLE
test(cli): assert control-plane bridge path without platform separators

### DIFF
--- a/packages/cli/tests/config/native-mcp-projection.test.ts
+++ b/packages/cli/tests/config/native-mcp-projection.test.ts
@@ -281,7 +281,7 @@ describe("native MCP projection lifecycle", () => {
 
     await expect(syncNativeMcpProjections(emptyResolution(), root, {
       includeKilnControlPlane: true,
-    })).rejects.toThrow(".kiln\\kiln.yaml");
+    })).rejects.toThrow(join(".kiln", "kiln.yaml"));
 
     expect(existsSync(join(root, ".codex", "config.toml"))).toBe(false);
     expect(existsSync(join(root, ".mcp.json"))).toBe(false);


### PR DESCRIPTION
Removes a hardcoded Windows path separator that makes `native-mcp-projection.test.ts` fail on Linux CI.

## Problem

`"refuses to project the control-plane bridge outside an adopted Kiln project"` asserted the thrown error contained a literal backslash path:

```ts
})).rejects.toThrow(".kiln\kiln.yaml");
```

The production code builds that marker path with `join(kilnDir, "kiln.yaml")`, so the message uses the host separator. On Windows the assertion matches; on Linux the real message contains `/` and the test fails:

```
Expected: ".kiln\kiln.yaml"
Received: "Cannot project the Kiln control-plane bridge: '/tmp/kiln-native-mcp-control-plane-unadopted-CD1vy1/.kiln/kiln.yaml' does not exist."
```

Observed on CI run 30192911517. This is one of several independent blockers keeping CI red on the integration branch.

## Change

One line — build the expected fragment with the same mechanism the source uses:

```diff
-    })).rejects.toThrow(".kiln\kiln.yaml");
+    })).rejects.toThrow(join(".kiln", "kiln.yaml"));
```

`join` was already imported from `node:path` and already used elsewhere in the file for this same path.

## Verification

Passes on Windows (13/13 in the file; `@kilnai/cli` 1522/1523, remaining failures preexisting and unrelated). Workspace typecheck clean.

**Not** verified on a Linux runner — no runner available locally. Proven structurally instead, using Node's platform-specific implementations to build both message shapes and confirm each contains the fragment its platform's `join` produces:

```
posix CI-shaped message contains posix.join fragment: true
win32 local-shaped message contains win32.join fragment: true
```

## Scope

Test-only. No production source changed.

Other Windows-looking literals in the file were reviewed and deliberately left: `"C:\...\mcp.bat"` values are opaque input fixtures asserted back verbatim and never passed through `path.join`, and `sourcePath` provenance strings are never read back or asserted.