### PR TITLE
test(cli): isolate tools command suite from the cli root import

### DIFF
--- a/packages/cli/tests/cli-help.test.ts
+++ b/packages/cli/tests/cli-help.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { KilnAppConfig } from "../src/config.js";
+import { createCli } from "../src/index.js";
+
+const APP_CONFIG: KilnAppConfig = {
+  createRegistry: () => {
+    throw new Error("createRegistry should not be used in tools command tests");
+  },
+  kilnYaml: {
+    version: "1",
+  },
+};
+
+describe("CLI help", () => {
+  const originalArgv = process.argv;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.restoreAllMocks();
+  });
+
+  it("shows the tools command in CLI help output", async () => {
+    process.argv = ["bun", "kiln", "--help"];
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as never);
+
+    await expect(createCli(APP_CONFIG)).rejects.toThrow("process.exit:0");
+
+    const helpOutput = stdoutSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(helpOutput).toContain("import-native");
+    expect(helpOutput).toContain("uninstall");
+    expect(helpOutput).toContain("route");
+    expect(helpOutput).toContain("tools");
+    expect(helpOutput).not.toContain("  serve");
+    expect(helpOutput).toContain(
+      "Launch native dev tools MCP server over stdio and inspect shared resources (--mcp, --resources, --resource <uri>)",
+    );
+  });
+});

--- a/packages/cli/tests/tools-command.test.ts
+++ b/packages/cli/tests/tools-command.test.ts
@@ -100,7 +100,6 @@ vi.mock("@kilnai/core", async (importOriginal) => {
   };
 });
 
-import { createCli } from "../src/index.js";
 import { toolsCommand } from "../src/commands/tools.js";
 
 const APP_CONFIG: KilnAppConfig = {
@@ -276,23 +275,4 @@ describe("tools command", () => {
     }, null, 2));
   });
 
-  it("shows the tools command in CLI help output", async () => {
-    process.argv = ["bun", "kiln", "--help"];
-    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`process.exit:${code ?? 0}`);
-    }) as never);
-
-    await expect(createCli(APP_CONFIG)).rejects.toThrow("process.exit:0");
-
-    const helpOutput = stdoutSpy.mock.calls.map((call) => String(call[0])).join("\n");
-    expect(helpOutput).toContain("import-native");
-    expect(helpOutput).toContain("uninstall");
-    expect(helpOutput).toContain("route");
-    expect(helpOutput).toContain("tools");
-    expect(helpOutput).not.toContain("  serve");
-    expect(helpOutput).toContain(
-      "Launch native dev tools MCP server over stdio and inspect shared resources (--mcp, --resources, --resource <uri>)",
-    );
-  });
 });


### PR DESCRIPTION
Fixes a suite-level crash in `packages/cli/tests/tools-command.test.ts` that prevented any of its tests from running, on both Windows and Linux.

## Problem

The whole suite aborted at import time — zero tests executed:

```
TypeError: Cannot read properties of undefined (reading 'list')
 ❯ buildRuntimeSurface ../runtime/src/gateway/attached-runtime-tool-surface.ts:1244:88
 ❯ ../runtime/src/gateway/gui-gateway.ts:50:1
```

This is **not** an import cycle and **not** a gap in core. `createDefaultBuiltinToolSurface` correctly returns `registry: createRegistryView(registry)` (`packages/core/src/tools/default-tool-surface.ts:427`).

The malformed object was this suite's own mock. Inside its `vi.mock("@kilnai/core", ...)`, the mocked factory returned only `{ bridge, toolNames, tools, resources, resourceNotifications }` — no `registry`, no `toolDefinitions`, no `capabilities`.

That partial double only became fatal because the same file imported the CLI root:

```
tools-command.test.ts  → createCli from ../src/index.js
cli/src/index.ts:51    → re-exports global-opencode-model-gateway-projection.ts
                       → imports a value from @kilnai/runtime
runtime/src/index.ts   → re-exports gui-gateway.ts
gui-gateway.ts:50      → attached-runtime-tool-surface.ts
       :138            → module-level eager const calls the (mocked) factory
       :1244           → dereferences the missing registry
```

`createCli` was imported for exactly one assertion: that the tools command appears in CLI help. Sibling suites mock the same factory just as partially and pass, because they only import `commands/tools.ts` and never evaluate the runtime barrel.

## Change

Moved the CLI-help assertion into its own `cli-help.test.ts`, which imports `createCli` with no `@kilnai/core` mock. `tools-command.test.ts` is now scoped to `commands/tools.ts` and no longer imports the CLI root.

No production source changed. The mock shape was deliberately left as-is — patching only `registry` would just advance the crash to `capabilities`, and guarding the dereference would conceal a broken caller contract.

## Verification

Test count is preserved: 7 before → 6 in `tools-command.test.ts` + 1 in `cli-help.test.ts`. Both suites now actually run:

- `tools-command.test.ts`: 6/6 pass (previously 0 ran)
- `cli-help.test.ts`: 1/1 passes
- `@kilnai/cli`: 152 files pass, 1529/1530 tests. The single remaining failure is `benchmark.test.ts` (publication digest mismatch), preexisting and unrelated.
- workspace typecheck clean

## Related observation, not fixed here

`packages/cli/tsconfig.json` sets `"include": ["src/**/*.ts"]` and excludes `src/**/*.test.ts`, so **no CLI test is typechecked**. That is how a mock violating `DefaultBuiltinToolSurface` survived silently. Closing that gap would likely surface type errors across many test files and belongs in its own change.