### PR TITLE
feat(core): require stable non-empty tool call identity

### DIFF
--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -215,6 +215,9 @@ export {
   normalizeToolCall,
   normalizeToolInput,
   getInvalidToolInputDetails,
+  assertValidToolCallIds,
+  buildSyntheticToolCallId,
+  SYNTHETIC_TOOL_CALL_ID_PREFIX,
 } from "./tool-call-input.js";
 export type { InvalidToolInputDetails } from "./tool-call-input.js";
 export {

--- a/packages/core/src/agents/infrastructure/__tests__/codex-oauth.test.ts
+++ b/packages/core/src/agents/infrastructure/__tests__/codex-oauth.test.ts
@@ -3831,4 +3831,195 @@ describe("CodexOAuthAdapter", () => {
       );
     });
   });
+
+  describe("tool call identity", () => {
+    it("synthesizes an id from response.id + output index when call_id and id are both absent", async () => {
+      mockFetch.mockResolvedValueOnce(sseResponse([
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              id: "resp_no_native_id_1",
+              status: "completed",
+              output: [
+                {
+                  type: "function_call",
+                  name: "read",
+                  arguments: "{\"filePath\":\"a.txt\"}",
+                },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            },
+          },
+        },
+      ]));
+
+      const { adapter } = await createAdapter();
+      const response = await adapter.createMessage(createOptions());
+
+      expect(response.toolCalls).toHaveLength(1);
+      expect(response.toolCalls[0]?.id).toBe("synth1:resp_no_native_id_1:0");
+    });
+
+    it("re-normalizing the same response yields the identical synthesized id", async () => {
+      const sseFor = () => sseResponse([
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              id: "resp_replay_stable_1",
+              status: "completed",
+              output: [
+                {
+                  type: "function_call",
+                  name: "read",
+                  arguments: "{\"filePath\":\"a.txt\"}",
+                },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            },
+          },
+        },
+      ]);
+
+      mockFetch.mockResolvedValueOnce(sseFor());
+      const { adapter: firstAdapter } = await createAdapter();
+      const first = await firstAdapter.createMessage(createOptions());
+
+      mockFetch.mockResolvedValueOnce(sseFor());
+      const { adapter: secondAdapter } = await createAdapter();
+      const second = await secondAdapter.createMessage(createOptions());
+
+      expect(first.toolCalls[0]?.id).toBe(second.toolCalls[0]?.id);
+    });
+
+    it("assigns distinct synthesized ids to distinct function calls in one response", async () => {
+      mockFetch.mockResolvedValueOnce(sseResponse([
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              id: "resp_distinct_calls_1",
+              status: "completed",
+              output: [
+                { type: "function_call", name: "read", arguments: "{\"filePath\":\"a.txt\"}" },
+                { type: "function_call", name: "read", arguments: "{\"filePath\":\"b.txt\"}" },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            },
+          },
+        },
+      ]));
+
+      const { adapter } = await createAdapter();
+      const response = await adapter.createMessage(createOptions());
+
+      expect(response.toolCalls.map((call) => call.id)).toEqual([
+        "synth1:resp_distinct_calls_1:0",
+        "synth1:resp_distinct_calls_1:1",
+      ]);
+    });
+
+    it("rejects when call_id, id, and response.id are all absent -- nothing stable to synthesize from", async () => {
+      mockFetch.mockResolvedValueOnce(sseResponse([
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              status: "completed",
+              output: [
+                { type: "function_call", name: "read", arguments: "{\"filePath\":\"a.txt\"}" },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            },
+          },
+        },
+      ]));
+
+      const { adapter } = await createAdapter();
+
+      await expect(adapter.createMessage(createOptions())).rejects.toMatchObject({
+        code: "TOOL_CALL_IDENTITY_INVALID",
+      });
+    });
+
+    it("rejects two missing-id calls in one Codex stream instead of silently collapsing them", async () => {
+      mockFetch.mockResolvedValueOnce(sseResponse([
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              status: "completed",
+              output: [
+                { type: "function_call", name: "read", arguments: "{\"filePath\":\"a.txt\"}" },
+                { type: "function_call", name: "read", arguments: "{\"filePath\":\"b.txt\"}" },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            },
+          },
+        },
+      ]));
+
+      const { adapter } = await createAdapter();
+
+      await expect(adapter.createMessage(createOptions())).rejects.toMatchObject({
+        code: "TOOL_CALL_IDENTITY_INVALID",
+      });
+    });
+
+    it("streaming: two missing-id function calls do not collapse into a single tool_use event", async () => {
+      mockFetch.mockResolvedValueOnce(sseResponse([
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              status: "completed",
+              output: [
+                { type: "function_call", name: "read", arguments: "{\"filePath\":\"a.txt\"}" },
+                { type: "function_call", name: "read", arguments: "{\"filePath\":\"b.txt\"}" },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            },
+          },
+        },
+      ]));
+
+      const { adapter } = await createAdapter();
+
+      await expect(async () => {
+        for await (const _event of adapter.streamMessage(createOptions())) {
+          // consume
+        }
+      }).rejects.toMatchObject({ code: "TOOL_CALL_IDENTITY_INVALID" });
+    });
+
+    it("rejects a whitespace-only call_id rather than treating it as present", async () => {
+      mockFetch.mockResolvedValueOnce(sseResponse([
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              id: "resp_whitespace_id_1",
+              status: "completed",
+              output: [
+                {
+                  type: "function_call",
+                  call_id: "   ",
+                  name: "read",
+                  arguments: "{\"filePath\":\"a.txt\"}",
+                },
+              ],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            },
+          },
+        },
+      ]));
+
+      const { adapter } = await createAdapter();
+      const response = await adapter.createMessage(createOptions());
+
+      // Falls through to id/response.id + index synthesis rather than the blank call_id.
+      expect(response.toolCalls[0]?.id).toBe("synth1:resp_whitespace_id_1:0");
+    });
+  });
 });

--- a/packages/core/src/agents/infrastructure/anthropic.ts
+++ b/packages/core/src/agents/infrastructure/anthropic.ts
@@ -11,7 +11,7 @@ import { textPart, extractText } from "../../engine/domain/content.js";
 import { KilnError } from "../../engine/errors.js";
 import { withRetry } from "./retry.js";
 import type { RetryOptions } from "./retry.js";
-import { normalizeToolInput } from "../tool-call-input.js";
+import { assertValidToolCallIds, normalizeToolInput } from "../tool-call-input.js";
 
 export const CLAUDE_OPUS = "claude-opus-4-6";
 export const CLAUDE_SONNET = "claude-sonnet-4-6";
@@ -69,6 +69,7 @@ export class AnthropicAdapter implements ProviderAdapter {
     );
 
     const toolInputBuffers = new Map<number, { id: string; name: string; json: string }>();
+    const emittedToolCalls: ToolCall[] = [];
 
     for await (const event of stream as AsyncIterable<Anthropic.Messages.RawMessageStreamEvent>) {
       switch (event.type) {
@@ -102,14 +103,14 @@ export class AnthropicAdapter implements ProviderAdapter {
         case "content_block_stop": {
           const buffer = toolInputBuffers.get(event.index);
           if (buffer) {
-            yield {
-              type: "tool_use",
-              content: JSON.stringify({
-                id: buffer.id,
-                name: buffer.name,
-                input: normalizeToolInput(buffer.name, buffer.json || "{}"),
-              }),
+            const toolCall: ToolCall = {
+              id: buffer.id,
+              name: buffer.name,
+              input: normalizeToolInput(buffer.name, buffer.json || "{}"),
             };
+            emittedToolCalls.push(toolCall);
+            assertValidToolCallIds(emittedToolCalls, { adapter: this.name });
+            yield { type: "tool_use", content: JSON.stringify(toolCall) };
             toolInputBuffers.delete(event.index);
           }
           break;
@@ -308,6 +309,8 @@ export class AnthropicAdapter implements ProviderAdapter {
         });
       }
     }
+
+    assertValidToolCallIds(toolCalls, { adapter: this.name });
 
     // Only add fallback empty text if there are no tool calls and no text
     const parts = responseParts.length > 0

--- a/packages/core/src/agents/infrastructure/codex-oauth.ts
+++ b/packages/core/src/agents/infrastructure/codex-oauth.ts
@@ -10,7 +10,7 @@ import { textPart, extractText } from "../../engine/domain/content.js";
 import type { ContentPart } from "../../engine/domain/content.js";
 import { KilnError } from "../../engine/errors.js";
 import { CodexOAuthAuth } from "./codex-oauth-auth.js";
-import { normalizeToolInput } from "../tool-call-input.js";
+import { assertValidToolCallIds, buildSyntheticToolCallId, normalizeToolInput } from "../tool-call-input.js";
 import {
   collectCanonicalToolNames,
   createProviderToolNameCodec,
@@ -624,7 +624,7 @@ export class CodexOAuthAdapter implements ProviderAdapter {
     const outputItems = response.output ?? [];
     const functionCallItems = outputItems.filter((item) => item.type === "function_call");
 
-    for (const item of outputItems) {
+    for (const [outputIndex, item] of outputItems.entries()) {
       if (item.type === "message") {
         const text = (item.content ?? [])
           .filter((content) => content.type === "output_text" && typeof content.text === "string")
@@ -640,12 +640,14 @@ export class CodexOAuthAdapter implements ProviderAdapter {
       if (item.type === "function_call") {
         const canonicalName = toolNames.toCanonicalName(item.name ?? "");
         toolCalls.push({
-          id: item.call_id ?? item.id ?? "",
+          id: this.deriveCodexToolCallId(item, response.id, outputIndex),
           name: canonicalName,
           input: normalizeToolInput(canonicalName, item.arguments, toolSchemas.get(canonicalName)),
         });
       }
     }
+
+    assertValidToolCallIds(toolCalls, { adapter: this.name });
 
     return {
       parts,
@@ -661,6 +663,31 @@ export class CodexOAuthAdapter implements ProviderAdapter {
         outputPer1M: 0,
       },
     };
+  }
+
+  /**
+   * Derives a replay-stable tool call id from Codex's own coordinates, in priority order:
+   * `call_id`, then item `id`, then `response.id` + the item's position in `response.output`.
+   * Falls through to an empty string (rejected by `assertValidToolCallIds`) only when Codex
+   * supplies none of those coordinates -- there is nothing stable left to synthesize from.
+   */
+  private deriveCodexToolCallId(
+    item: ResponsesOutputItem,
+    responseId: string | undefined,
+    outputIndex: number,
+  ): string {
+    const callId = item.call_id?.trim();
+    if (callId) {
+      return callId;
+    }
+    const itemId = item.id?.trim();
+    if (itemId) {
+      return itemId;
+    }
+    if (responseId) {
+      return buildSyntheticToolCallId(responseId, String(outputIndex));
+    }
+    return "";
   }
 
   private async consumeStreamingResponse(response: Response, hasTools: boolean): Promise<ResponsesResponse> {

--- a/packages/core/src/agents/infrastructure/ollama.ts
+++ b/packages/core/src/agents/infrastructure/ollama.ts
@@ -80,7 +80,7 @@ export class OllamaAdapter implements ProviderAdapter {
       const requestHash = hashOllamaRequestBody(body);
       for (const [ordinal, tc] of data.message.tool_calls.entries()) {
         toolCalls.push({
-          id: buildSyntheticToolCallId(requestHash, String(ordinal)),
+          id: buildSyntheticToolCallId(requestHash, String(ordinal), hashOllamaToolCall(tc)),
           name: tc.function.name,
           input: tc.function.arguments,
         });
@@ -245,6 +245,19 @@ function unsupportedModality(modality: string, reason: string): KilnError {
  */
 function hashOllamaRequestBody(body: Record<string, unknown>): string {
   return createHash("sha256").update(stableStringify(body)).digest("hex");
+}
+
+/**
+ * Ollama's generation is nondeterministic: a fixed request can return a different tool call
+ * at the same ordinal on different attempts. The request hash + ordinal alone would collide
+ * two distinct generated calls onto the same synthetic id, so the derivation also folds in a
+ * hash of the tool call's own content (name + arguments). Re-normalizing the same *persisted*
+ * response still yields the same hash -- this only distinguishes genuinely different outputs.
+ */
+function hashOllamaToolCall(toolCall: OllamaToolCall): string {
+  return createHash("sha256")
+    .update(stableStringify({ name: toolCall.function.name, arguments: toolCall.function.arguments }))
+    .digest("hex");
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/core/src/agents/infrastructure/ollama.ts
+++ b/packages/core/src/agents/infrastructure/ollama.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   ProviderAdapter,
   CreateMessageOptions,
@@ -8,6 +9,7 @@ import type {
 import type { ContentPart } from "../../engine/domain/content.js";
 import { textPart, extractText } from "../../engine/domain/content.js";
 import { KilnError } from "../../engine/errors.js";
+import { assertValidToolCallIds, buildSyntheticToolCallId } from "../tool-call-input.js";
 
 export const LLAMA3 = "llama3.1";
 export const CODELLAMA = "codellama";
@@ -75,14 +77,16 @@ export class OllamaAdapter implements ProviderAdapter {
 
     const toolCalls: ToolCall[] = [];
     if (data.message.tool_calls) {
-      for (const tc of data.message.tool_calls) {
+      const requestHash = hashOllamaRequestBody(body);
+      for (const [ordinal, tc] of data.message.tool_calls.entries()) {
         toolCalls.push({
-          id: crypto.randomUUID(),
+          id: buildSyntheticToolCallId(requestHash, String(ordinal)),
           name: tc.function.name,
           input: tc.function.arguments,
         });
       }
     }
+    assertValidToolCallIds(toolCalls, { adapter: this.name });
 
     return {
       parts: [textPart(data.message.content)],
@@ -230,4 +234,28 @@ function unsupportedModality(modality: string, reason: string): KilnError {
     retryable: false,
     context: { provider: "ollama", modality },
   });
+}
+
+/**
+ * Ollama's wire protocol carries no tool call id at all, so identity must be synthesized.
+ * Hashes the exact request body sent to Ollama (deterministic key order, no timestamps or
+ * randomness) -- re-normalizing the same logical request yields the identical hash, and the
+ * caller combines it with the tool call's ordinal within the response to distinguish sibling
+ * calls in one turn.
+ */
+function hashOllamaRequestBody(body: Record<string, unknown>): string {
+  return createHash("sha256").update(stableStringify(body)).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+    return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
 }

--- a/packages/core/src/agents/infrastructure/openai-compat.ts
+++ b/packages/core/src/agents/infrastructure/openai-compat.ts
@@ -125,6 +125,19 @@ interface OpenAIStreamChunk {
   readonly choices: readonly OpenAIStreamChoice[];
 }
 
+/**
+ * Accumulator for one streamed tool call. `providerId`/`chunkId` track which sources have
+ * already contributed to `id` so a later, conflicting delta can be detected instead of
+ * silently discarded or silently overwriting a previously reconciled identity.
+ */
+interface StreamedToolCallBuffer {
+  id: string;
+  name: string;
+  arguments: string;
+  providerId?: string;
+  chunkId?: string;
+}
+
 export abstract class OpenAICompatAdapter implements ProviderAdapter {
   readonly name: string;
 
@@ -180,10 +193,7 @@ export abstract class OpenAICompatAdapter implements ProviderAdapter {
       return;
     }
 
-    const toolBuffers = new Map<
-      number,
-      { id: string; name: string; arguments: string }
-    >();
+    const toolBuffers = new Map<number, StreamedToolCallBuffer>();
 
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
@@ -225,9 +235,10 @@ export abstract class OpenAICompatAdapter implements ProviderAdapter {
             for (const tc of delta.tool_calls) {
               let buf = toolBuffers.get(tc.index);
               if (!buf) {
-                buf = { id: this.deriveStreamedToolCallId(tc.id, chunk.id, tc.index), name: tc.function?.name ?? "", arguments: "" };
+                buf = { id: "", name: tc.function?.name ?? "", arguments: "" };
                 toolBuffers.set(tc.index, buf);
               }
+              this.reconcileStreamedToolCallId(buf, tc.id, chunk.id, tc.index);
               if (tc.function?.arguments) {
                 buf.arguments += tc.function.arguments;
               }
@@ -245,24 +256,50 @@ export abstract class OpenAICompatAdapter implements ProviderAdapter {
   }
 
   /**
-   * Derives a replay-stable tool call id for a streamed OpenAI-compatible delta, in priority
-   * order: the provider's own `tc.id`, then the top-level chunk/response id + `tc.index`.
-   * Falls through to an empty string (rejected by `assertValidToolCallIds` at flush time) only
-   * when the provider supplies neither -- there is nothing stable left to synthesize from.
+   * Reconciles a streamed OpenAI-compatible delta into the buffered call's identity. A native
+   * `tc.id` always wins over a synthesized one -- this lets a buffer that started without an id
+   * (no `tc.id`, no chunk id on the first delta) adopt a native id supplied on a later delta,
+   * instead of failing at flush even though a stable id eventually arrived. Once a native id or
+   * a chunk id has been observed for this buffer, any later delta contradicting it (a different
+   * native id, or a different chunk id backing the synthesized id) is a malformed stream and
+   * fails closed rather than being silently absorbed or overwritten.
    */
-  private deriveStreamedToolCallId(
+  private reconcileStreamedToolCallId(
+    buf: StreamedToolCallBuffer,
     providerId: string | undefined,
     chunkId: string | undefined,
     index: number,
-  ): string {
+  ): void {
     const trimmedProviderId = providerId?.trim();
     if (trimmedProviderId) {
-      return trimmedProviderId;
+      if (buf.providerId !== undefined && buf.providerId !== trimmedProviderId) {
+        throw new KilnError(
+          "TOOL_CALL_IDENTITY_INVALID",
+          `${this.name} sent conflicting native tool call ids ("${buf.providerId}" and "${trimmedProviderId}") at stream index ${index}.`,
+          { context: { adapter: this.name, index, id: buf.providerId, conflictingId: trimmedProviderId } },
+        );
+      }
+      buf.providerId = trimmedProviderId;
+      buf.id = trimmedProviderId;
+      return;
     }
+
+    if (buf.providerId !== undefined) {
+      // A native id already anchors this buffer; deltas without one carry no new identity.
+      return;
+    }
+
     if (chunkId) {
-      return buildSyntheticToolCallId(chunkId, String(index));
+      if (buf.chunkId !== undefined && buf.chunkId !== chunkId) {
+        throw new KilnError(
+          "TOOL_CALL_IDENTITY_INVALID",
+          `${this.name} sent conflicting chunk ids ("${buf.chunkId}" and "${chunkId}") for the same buffered tool call at stream index ${index}.`,
+          { context: { adapter: this.name, index, id: buf.chunkId, conflictingId: chunkId } },
+        );
+      }
+      buf.chunkId = chunkId;
+      buf.id = buildSyntheticToolCallId(chunkId, String(index));
     }
-    return "";
   }
 
   /**
@@ -270,7 +307,7 @@ export abstract class OpenAICompatAdapter implements ProviderAdapter {
    * matching the adapter's buffering model) before yielding `tool_use` events for it.
    */
   private *flushStreamedToolCalls(
-    toolBuffers: ReadonlyMap<number, { id: string; name: string; arguments: string }>,
+    toolBuffers: ReadonlyMap<number, StreamedToolCallBuffer>,
     toolNames: ProviderToolNameCodec,
   ): Generator<AgentStreamEvent> {
     if (toolBuffers.size === 0) {

--- a/packages/core/src/agents/infrastructure/openai-compat.ts
+++ b/packages/core/src/agents/infrastructure/openai-compat.ts
@@ -10,7 +10,7 @@ import { textPart, extractText } from "../../engine/domain/content.js";
 import { KilnError } from "../../engine/errors.js";
 import { withRetry } from "./retry.js";
 import type { RetryOptions } from "./retry.js";
-import { normalizeToolInput } from "../tool-call-input.js";
+import { assertValidToolCallIds, buildSyntheticToolCallId, normalizeToolInput } from "../tool-call-input.js";
 import {
   collectCanonicalToolNames,
   createProviderToolNameCodec,
@@ -121,6 +121,7 @@ interface OpenAIStreamChoice {
 }
 
 interface OpenAIStreamChunk {
+  readonly id?: string;
   readonly choices: readonly OpenAIStreamChoice[];
 }
 
@@ -204,19 +205,7 @@ export abstract class OpenAICompatAdapter implements ProviderAdapter {
           const data = trimmed.slice(6);
           if (data === "[DONE]") {
             // Flush any remaining tool calls
-            for (const [, buf] of toolBuffers) {
-              yield {
-                type: "tool_use",
-                content: JSON.stringify({
-                  id: buf.id,
-                  name: request.toolNames.toCanonicalName(buf.name),
-                  input: normalizeToolInput(
-                    request.toolNames.toCanonicalName(buf.name),
-                    buf.arguments || "{}",
-                  ),
-                }),
-              };
-            }
+            yield* this.flushStreamedToolCalls(toolBuffers, request.toolNames);
             toolBuffers.clear();
             yield { type: "done", content: "" };
             return;
@@ -236,7 +225,7 @@ export abstract class OpenAICompatAdapter implements ProviderAdapter {
             for (const tc of delta.tool_calls) {
               let buf = toolBuffers.get(tc.index);
               if (!buf) {
-                buf = { id: tc.id ?? "", name: tc.function?.name ?? "", arguments: "" };
+                buf = { id: this.deriveStreamedToolCallId(tc.id, chunk.id, tc.index), name: tc.function?.name ?? "", arguments: "" };
                 toolBuffers.set(tc.index, buf);
               }
               if (tc.function?.arguments) {
@@ -251,20 +240,51 @@ export abstract class OpenAICompatAdapter implements ProviderAdapter {
     }
 
     // Flush remaining tool calls if stream ended without [DONE]
-    for (const [, buf] of toolBuffers) {
-      yield {
-        type: "tool_use",
-        content: JSON.stringify({
-          id: buf.id,
-          name: request.toolNames.toCanonicalName(buf.name),
-          input: normalizeToolInput(
-            request.toolNames.toCanonicalName(buf.name),
-            buf.arguments || "{}",
-          ),
-        }),
-      };
-    }
+    yield* this.flushStreamedToolCalls(toolBuffers, request.toolNames);
     yield { type: "done", content: "" };
+  }
+
+  /**
+   * Derives a replay-stable tool call id for a streamed OpenAI-compatible delta, in priority
+   * order: the provider's own `tc.id`, then the top-level chunk/response id + `tc.index`.
+   * Falls through to an empty string (rejected by `assertValidToolCallIds` at flush time) only
+   * when the provider supplies neither -- there is nothing stable left to synthesize from.
+   */
+  private deriveStreamedToolCallId(
+    providerId: string | undefined,
+    chunkId: string | undefined,
+    index: number,
+  ): string {
+    const trimmedProviderId = providerId?.trim();
+    if (trimmedProviderId) {
+      return trimmedProviderId;
+    }
+    if (chunkId) {
+      return buildSyntheticToolCallId(chunkId, String(index));
+    }
+    return "";
+  }
+
+  /**
+   * Validates every buffered tool call's identity as a single collection (once per flush,
+   * matching the adapter's buffering model) before yielding `tool_use` events for it.
+   */
+  private *flushStreamedToolCalls(
+    toolBuffers: ReadonlyMap<number, { id: string; name: string; arguments: string }>,
+    toolNames: ProviderToolNameCodec,
+  ): Generator<AgentStreamEvent> {
+    if (toolBuffers.size === 0) {
+      return;
+    }
+    const toolCalls: ToolCall[] = [...toolBuffers.values()].map((buf) => ({
+      id: buf.id,
+      name: toolNames.toCanonicalName(buf.name),
+      input: normalizeToolInput(toolNames.toCanonicalName(buf.name), buf.arguments || "{}"),
+    }));
+    assertValidToolCallIds(toolCalls, { adapter: this.name });
+    for (const toolCall of toolCalls) {
+      yield { type: "tool_use", content: JSON.stringify(toolCall) };
+    }
   }
 
   private mapPartsToOpenAI(parts: readonly ContentPart[]): OpenAIContent {
@@ -436,6 +456,7 @@ export abstract class OpenAICompatAdapter implements ProviderAdapter {
         ),
       }),
     );
+    assertValidToolCallIds(toolCalls, { adapter: this.name });
 
     return {
       parts: [textPart(content)],

--- a/packages/core/src/agents/tool-call-input.ts
+++ b/packages/core/src/agents/tool-call-input.ts
@@ -191,6 +191,15 @@ export function assertValidToolCallIds(
         },
       );
     }
+    if (trimmedId !== toolCall.id) {
+      throw new KilnError(
+        "TOOL_CALL_IDENTITY_INVALID",
+        `${context.adapter} produced an untrimmed tool call id at index ${index}.`,
+        {
+          context: { adapter: context.adapter, index, id: toolCall.id },
+        },
+      );
+    }
 
     const priorIndex = seenAtIndex.get(trimmedId);
     if (priorIndex !== undefined) {

--- a/packages/core/src/agents/tool-call-input.ts
+++ b/packages/core/src/agents/tool-call-input.ts
@@ -1,6 +1,18 @@
+import { KilnError } from "../engine/errors.js";
 import type { ToolCall } from "./index.js";
 
 const INVALID_TOOL_INPUT_MARKER = "__kilnInvalidToolInput";
+
+/**
+ * Prefix marking a tool call id as adapter-synthesized rather than provider-supplied.
+ * Versioned so future synthesis strategies can be distinguished from this one.
+ */
+export const SYNTHETIC_TOOL_CALL_ID_PREFIX = "synth1:";
+
+/** Builds a versioned synthetic tool call id from immutable, replay-stable coordinates. */
+export function buildSyntheticToolCallId(...coordinates: readonly string[]): string {
+  return `${SYNTHETIC_TOOL_CALL_ID_PREFIX}${coordinates.join(":")}`;
+}
 
 export interface InvalidToolInputDetails {
   readonly reason: string;
@@ -153,6 +165,45 @@ export function getInvalidToolInputDetails(
     reason,
     raw: marker.raw,
   };
+}
+
+/**
+ * Enforces the core tool-call identity invariant: every id in `toolCalls` is trimmed,
+ * non-empty, and unique within this collection (a single normalized response/stream flush).
+ *
+ * This is the single point where the invariant is enforced -- adapters own deriving a
+ * candidate id from stable provider coordinates; this function owns validating the result.
+ * Throws a KilnError (fail-closed) rather than silently repairing blank or duplicate ids.
+ */
+export function assertValidToolCallIds(
+  toolCalls: readonly ToolCall[],
+  context: { readonly adapter: string },
+): void {
+  const seenAtIndex = new Map<string, number>();
+  for (const [index, toolCall] of toolCalls.entries()) {
+    const trimmedId = toolCall.id.trim();
+    if (trimmedId.length === 0) {
+      throw new KilnError(
+        "TOOL_CALL_IDENTITY_INVALID",
+        `${context.adapter} produced a blank tool call id at index ${index}.`,
+        {
+          context: { adapter: context.adapter, index, id: toolCall.id },
+        },
+      );
+    }
+
+    const priorIndex = seenAtIndex.get(trimmedId);
+    if (priorIndex !== undefined) {
+      throw new KilnError(
+        "TOOL_CALL_IDENTITY_INVALID",
+        `${context.adapter} produced duplicate tool call id "${trimmedId}" at indexes ${priorIndex} and ${index}.`,
+        {
+          context: { adapter: context.adapter, index, priorIndex, id: trimmedId },
+        },
+      );
+    }
+    seenAtIndex.set(trimmedId, index);
+  }
 }
 
 export function normalizeToolCall(toolCall: ToolCall): ToolCall {

--- a/packages/core/src/engine/error-catalog.ts
+++ b/packages/core/src/engine/error-catalog.ts
@@ -531,6 +531,14 @@ export function getErrorSuggestion(
       return { suggestion, docUrl: docUrl(code) };
     }
 
+    case "TOOL_CALL_IDENTITY_INVALID": {
+      const adapter = context?.adapter;
+      let suggestion = "A provider adapter produced a blank or duplicate tool call id.";
+      if (adapter) suggestion += ` Adapter: "${adapter}".`;
+      suggestion += " This is a fail-closed invariant violation, not something to silently repair -- fix the adapter's id derivation.";
+      return { suggestion, docUrl: docUrl(code) };
+    }
+
     case "INTEGRATION_TOOL_FAILED": {
       const provider = context?.provider;
       const operation = context?.operation;

--- a/packages/core/src/engine/errors.ts
+++ b/packages/core/src/engine/errors.ts
@@ -96,6 +96,8 @@ export type KilnErrorCode =
   // Tool execution (Phase 5b)
   | "TOOL_RATE_LIMITED"
   | "WEBHOOK_TOOL_FAILED"
+  // Tool call identity (cross-harness gateway)
+  | "TOOL_CALL_IDENTITY_INVALID"
   // Integration tools
   | "INTEGRATION_TOOL_FAILED"
   | "INTEGRATION_ADAPTER_NOT_FOUND"

--- a/packages/core/tests/agents/infrastructure/anthropic.test.ts
+++ b/packages/core/tests/agents/infrastructure/anthropic.test.ts
@@ -327,6 +327,35 @@ describe("AnthropicAdapter", () => {
       });
     });
 
+    it("rejects duplicate tool_use ids within one response", async () => {
+      mockCreate.mockResolvedValueOnce(
+        makeMessageResponse({
+          content: [
+            { type: "tool_use", id: "toolu_dup", name: "search", input: { query: "a" } },
+            { type: "tool_use", id: "toolu_dup", name: "search", input: { query: "b" } },
+          ],
+        }),
+      );
+
+      await expect(adapter.createMessage(makeOptions())).rejects.toMatchObject({
+        code: "TOOL_CALL_IDENTITY_INVALID",
+      });
+    });
+
+    it("rejects a whitespace-only tool_use id", async () => {
+      mockCreate.mockResolvedValueOnce(
+        makeMessageResponse({
+          content: [
+            { type: "tool_use", id: "   ", name: "search", input: { query: "a" } },
+          ],
+        }),
+      );
+
+      await expect(adapter.createMessage(makeOptions())).rejects.toMatchObject({
+        code: "TOOL_CALL_IDENTITY_INVALID",
+      });
+    });
+
     it("handles null cache token counts", async () => {
       mockCreate.mockResolvedValueOnce(
         makeMessageResponse({
@@ -713,6 +742,43 @@ describe("AnthropicAdapter", () => {
 
       const params = mockCreate.mock.calls[0]![0];
       expect(params.stream).toBe(true);
+    });
+
+    it("rejects a streamed response that emits two tool_use blocks with the same id", async () => {
+      const streamEvents = [
+        { type: "message_start", message: makeMessageResponse() },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "toolu_dup_stream", name: "search", input: {} },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"query":"a"}' },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "tool_use", id: "toolu_dup_stream", name: "search", input: {} },
+        },
+        {
+          type: "content_block_delta",
+          index: 1,
+          delta: { type: "input_json_delta", partial_json: '{"query":"b"}' },
+        },
+        { type: "content_block_stop", index: 1 },
+        { type: "message_stop" },
+      ];
+
+      mockCreate.mockResolvedValueOnce(createAsyncIterable(streamEvents));
+
+      await expect(async () => {
+        for await (const _event of adapter.streamMessage(makeOptions())) {
+          // consume
+        }
+      }).rejects.toMatchObject({ code: "TOOL_CALL_IDENTITY_INVALID" });
     });
   });
 });

--- a/packages/core/tests/agents/infrastructure/ollama.test.ts
+++ b/packages/core/tests/agents/infrastructure/ollama.test.ts
@@ -317,6 +317,69 @@ describe("OllamaAdapter", () => {
     });
   });
 
+  describe("tool call identity", () => {
+    function toolCallResponse(names: string[]) {
+      return {
+        ok: true,
+        json: async () => ({
+          message: {
+            content: "",
+            tool_calls: names.map((name) => ({
+              function: { name, arguments: { query: "test" } },
+            })),
+          },
+          done: true,
+          prompt_eval_count: 20,
+          eval_count: 10,
+        }),
+      };
+    }
+
+    it("derives a deterministic id from the request body + tool-call ordinal", async () => {
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search"]));
+      const adapter = new OllamaAdapter();
+      const options = makeOptions({ tools: [makeToolDef()] });
+      const response = await adapter.createMessage(options);
+
+      expect(response.toolCalls).toHaveLength(1);
+      expect(response.toolCalls[0]!.id).toMatch(/^synth1:[0-9a-f]{64}:0$/);
+    });
+
+    it("produces the identical id across two independent normalizations of the same request", async () => {
+      const options = makeOptions({ tools: [makeToolDef()] });
+
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search"]));
+      const first = await new OllamaAdapter().createMessage(options);
+
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search"]));
+      const second = await new OllamaAdapter().createMessage(options);
+
+      expect(first.toolCalls[0]!.id).toBe(second.toolCalls[0]!.id);
+    });
+
+    it("produces distinct ids for distinct tool-call ordinals in the same response", async () => {
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search", "search"]));
+      const adapter = new OllamaAdapter();
+      const response = await adapter.createMessage(makeOptions({ tools: [makeToolDef()] }));
+
+      expect(response.toolCalls).toHaveLength(2);
+      expect(response.toolCalls[0]!.id).not.toBe(response.toolCalls[1]!.id);
+    });
+
+    it("produces a different id when the request body differs", async () => {
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search"]));
+      const first = await new OllamaAdapter().createMessage(makeOptions({ tools: [makeToolDef()] }));
+
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search"]));
+      const second = await new OllamaAdapter().createMessage(makeOptions({
+        messages: [{ role: "user", parts: textParts("A different prompt") }],
+        tools: [makeToolDef()],
+      }));
+
+      expect(first.toolCalls[0]!.id).not.toBe(second.toolCalls[0]!.id);
+    });
+  });
+
   describe("streamMessage", () => {
     it("yields text events from NDJSON", async () => {
       const body = makeStreamBody([

--- a/packages/core/tests/agents/infrastructure/ollama.test.ts
+++ b/packages/core/tests/agents/infrastructure/ollama.test.ts
@@ -342,7 +342,7 @@ describe("OllamaAdapter", () => {
       const response = await adapter.createMessage(options);
 
       expect(response.toolCalls).toHaveLength(1);
-      expect(response.toolCalls[0]!.id).toMatch(/^synth1:[0-9a-f]{64}:0$/);
+      expect(response.toolCalls[0]!.id).toMatch(/^synth1:[0-9a-f]{64}:0:[0-9a-f]{64}$/);
     });
 
     it("produces the identical id across two independent normalizations of the same request", async () => {
@@ -364,6 +364,46 @@ describe("OllamaAdapter", () => {
 
       expect(response.toolCalls).toHaveLength(2);
       expect(response.toolCalls[0]!.id).not.toBe(response.toolCalls[1]!.id);
+    });
+
+    it("produces a different id for a fixed request when the generated response differs", async () => {
+      // Ollama's generation is nondeterministic: the same request can return different
+      // tool calls at the same ordinal on different attempts. Identity must distinguish
+      // them -- otherwise two different calls collide on the same synthetic id.
+      const options = makeOptions({ tools: [makeToolDef()] });
+
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search"]));
+      const first = await new OllamaAdapter().createMessage(options);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          message: {
+            content: "",
+            tool_calls: [{ function: { name: "delete", arguments: { path: "b" } } }],
+          },
+          done: true,
+          prompt_eval_count: 20,
+          eval_count: 10,
+        }),
+      });
+      const second = await new OllamaAdapter().createMessage(options);
+
+      expect(first.toolCalls[0]!.id).not.toBe(second.toolCalls[0]!.id);
+    });
+
+    it("re-normalizing the same persisted response for the same request yields the same id", async () => {
+      // Replay-stability: the same *response* (not just the same request) must still
+      // produce the same id on a second normalization.
+      const options = makeOptions({ tools: [makeToolDef()] });
+
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search"]));
+      const first = await new OllamaAdapter().createMessage(options);
+
+      mockFetch.mockResolvedValueOnce(toolCallResponse(["search"]));
+      const second = await new OllamaAdapter().createMessage(options);
+
+      expect(first.toolCalls[0]!.id).toBe(second.toolCalls[0]!.id);
     });
 
     it("produces a different id when the request body differs", async () => {

--- a/packages/core/tests/agents/infrastructure/openai-compat.test.ts
+++ b/packages/core/tests/agents/infrastructure/openai-compat.test.ts
@@ -509,6 +509,121 @@ describe("OpenAIAdapter", () => {
       }),
     });
   });
+
+  describe("tool call identity", () => {
+    it("synthesizes a streamed id from the chunk id + tc.index when the provider omits tc.id", async () => {
+      const chunk = JSON.stringify({
+        id: "chatcmpl-omitted-id-1",
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              function: { name: "search", arguments: '{"query":"test"}' },
+            }],
+          },
+        }],
+      });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: mockSSEStream([chunk]),
+      }));
+
+      const events: AgentStreamEvent[] = [];
+      for await (const event of adapter.streamMessage(makeOptions({ tools: [makeToolDef()] }))) {
+        events.push(event);
+      }
+
+      expect(events).toContainEqual({
+        type: "tool_use",
+        content: JSON.stringify({
+          id: "synth1:chatcmpl-omitted-id-1:0",
+          name: "search",
+          input: { query: "test" },
+        }),
+      });
+    });
+
+    it("rejects a streamed tool call when neither tc.id nor a chunk id is available", async () => {
+      const chunk = JSON.stringify({
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              function: { name: "search", arguments: '{"query":"test"}' },
+            }],
+          },
+        }],
+      });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: mockSSEStream([chunk]),
+      }));
+
+      await expect(async () => {
+        for await (const _event of adapter.streamMessage(makeOptions({ tools: [makeToolDef()] }))) {
+          // consume
+        }
+      }).rejects.toMatchObject({ code: "TOOL_CALL_IDENTITY_INVALID" });
+    });
+
+    it("rejects duplicate ids within one non-streaming response", async () => {
+      const body = makeOpenAIResponse({
+        choices: [{
+          message: {
+            content: null,
+            tool_calls: [
+              { id: "call_dup", type: "function", function: { name: "search", arguments: '{"query":"a"}' } },
+              { id: "call_dup", type: "function", function: { name: "search", arguments: '{"query":"b"}' } },
+            ],
+          },
+        }],
+      });
+      vi.stubGlobal("fetch", mockFetchResponse(body));
+
+      await expect(adapter.createMessage(makeOptions({ tools: [makeToolDef()] }))).rejects.toMatchObject({
+        code: "TOOL_CALL_IDENTITY_INVALID",
+      });
+    });
+
+    it("rejects a whitespace-only tool call id in a non-streaming response", async () => {
+      const body = makeOpenAIResponse({
+        choices: [{
+          message: {
+            content: null,
+            tool_calls: [
+              { id: "   ", type: "function", function: { name: "search", arguments: '{"query":"a"}' } },
+            ],
+          },
+        }],
+      });
+      vi.stubGlobal("fetch", mockFetchResponse(body));
+
+      await expect(adapter.createMessage(makeOptions({ tools: [makeToolDef()] }))).rejects.toMatchObject({
+        code: "TOOL_CALL_IDENTITY_INVALID",
+      });
+    });
+
+    it("preserves a valid provider id unchanged (regression guard)", async () => {
+      const body = makeOpenAIResponse({
+        choices: [{
+          message: {
+            content: null,
+            tool_calls: [
+              { id: "call_valid_1", type: "function", function: { name: "search", arguments: '{"query":"a"}' } },
+            ],
+          },
+        }],
+      });
+      vi.stubGlobal("fetch", mockFetchResponse(body));
+
+      const response = await adapter.createMessage(makeOptions({ tools: [makeToolDef()] }));
+      expect(response.toolCalls).toEqual([
+        { id: "call_valid_1", name: "search", input: { query: "a" } },
+      ]);
+    });
+  });
 });
 
 describe("DeepSeekAdapter", () => {

--- a/packages/core/tests/agents/infrastructure/openai-compat.test.ts
+++ b/packages/core/tests/agents/infrastructure/openai-compat.test.ts
@@ -605,6 +605,86 @@ describe("OpenAIAdapter", () => {
       });
     });
 
+    it("adopts a native id that arrives on a later delta instead of keeping the first-observed synthetic id", async () => {
+      // First delta has no tc.id and no chunk id -> would previously buffer id "" and fail
+      // at flush. A later delta for the same index supplies a native id; that must win.
+      const chunk1 = JSON.stringify({
+        choices: [{
+          delta: { tool_calls: [{ index: 0, function: { name: "search", arguments: '{"query":' } }] },
+        }],
+      });
+      const chunk2 = JSON.stringify({
+        choices: [{
+          delta: { tool_calls: [{ index: 0, id: "call_native", function: { arguments: '"test"}' } }] },
+        }],
+      });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: mockSSEStream([chunk1, chunk2]),
+      }));
+
+      const events: AgentStreamEvent[] = [];
+      for await (const event of adapter.streamMessage(makeOptions({ tools: [makeToolDef()] }))) {
+        events.push(event);
+      }
+
+      expect(events).toContainEqual({
+        type: "tool_use",
+        content: JSON.stringify({ id: "call_native", name: "search", input: { query: "test" } }),
+      });
+    });
+
+    it("rejects a stream that reuses one index for two conflicting native tool call ids", async () => {
+      const chunk1 = JSON.stringify({
+        choices: [{
+          delta: { tool_calls: [{ index: 0, id: "call-A", function: { name: "search", arguments: "{}" } }] },
+        }],
+      });
+      const chunk2 = JSON.stringify({
+        choices: [{
+          delta: { tool_calls: [{ index: 0, id: "call-B", function: { arguments: "{}" } }] },
+        }],
+      });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: mockSSEStream([chunk1, chunk2]),
+      }));
+
+      await expect(async () => {
+        for await (const _event of adapter.streamMessage(makeOptions({ tools: [makeToolDef()] }))) {
+          // consume
+        }
+      }).rejects.toMatchObject({ code: "TOOL_CALL_IDENTITY_INVALID" });
+    });
+
+    it("rejects a stream where the chunk id backing a synthetic id changes mid-buffer", async () => {
+      const chunk1 = JSON.stringify({
+        id: "chatcmpl-A",
+        choices: [{
+          delta: { tool_calls: [{ index: 0, function: { name: "search", arguments: "{}" } }] },
+        }],
+      });
+      const chunk2 = JSON.stringify({
+        id: "chatcmpl-B",
+        choices: [{
+          delta: { tool_calls: [{ index: 0, function: { arguments: "{}" } }] },
+        }],
+      });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: mockSSEStream([chunk1, chunk2]),
+      }));
+
+      await expect(async () => {
+        for await (const _event of adapter.streamMessage(makeOptions({ tools: [makeToolDef()] }))) {
+          // consume
+        }
+      }).rejects.toMatchObject({ code: "TOOL_CALL_IDENTITY_INVALID" });
+    });
+
     it("preserves a valid provider id unchanged (regression guard)", async () => {
       const body = makeOpenAIResponse({
         choices: [{

--- a/packages/core/tests/agents/tool-call-input.test.ts
+++ b/packages/core/tests/agents/tool-call-input.test.ts
@@ -106,6 +106,31 @@ describe("assertValidToolCallIds", () => {
     );
   });
 
+  it("rejects an id with leading or trailing whitespace instead of silently accepting it padded", () => {
+    // The documented invariant is "trimmed, non-empty, unique". An id that round-trips
+    // padded (e.g. from Anthropic or non-streaming OpenAI) must not silently pass.
+    expect(() => assertValidToolCallIds(
+      [toolCall(" call_1 ")],
+      { adapter: "test-adapter" },
+    )).toThrow(/untrimmed tool call id/);
+  });
+
+  it("throws a KilnError with adapter/index/id context on untrimmed ids", async () => {
+    const { KilnError } = await import("../../src/engine/errors.js");
+    try {
+      assertValidToolCallIds([toolCall(" call_1 ")], { adapter: "test-adapter" });
+      expect.unreachable("expected assertValidToolCallIds to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(KilnError);
+      expect((error as InstanceType<typeof KilnError>).code).toBe("TOOL_CALL_IDENTITY_INVALID");
+      expect((error as InstanceType<typeof KilnError>).context).toMatchObject({
+        adapter: "test-adapter",
+        index: 0,
+        id: " call_1 ",
+      });
+    }
+  });
+
   it("survives a JSON serialize/deserialize round trip with identity unchanged", () => {
     const original: readonly ToolCall[] = [toolCall("call_1"), toolCall("call_2")];
     const roundTripped = JSON.parse(JSON.stringify(original)) as ToolCall[];

--- a/packages/core/tests/agents/tool-call-input.test.ts
+++ b/packages/core/tests/agents/tool-call-input.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import type { ToolCall } from "../../src/agents/index.js";
+import {
+  SYNTHETIC_TOOL_CALL_ID_PREFIX,
+  buildSyntheticToolCallId,
+  assertValidToolCallIds,
+} from "../../src/agents/tool-call-input.js";
+
+function toolCall(id: string, overrides: Partial<ToolCall> = {}): ToolCall {
+  return { id, name: "read", input: {}, ...overrides };
+}
+
+describe("buildSyntheticToolCallId", () => {
+  it("joins coordinates behind the versioned synthetic prefix", () => {
+    expect(buildSyntheticToolCallId("resp_1", "0")).toBe(`${SYNTHETIC_TOOL_CALL_ID_PREFIX}resp_1:0`);
+    expect(buildSyntheticToolCallId("a", "b", "c")).toBe(`${SYNTHETIC_TOOL_CALL_ID_PREFIX}a:b:c`);
+  });
+
+  it("is deterministic for identical coordinates", () => {
+    expect(buildSyntheticToolCallId("resp_1", "2")).toBe(buildSyntheticToolCallId("resp_1", "2"));
+  });
+
+  it("produces distinct ids for distinct coordinates", () => {
+    expect(buildSyntheticToolCallId("resp_1", "0")).not.toBe(buildSyntheticToolCallId("resp_1", "1"));
+    expect(buildSyntheticToolCallId("resp_1", "0")).not.toBe(buildSyntheticToolCallId("resp_2", "0"));
+  });
+});
+
+describe("assertValidToolCallIds", () => {
+  it("accepts a collection of trimmed, unique, non-empty ids", () => {
+    expect(() => assertValidToolCallIds(
+      [toolCall("call_1"), toolCall("call_2")],
+      { adapter: "test-adapter" },
+    )).not.toThrow();
+  });
+
+  it("rejects a blank id", () => {
+    expect(() => assertValidToolCallIds(
+      [toolCall("")],
+      { adapter: "test-adapter" },
+    )).toThrow(/blank tool call id/);
+  });
+
+  it("rejects a whitespace-only id", () => {
+    expect(() => assertValidToolCallIds(
+      [toolCall("   ")],
+      { adapter: "test-adapter" },
+    )).toThrow(/blank tool call id/);
+  });
+
+  it("rejects duplicate ids within the same collection", () => {
+    expect(() => assertValidToolCallIds(
+      [toolCall("call_1"), toolCall("call_1")],
+      { adapter: "test-adapter" },
+    )).toThrow(/duplicate tool call id/);
+  });
+
+  it("rejects two blank ids rather than silently collapsing them (no dedupe-by-blank)", () => {
+    // Two missing-id calls must not be treated as "the same call" -- assert throws
+    // instead of allowing a downstream consumer to collapse them.
+    expect(() => assertValidToolCallIds(
+      [toolCall(""), toolCall("")],
+      { adapter: "test-adapter" },
+    )).toThrow(/blank tool call id/);
+  });
+
+  it("throws a KilnError with adapter/index/id context on blank ids", async () => {
+    const { KilnError } = await import("../../src/engine/errors.js");
+    try {
+      assertValidToolCallIds([toolCall("ok"), toolCall("")], { adapter: "test-adapter" });
+      expect.unreachable("expected assertValidToolCallIds to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(KilnError);
+      expect((error as InstanceType<typeof KilnError>).code).toBe("TOOL_CALL_IDENTITY_INVALID");
+      expect((error as InstanceType<typeof KilnError>).context).toMatchObject({
+        adapter: "test-adapter",
+        index: 1,
+      });
+    }
+  });
+
+  it("throws a KilnError with adapter/index/priorIndex/id context on duplicate ids", async () => {
+    const { KilnError } = await import("../../src/engine/errors.js");
+    try {
+      assertValidToolCallIds([toolCall("dup"), toolCall("dup")], { adapter: "test-adapter" });
+      expect.unreachable("expected assertValidToolCallIds to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(KilnError);
+      expect((error as InstanceType<typeof KilnError>).code).toBe("TOOL_CALL_IDENTITY_INVALID");
+      expect((error as InstanceType<typeof KilnError>).context).toMatchObject({
+        adapter: "test-adapter",
+        index: 1,
+        priorIndex: 0,
+        id: "dup",
+      });
+    }
+  });
+
+  it("detects legacy persisted blank/duplicate identities rather than silently rewriting them", () => {
+    // Simulates a persisted transcript record hydrated with the historical bug (blank id).
+    const legacyPersisted: readonly ToolCall[] = [
+      { id: "", name: "read", input: { filePath: "a.txt" } },
+    ];
+    expect(() => assertValidToolCallIds(legacyPersisted, { adapter: "rehydrated-transcript" })).toThrow(
+      /blank tool call id/,
+    );
+  });
+
+  it("survives a JSON serialize/deserialize round trip with identity unchanged", () => {
+    const original: readonly ToolCall[] = [toolCall("call_1"), toolCall("call_2")];
+    const roundTripped = JSON.parse(JSON.stringify(original)) as ToolCall[];
+    expect(roundTripped).toEqual(original);
+    expect(() => assertValidToolCallIds(roundTripped, { adapter: "test-adapter" })).not.toThrow();
+  });
+});

--- a/packages/runtime/src/gateway/gui-gateway.ts
+++ b/packages/runtime/src/gateway/gui-gateway.ts
@@ -2149,6 +2149,13 @@ class GuiActivityStreamer {
   private memoryLatticeHandler: ((event: KilnEvent) => void) | null = null;
   private lastKnownKilnSessionId: string | undefined;
   private outOfTurnBrowserEvidenceSequence = 0;
+  /**
+   * Fallback ordinal for tool_use/tool_result events forwarded outside any active turn capture
+   * (e.g. an orphaned event arriving after `endTurnCapture`). Deterministic per connection --
+   * never a timestamp or random value -- because nothing in this no-capture path is persisted
+   * or replayed; it only feeds the live activity stream to the connected browser.
+   */
+  private noCaptureToolOrdinal = 0;
   private approvalBridge: {
     approve: (approvalId: string) => void;
     reject: (approvalId: string, reason: string) => void;
@@ -2455,7 +2462,7 @@ class GuiActivityStreamer {
     } else if (event.type === "tool_use") {
       const toolCallId = event.toolCallId ?? (this.capture
         ? `${this.capture.sessionId}:live:tool:${++this.capture.toolOrdinal}`
-        : `${event.toolName ?? "tool"}_${Date.now()}`);
+        : `${event.toolName ?? "tool"}:no-capture:${++this.noCaptureToolOrdinal}`);
       if (this.capture) {
         const pending = this.capture.pendingToolCallIds.get(event.toolName) ?? [];
         pending.push(toolCallId);
@@ -2500,7 +2507,9 @@ class GuiActivityStreamer {
         }
       } else {
         toolCallId = pending?.shift()
-          ?? (this.capture ? `${this.capture.sessionId}:live:tool:${++this.capture.toolOrdinal}` : `${event.toolName ?? "tool"}_${Date.now()}`);
+          ?? (this.capture
+            ? `${this.capture.sessionId}:live:tool:${++this.capture.toolOrdinal}`
+            : `${event.toolName ?? "tool"}:no-capture:${++this.noCaptureToolOrdinal}`);
       }
       if (pending && pending.length === 0 && this.capture) {
         this.capture.pendingToolCallIds.delete(event.toolName);

--- a/packages/runtime/src/model-gateway/provider-adapter-one-round-dispatcher.ts
+++ b/packages/runtime/src/model-gateway/provider-adapter-one-round-dispatcher.ts
@@ -1,4 +1,5 @@
 import {
+  assertValidToolCallIds,
   type AccountRef,
   type AgentMessage,
   type AgentResponse,
@@ -65,6 +66,10 @@ export class ProviderAdapterOneRoundDispatcher implements ModelGatewayOneRoundDi
 
     const projection = buildFunctionToolProjection(input.turn.tools ?? []);
     const response = await this.#adapter.createMessage(toCreateMessageOptions(input, projection));
+    // ProviderAdapter is an open boundary; this bridge projects adapter-produced tool calls
+    // directly into the model-gateway turn result, so identity must be validated here too
+    // rather than trusting the adapter's own convention.
+    assertValidToolCallIds(response.toolCalls, { adapter: this.#providerId });
     return toModelTurnResult(response, projection);
   }
 }

--- a/packages/runtime/src/session/runtime-session-orchestrator.ts
+++ b/packages/runtime/src/session/runtime-session-orchestrator.ts
@@ -12,6 +12,7 @@ import type {
 } from "@kilnai/core";
 import {
   accountedWorkItemEvidence,
+  assertValidToolCallIds,
   extractText,
   getInvalidToolInputDetails,
   KilnError,
@@ -416,6 +417,10 @@ export class RuntimeSessionOrchestrator {
         ...(providerExecutionContext ? { executionContext: providerExecutionContext } : {}),
       });
       throwIfRuntimeTurnAborted(perCallConfig?.abortSignal);
+      // ProviderAdapter is an open boundary -- any implementation, not only the built-in
+      // adapters, must have its tool call identity validated before results enter the runtime
+      // (added to session history, executed, or projected by the model-gateway bridge).
+      assertValidToolCallIds(response.toolCalls, { adapter: routing.effectiveProvider.name });
 
       const usageTotals = this.telemetry.recordResponse(
         session.id,

--- a/packages/runtime/tests/model-gateway/provider-adapter-one-round-dispatcher.test.ts
+++ b/packages/runtime/tests/model-gateway/provider-adapter-one-round-dispatcher.test.ts
@@ -132,6 +132,22 @@ describe("ProviderAdapterOneRoundDispatcher", () => {
     expect(provider.createMessage).not.toHaveBeenCalled();
   });
 
+  it("fails closed on duplicate tool call ids from the raw adapter instead of projecting them", async () => {
+    // The one-round bridge projects adapter-produced tool calls directly into the model-turn
+    // result; identity must be validated here too, not only by the built-in adapters.
+    const provider = adapter({
+      toolCalls: [
+        { id: "dup", name: "lookup", input: { q: "a" } },
+        { id: "dup", name: "lookup", input: { q: "b" } },
+      ],
+    });
+    const dispatcher = new ProviderAdapterOneRoundDispatcher({ account, providerId: "anthropic", adapter: provider });
+
+    await expect(dispatcher.dispatchOneRound(input())).rejects.toMatchObject({
+      code: "TOOL_CALL_IDENTITY_INVALID",
+    });
+  });
+
   it("rejects route and account mismatches before dispatch", async () => {
     const provider = adapter();
     const dispatcher = new ProviderAdapterOneRoundDispatcher({ account, providerId: "anthropic", adapter: provider });

--- a/packages/runtime/tests/session/runtime-session-orchestrator-tools.test.ts
+++ b/packages/runtime/tests/session/runtime-session-orchestrator-tools.test.ts
@@ -241,6 +241,43 @@ function makeCapabilityMap(overrides?: Partial<Capability>): ReadonlyMap<string,
 }
 
 describe("RuntimeSessionOrchestrator - Tool Execution Enhancements", () => {
+  it("fails closed on blank/duplicate tool call ids from a custom adapter before persisting or executing them", async () => {
+    // ProviderAdapter is an open boundary -- any implementation, not just the built-in ones,
+    // must have its tool call identity validated before results enter the runtime.
+    const getData = vi.fn().mockResolvedValue("should never run");
+    const provider: ProviderAdapter = {
+      name: "custom-adapter",
+      createMessage: vi.fn().mockResolvedValue({
+        parts: textParts("using tool"),
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        toolCalls: [
+          { id: "", name: "get_data", input: { query: "a" } },
+          { id: "", name: "get_data", input: { query: "b" } },
+        ],
+        stopReason: "tool_use",
+      }),
+      streamMessage: vi.fn() as unknown as ProviderAdapter["streamMessage"],
+    };
+    const orchestrator = new RuntimeSessionOrchestrator({
+      provider,
+      tools: [{ name: "get_data", description: "Gets data", inputSchema: {}, tags: new Set() }],
+      builtinTools: new Map([["get_data", getData]]),
+    });
+    const session = makeSession();
+
+    await expect(orchestrator.processMessage(session, textParts("go"))).rejects.toMatchObject({
+      code: "TOOL_CALL_IDENTITY_INVALID",
+    });
+
+    expect(getData).not.toHaveBeenCalled();
+    expect(
+      session.conversationHistory.some((message) => message.parts.some((part) => part.type === "tool_use")),
+    ).toBe(false);
+  });
+
   it("forces one bounded recovery round before allowing an exact-date answer", async () => {
     const provider: ProviderAdapter = {
       name: "mock",


### PR DESCRIPTION
Makes tool call identity stable, non-empty and unique at the point it is produced, and enforces that at the runtime boundary so no provider adapter can bypass it.

## Problem

Nothing guaranteed a tool call carried usable identity. Four adapters were broken in three different ways:

| Adapter | Was | Defect |
|---|---|---|
| Codex OAuth | `item.call_id ?? item.id ?? ""` | empty string, though `response.id` + output index were available |
| OpenAI-compatible streaming | `tc.id ?? ""` | empty string |
| Ollama | `crypto.randomUUID()` | regenerated on every normalization — never replay-stable |
| Anthropic, non-streaming OpenAI | provider id, unchecked | never validated non-empty or unique |

The domain type said only `id: string`, and `normalizeToolCall` passed it through verbatim. There was no owner.

These were live defects, not latent ones:

- `codex-oauth` deduplicates streamed calls by id, so several missing-id calls collapsed to `""` and **later calls were silently suppressed**
- `conversation-turn-projection`, `operator-cockpit-projection` and `workflow-activity-projection` key by id and **merged unrelated tool calls** when ids duplicated
- an unvalidated response could drive an unbounded tool-round loop — a regression test for this **hung indefinitely** before the boundary fix landed

## Change

**Core owns the invariant.** `assertValidToolCallIds` in `packages/core/src/agents/tool-call-input.ts` — the file that already owns ToolCall normalization — requires every id to be trimmed, non-empty, and unique within its normalization scope. It fails closed with `KilnError`, reusing the existing error catalog rather than introducing a new error type. Untrimmed ids are rejected rather than silently passed through padded.

**Each adapter owns its coordinates.** Synthetic ids are built through `buildSyntheticToolCallId` behind a versioned `synth1:` prefix, so a derived identity is always distinguishable from a provider-supplied one:

- **Codex OAuth** — `call_id`, then item `id`, then `response.id` + output-item index. None available rejects the response.
- **OpenAI-compatible streaming** — `tc.id`, else chunk id + tool index, reconciled on *every* delta: a native id arriving late backfills the buffer and wins, while a delta contradicting an already-observed identity fails closed instead of being absorbed.
- **Ollama** — its wire protocol carries no id at all, so synthesis is mandatory: a hash over the deterministically serialized request, the tool call's own content, and its ordinal. Distinguishes two different generations of the same request while keeping re-normalization of one persisted response stable.
- **Anthropic / non-streaming OpenAI** — provider id preserved verbatim, validated centrally.

**The invariant is enforced where adapters enter the runtime**, not only inside the four built-in ones. `ProviderAdapter` is an open interface; validating only inside known adapters would be a convention, not an invariant. Both entry boundaries — the orchestrator's tool-round loop and the model-gateway one-round dispatcher — validate immediately after `createMessage` resolves, before anything reaches session history, execution, persistence or projection. Two enforcement points are required because no upstream construction site dominates both paths; an independent review confirmed no single choke point exists today.

**Removed a non-replay-stable repair.** `gui-gateway` had two `${toolName}_${Date.now()}` fallbacks. Both are gone.

## Verification

Independent adversarial review (Codex `gpt-5.6-sol`) ran three rounds against frozen SHAs. Round one raised six findings, round two three; every finding attributable to this code is fixed and re-verified, including the bypassable-boundary defect and the Ollama collision.

- `@kilnai/core` 3626/3628 (2 preexisting `publication-readiness` digest failures)
- `@kilnai/runtime`, `@kilnai/cli`, `@kilnai/gateway-contracts` green apart from the known preexisting `benchmark` digest failure
- workspace typecheck clean, `git diff --check` clean

## Scope

This covers identity **at production and at the runtime boundary** — it prevents new unusable identity from being created.

It deliberately does **not** validate identity when replaying already-persisted sessions or transcripts. That work was attempted and discarded: review established that the persisted format cannot support it today, because `operator-transcript-projection.ts` and `run-session.ts` write `tool_use` events **without** `toolCallId` at all, and persisted events record no normalization scope. Any validator built on that data is simultaneously too strict — rejecting legitimate `kiln run` transcripts — and too weak, since events without a turn id can never be compared. The producer-side defect is filed separately and must be fixed first.
