### PR TITLE
feat(runtime): deterministic multi-account managed routing proof

### DIFF
--- a/docs/architecture/managed-account-leases.md
+++ b/docs/architecture/managed-account-leases.md
@@ -13,8 +13,9 @@ Runtime owns their capacity, persistence, settlement, and recovery.
   and the sanitized `ManagedAccountLeaseEvidence` contract.
 - CLI composition projects existing `modelGateway.accounts` and
   `modelGateway.virtualModels` through the Runtime-owned candidate port.
-- Runtime owns one process-scoped SQLite lease authority per project runtime.
-  Route catalogs and adapter factories do not own or recreate capacity.
+- Runtime owns one process-scoped SQLite lease and affinity authority per
+  project runtime for managed invocations. Route catalogs and adapter factories
+  do not own or recreate managed-path capacity.
 - Provider adapters expose execution settlement. They do not select accounts,
   release capacity, retry across accounts, or reconstruct policy.
 - Gateway Contracts and operator surfaces project canonical evidence without
@@ -35,17 +36,39 @@ credential route and never implies account-capacity ownership.
 1. Admit governance, configured profile, route, authority, and capability.
 2. Resolve secret-free candidates for the route's explicit account policy.
 3. Acquire one durable lease in an immediate SQLite transaction.
-4. Persist the sanitized account reference, credential revision digest,
+4. Resolve configured continuity against the durable stable-capacity mapping,
+   then persist the sanitized account reference, credential revision digest,
    selection reason, candidate rejection evidence, and affinity outcome.
 5. Resolve only the leased credential revision and bind a non-pooled direct
    adapter.
 6. Advance `AttemptCommit` to `dispatching` immediately before provider effects.
 7. Project the operator-visible terminal state independently of settlement.
-8. Release capacity only after authoritative execution settlement.
+8. On success, atomically release the lease and compare-and-set its affinity
+   mapping. On every other outcome, release capacity only after authoritative
+   execution settlement.
 
-No account reassignment is permitted after `dispatching`. Adapter or SDK
-cross-account retry is disabled on selected-account paths. Credential revision
-drift fails before dispatch and releases the pre-dispatch lease.
+No account reassignment is permitted after `dispatching`. OpenCode and direct
+selected-account adapters disable their internal account retry. Codex retains
+its bounded same-credential transient and authorization retries; those retries
+cannot enumerate, materialize, bind, construct, or dispatch through another
+account. Credential revision drift fails before dispatch and releases only the
+pre-dispatch lease.
+
+## Configured Projection And Time
+
+`ConfiguredManagedAccountRuntime` is the production candidate projector. It
+reads only accounts explicitly named by the selected virtual model, emits
+secret-free configured account references and credential revision digests, and
+materializes only the revision already fenced by the acquired lease.
+
+Its usage clock is injected once at composition and the same `Date` is passed
+to usage listing and candidate construction. Time is evidence input, not
+authority:
+
+- fresh `exhausted` usage is unhealthy and excluded;
+- expired usage disappears and becomes missing evidence, eligible with penalty;
+- a newer explicit non-exhausted observation restores preference;
+- usage expiry never creates an `available` observation or releases capacity.
 
 ## Capacity And Settlement
 
@@ -66,6 +89,32 @@ Capacity follows settlement, not terminal projection.
 Release is idempotent and fenced by lease owner, lease ID, account, route, job,
 and Runtime invocation identity. Lease rows are retained for replay rather than
 deleted.
+
+## Managed Affinity
+
+Configured virtual models project `none`, `prefer`, or `require` continuity,
+scope, and explicit rebind permission through the candidate port. Managed jobs
+do not read gateway configuration directly and callers cannot submit an account
+or affinity key.
+
+Runtime derives an opaque SHA-256 key from admitted requester and parent
+lineage, the account policy, canonical route, policy scope, and the parent turn
+only for turn-scoped continuity. The authority stores that key against stable
+configured `capacityIdentity`, not credential revision or the opaque account
+reference.
+
+- `none` always enters selection as new work.
+- `prefer` creates a mapping only after successful execution and honors an
+  existing mapping while respecting reservations and total concurrency.
+- `require` fails closed without a durable mapping.
+- rebind is pre-dispatch and requires explicit configured permission.
+
+Successful finalization releases the exact lease and applies a first-bind or
+rebind compare-and-set in one immediate SQLite transaction. Its canonical
+outcome is `won`, `already-matched`, or `conflict`. A conflict preserves the
+winner and the successful provider result; it cannot overwrite, retry, or
+reassign work after effects. Failure, timeout, cancellation, and binding
+failure never mutate affinity.
 
 ## Recovery
 
@@ -88,12 +137,13 @@ composition project, before it marks those jobs interrupted.
 
 Canonical account-lease evidence contains opaque account and policy identities,
 canonical provider/model route, credential revision digest, selection and
-rejection reasons, affinity outcome, timestamps, lifecycle state, and safe
-resource or diagnostic URIs. It excludes credentials, tokens, raw provider
-payloads, exception details, and machine-specific paths. Account references
-must use the `configured:` namespace. Resource and diagnostic evidence is
-restricted to the lease's own `kiln://managed-accounts/leases/<lease-id>`
-namespace and its closed diagnostic vocabulary.
+rejection reasons, affinity selection and commit outcomes, timestamps,
+lifecycle state, and safe resource or diagnostic URIs. It excludes credentials,
+tokens, lineage-derived affinity keys, raw provider payloads, exception
+details, and machine-specific paths. Account references must use the
+`configured:` namespace. Resource and diagnostic evidence is restricted to the
+lease's own `kiln://managed-accounts/leases/<lease-id>` namespace and its closed
+diagnostic vocabulary.
 
 Managed-job V4 is the only writer and carries current lease evidence plus its
 lifecycle history. Lease observations advance aggregate `updatedAt` without
@@ -109,10 +159,16 @@ When execution settles after timeout or cancellation, Runtime appends a newer
 canonical terminal event carrying the released lease. Replay and every
 operator surface therefore converge on settlement without rewriting history.
 
+These guarantees are limited to managed invocations. Model Gateway ingress
+still uses `LocalModelGatewayStore`, whose lease and affinity tables are a
+separate pre-existing authority. Cross-path capacity and affinity exclusivity is
+not yet guaranteed and remains an explicit Roadmap 02 convergence slice.
+
 ## Non-Goals
 
 - No ambient account discovery or inferred account policy.
 - No quota evasion, hidden rotation, or provider-specific routing policy.
-- No economic routing or complete exhaustion/reset benchmark matrix.
+- No economic routing.
 - No default timer that fabricates settlement or frees unknown work.
 - No remote multi-runtime capacity sharing.
+- No claim of shared capacity or affinity with Model Gateway ingress.

--- a/docs/roadmap/02-managed-invocation-routing.md
+++ b/docs/roadmap/02-managed-invocation-routing.md
@@ -1,7 +1,7 @@
 # 02 - Managed Invocation Routing
 
 Status: Active delivery track
-Execution: Slice 1 complete; prepare deterministic multi-account proof.
+Execution: Slices 1 and 2 complete; Slice 3 requires explicit operator authorization.
 Created: 2026-07-23
 
 ## Objective
@@ -55,11 +55,18 @@ continues consuming capacity.
 
 ### Slice 2 - Deterministic Multi-Account Proof
 
-Status: Queued behind Slice 1.
+Status: Complete in issue #30.
 
-Use two configured synthetic accounts and a fake clock to prove exhaustion,
-reset, concurrency, reserved slots, affinity, cancellation, timeout settlement,
-and no cross-account retry. Restore Codex managed routes only after this passes.
+Two explicitly configured synthetic accounts and one injected usage clock prove
+the three usage states, deterministic selection, atomic capacity, reservations,
+durable affinity and fenced rebind, timeout/cancellation settlement, two-account
+recovery, revision-stable capacity, and absence of cross-account retry.
+Successful release and affinity CAS are one authority transaction, with
+`won`, `already-matched`, or `conflict` retained in V4 status, result, history,
+replay, and operator projections.
+
+The proof is portable and network-free. It establishes managed-path guarantees
+only and does not restore or mutate operator Codex configuration.
 
 ### Slice 3 - Bounded Live Probe
 
@@ -77,9 +84,20 @@ Represent quota class, subscription class, metered-cost class, and comparable
 cost separately. Explain why an eligible job used Codex or OpenCode. Add explicit
 reservations and ceilings without claiming free execution without evidence.
 
+### Slice 5 - Cross-Path Account Authority Convergence
+
+Status: Queued after the managed-path proof.
+
+Unify capacity and affinity authority when Model Gateway ingress and managed
+jobs target the same configured accounts. Replace the ingress
+`LocalModelGatewayStore` lease deletion and last-writer-wins affinity behavior
+with the same stable-capacity, settlement-conservative, fenced semantics,
+without importing gateway process recovery into managed invocation.
+
 ## Promotion Gates
 
-- Legacy pooled adapters retain the exactly-one guard until replaced.
+- Legacy pooled adapters retain the exactly-one guard while they remain real
+  consumers.
 - Every job records one explicit account selection and releases it correctly.
 - Missing or stale usage is `unknown`, never fabricated.
 - No provider commitment triggers hidden account retry.
@@ -87,9 +105,10 @@ reservations and ceilings without claiming free execution without evidence.
 
 ## Verification
 
-Focused Core/Runtime/CLI tests, fake-clock integration tests, clean output-tree
-typecheck/build, full affected-package tests, `git diff --check`, and an
-authorized bounded live probe.
+Focused Core/Runtime/CLI tests, injected-clock integration tests, clean
+output-tree typecheck/build, full affected-package tests, `git diff --check`,
+and independent review. The authorized bounded live probe remains Slice 3 and
+is not evidence for Slice 2.
 
 ## Completion Criteria
 

--- a/docs/roadmap/02-managed-invocation-routing.md
+++ b/docs/roadmap/02-managed-invocation-routing.md
@@ -64,6 +64,9 @@ recovery, revision-stable capacity, and absence of cross-account retry.
 Successful release and affinity CAS are one authority transaction, with
 `won`, `already-matched`, or `conflict` retained in V4 status, result, history,
 replay, and operator projections.
+The account-scoped retry proof constructs the selected Codex adapter with its
+bounded same-credential retries enabled while asserting zero materialization,
+binding, adapter construction, or dispatch through the other account.
 
 The proof is portable and network-free. It establishes managed-path guarantees
 only and does not restore or mutate operator Codex configuration.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -22,7 +22,7 @@ roadmap reorganization.
 
 | Order | Track | State | Next bounded work |
 | --- | --- | --- | --- |
-| 1 | [02 - Managed Invocation Routing](./02-managed-invocation-routing.md) | Ready | Complete per-job account leases and lifecycle evidence. |
+| 1 | [02 - Managed Invocation Routing](./02-managed-invocation-routing.md) | Blocked | Obtain explicit operator authorization for the bounded Slice 3 live probe. |
 | 2 | [03 - Model Gateway Lifecycle](./03-model-gateway-lifecycle.md) | Blocked | Fix deterministic teardown, then apply and live-prove the reviewed user-scoped gateway configuration on an operator machine. |
 | 3 | [04 - Cross-Harness Integration](./04-cross-harness-integration.md) | Blocked | Close OpenCode live parity, then migrate and prove the harness-neutral control-plane bridge. |
 | 4 | [05 - Skill Capability Plane](./05-skill-capability-plane.md) | Research | Define the provider-neutral skill evidence and admission contract. |

--- a/packages/core/src/agents/managed-invocation/index.ts
+++ b/packages/core/src/agents/managed-invocation/index.ts
@@ -677,6 +677,38 @@ export const MANAGED_ACCOUNT_LEASE_LIFECYCLE_STATES = [
 
 export type ManagedAccountLeaseLifecycleState = typeof MANAGED_ACCOUNT_LEASE_LIFECYCLE_STATES[number];
 
+export const MANAGED_ACCOUNT_AFFINITY_COMMIT_OUTCOMES = [
+  "won",
+  "already-matched",
+  "conflict",
+] as const;
+
+export type ManagedAccountAffinityCommitOutcome =
+  typeof MANAGED_ACCOUNT_AFFINITY_COMMIT_OUTCOMES[number];
+
+export type ManagedAccountAffinityPolicy =
+  | {
+    readonly continuity: "none";
+  }
+  | {
+    readonly continuity: "prefer" | "require";
+    readonly scope: "session" | "turn";
+    readonly allowRebind?: boolean;
+  };
+
+declare const managedAccountAffinityKeyBrand: unique symbol;
+
+export type ManagedAccountAffinityKey = string & {
+  readonly [managedAccountAffinityKeyBrand]: true;
+};
+
+export function createManagedAccountAffinityKey(value: string): ManagedAccountAffinityKey {
+  if (!/^[a-f0-9]{64}$/.test(value)) {
+    throw new TypeError("Managed account affinity key must be an opaque SHA-256 digest");
+  }
+  return value as ManagedAccountAffinityKey;
+}
+
 export interface ManagedAccountLeaseEvidence {
   readonly leaseId: string;
   readonly accountPolicyId: AccountPolicyId;
@@ -688,6 +720,7 @@ export interface ManagedAccountLeaseEvidence {
   readonly selectionReason: ModelGatewayAccountSelection["reason"];
   readonly candidateRejections: readonly ModelGatewayAccountRejection[];
   readonly affinityOutcome?: ModelGatewayAffinityOutcome;
+  readonly affinityCommitOutcome?: ManagedAccountAffinityCommitOutcome;
   readonly acquiredAt: string;
   readonly lifecycleState: ManagedAccountLeaseLifecycleState;
   readonly releasedAt?: string;
@@ -706,6 +739,7 @@ export interface ManagedAccountLeaseEvidenceInput {
   readonly selectionReason: ModelGatewayAccountSelection["reason"];
   readonly candidateRejections?: readonly ModelGatewayAccountRejection[];
   readonly affinityOutcome?: ModelGatewayAffinityOutcome;
+  readonly affinityCommitOutcome?: ManagedAccountAffinityCommitOutcome;
   readonly acquiredAt: string;
   readonly lifecycleState: ManagedAccountLeaseLifecycleState;
   readonly releasedAt?: string;
@@ -731,6 +765,9 @@ export function defineManagedAccountLeaseEvidence(
   }
   if (releasedAt !== undefined && Date.parse(releasedAt) < Date.parse(acquiredAt)) {
     throw new Error("Managed account lease released timestamp cannot precede acquisition");
+  }
+  if (input.affinityCommitOutcome !== undefined && lifecycleState !== "released") {
+    throw new Error("Managed account lease affinity commit outcome requires released state");
   }
   if (!/^[a-f0-9]{64}$/.test(input.credentialRevisionId)) {
     throw new Error("Managed account lease credential revision identity must be a SHA-256 digest");
@@ -767,6 +804,9 @@ export function defineManagedAccountLeaseEvidence(
     })),
     ...(input.affinityOutcome !== undefined
       ? { affinityOutcome: requireManagedAccountAffinityOutcome(input.affinityOutcome) }
+      : {}),
+    ...(input.affinityCommitOutcome !== undefined
+      ? { affinityCommitOutcome: requireManagedAccountAffinityCommitOutcome(input.affinityCommitOutcome) }
       : {}),
     acquiredAt,
     lifecycleState,
@@ -881,6 +921,15 @@ function requireManagedAccountAffinityOutcome(
 ): ModelGatewayAffinityOutcome {
   if (value !== "honored" && value !== "missing" && value !== "rejected" && value !== "rebound") {
     throw new Error(`Unsupported managed account lease affinity outcome: ${String(value)}`);
+  }
+  return value;
+}
+
+function requireManagedAccountAffinityCommitOutcome(
+  value: ManagedAccountAffinityCommitOutcome,
+): ManagedAccountAffinityCommitOutcome {
+  if (!MANAGED_ACCOUNT_AFFINITY_COMMIT_OUTCOMES.includes(value)) {
+    throw new Error(`Unsupported managed account affinity commit outcome: ${String(value)}`);
   }
   return value;
 }

--- a/packages/core/tests/managed-agent/invocation-contracts.test.ts
+++ b/packages/core/tests/managed-agent/invocation-contracts.test.ts
@@ -161,6 +161,43 @@ describe("managed agent invocation contracts", () => {
     expect(evidence).not.toHaveProperty("workingDirectoryPath");
   });
 
+  it("validates the canonical managed affinity commit outcome", () => {
+    const base = {
+      leaseId: "account-lease-1",
+      accountPolicyId: "managed-codex",
+      accountRef: "configured:primary:opaque",
+      route: {
+        providerId: "codex-oauth",
+        providerModelId: "gpt-5.6-terra",
+        scope: "virtual:managed-codex",
+      },
+      jobId: "job-1",
+      runtimeInvocationId: "invocation-1",
+      credentialRevisionId: "a".repeat(64),
+      selectionReason: "least-pressure" as const,
+      acquiredAt: "2026-07-28T22:30:00.000Z",
+      lifecycleState: "released" as const,
+      releasedAt: "2026-07-28T22:31:00.000Z",
+      resourceUris: ["kiln://managed-accounts/leases/account-lease-1"],
+      diagnosticUris: [],
+    };
+
+    expect(defineManagedAccountLeaseEvidence({
+      ...base,
+      affinityCommitOutcome: "won",
+    })).toMatchObject({ affinityCommitOutcome: "won" });
+    expect(() => defineManagedAccountLeaseEvidence({
+      ...base,
+      affinityCommitOutcome: "overwritten" as "won",
+    })).toThrow("Unsupported managed account affinity commit outcome");
+    expect(() => defineManagedAccountLeaseEvidence({
+      ...base,
+      lifecycleState: "held",
+      releasedAt: undefined,
+      affinityCommitOutcome: "conflict",
+    })).toThrow("affinity commit outcome requires released state");
+  });
+
   it("validates account lease terminal and identity invariants", () => {
     const base = {
       leaseId: "account-lease-1",

--- a/packages/gateway-contracts/src/operator-cockpit-projection.ts
+++ b/packages/gateway-contracts/src/operator-cockpit-projection.ts
@@ -327,6 +327,7 @@ export interface OperatorCockpitInvocationAccountLeaseProjection {
     readonly reason: string;
   }[];
   readonly affinityOutcome?: string;
+  readonly affinityCommitOutcome?: "won" | "already-matched" | "conflict";
   readonly acquiredAt: string;
   readonly lifecycleState: "held" | "settlement-pending" | "released" | "release-failed" | "leaked";
   readonly releasedAt?: string;
@@ -1344,12 +1345,14 @@ function readAccountLease(payload: Record<string, unknown>): OperatorCockpitInvo
   const candidateRejections = readAccountLeaseCandidateRejections(lease.candidateRejections);
   const acquiredAt = readString(lease.acquiredAt);
   const lifecycleState = readAccountLeaseLifecycleState(lease.lifecycleState);
+  const affinityCommitOutcome = readAccountAffinityCommitOutcome(lease.affinityCommitOutcome);
   const resourceUris = readRequiredStringList(lease.resourceUris);
   const diagnosticUris = readRequiredStringList(lease.diagnosticUris);
   if (
     !leaseId || !accountPolicyId || !accountRef || !providerId || !providerModelId || !scope
     || !jobId || !runtimeInvocationId || !credentialRevisionId || !/^[a-f0-9]{64}$/u.test(credentialRevisionId)
     || !selectionReason || !candidateRejections || !acquiredAt || !lifecycleState || !resourceUris || !diagnosticUris
+    || affinityCommitOutcome === null
   ) {
     return null;
   }
@@ -1366,6 +1369,7 @@ function readAccountLease(payload: Record<string, unknown>): OperatorCockpitInvo
     selectionReason,
     candidateRejections,
     ...(readString(lease.affinityOutcome) ? { affinityOutcome: readString(lease.affinityOutcome)! } : {}),
+    ...(affinityCommitOutcome !== undefined ? { affinityCommitOutcome } : {}),
     acquiredAt,
     lifecycleState,
     ...(releasedAt ? { releasedAt } : {}),
@@ -1398,6 +1402,15 @@ function readAccountLeaseLifecycleState(
     || value === "released"
     || value === "release-failed"
     || value === "leaked"
+    ? value
+    : null;
+}
+
+function readAccountAffinityCommitOutcome(
+  value: unknown,
+): OperatorCockpitInvocationAccountLeaseProjection["affinityCommitOutcome"] | null {
+  if (value === undefined) return undefined;
+  return value === "won" || value === "already-matched" || value === "conflict"
     ? value
     : null;
 }

--- a/packages/gateway-contracts/src/operator-cockpit-projection.ts
+++ b/packages/gateway-contracts/src/operator-cockpit-projection.ts
@@ -1353,6 +1353,7 @@ function readAccountLease(payload: Record<string, unknown>): OperatorCockpitInvo
     || !jobId || !runtimeInvocationId || !credentialRevisionId || !/^[a-f0-9]{64}$/u.test(credentialRevisionId)
     || !selectionReason || !candidateRejections || !acquiredAt || !lifecycleState || !resourceUris || !diagnosticUris
     || affinityCommitOutcome === null
+    || (affinityCommitOutcome !== undefined && lifecycleState !== "released")
   ) {
     return null;
   }

--- a/packages/gateway-contracts/src/operator-event-presentation.ts
+++ b/packages/gateway-contracts/src/operator-event-presentation.ts
@@ -1839,6 +1839,7 @@ function addManagedCapabilitySnapshotDetails(
   addItem(details, "Account lease state", accountLease?.lifecycleState);
   addItem(details, "Account selection", accountLease?.selectionReason);
   addItem(details, "Account affinity", accountLease?.affinityOutcome);
+  addItem(details, "Account affinity commit", accountLease?.affinityCommitOutcome);
   addItem(details, "Account lease acquired", accountLease?.acquiredAt);
   addItem(details, "Account lease released", accountLease?.releasedAt);
   addItem(details, "Account lease resources", formatStringList(accountLease?.resourceUris));

--- a/packages/gateway-contracts/tests/operator-cockpit-projection.test.ts
+++ b/packages/gateway-contracts/tests/operator-cockpit-projection.test.ts
@@ -40,6 +40,53 @@ describe("operator cockpit read-only projection", () => {
     });
   });
 
+  it("projects successful managed affinity commit evidence without deriving policy", () => {
+    const completed = structuredClone(managedAccountLeaseEvents[1]) as OperatorSessionEvent;
+    const payload = completed.payload as Record<string, unknown> & {
+      lifecycleState: string;
+      managedInvocationEvidence: {
+        lifecycle: {
+          accountLease: {
+            affinityCommitOutcome?: string;
+            diagnosticUris: string[];
+          };
+        };
+      };
+    };
+    completed.kind = "agent_invocation_completed";
+    payload.lifecycleState = "completed";
+    payload.managedInvocationEvidence.lifecycle.accountLease.affinityCommitOutcome = "won";
+    payload.managedInvocationEvidence.lifecycle.accountLease.diagnosticUris = [];
+
+    const projection = projectOperatorCockpitReadOnlyView({
+      projectedAt: "2026-07-28T12:01:00.000Z",
+      attachTargets: [{
+        instanceId: MANAGED_ACCOUNT_LEASE_FIXTURE.instanceId,
+        label: "Synthetic managed account runtime",
+        kind: "local",
+      }],
+      events: [completed],
+    });
+
+    expect(projection.invocations[0]?.accountLease).toMatchObject({
+      accountRef: MANAGED_ACCOUNT_LEASE_FIXTURE.accountRef,
+      lifecycleState: "released",
+      affinityCommitOutcome: "won",
+    });
+
+    payload.managedInvocationEvidence.lifecycle.accountLease.affinityCommitOutcome = "overwritten";
+    const rejected = projectOperatorCockpitReadOnlyView({
+      projectedAt: "2026-07-28T12:01:00.000Z",
+      attachTargets: [{
+        instanceId: MANAGED_ACCOUNT_LEASE_FIXTURE.instanceId,
+        label: "Synthetic managed account runtime",
+        kind: "local",
+      }],
+      events: [completed],
+    });
+    expect(rejected.invocations[0]?.accountLease).toBeUndefined();
+  });
+
   it("projects canonical events into target-aware cockpit views without mutation authority", () => {
     const fixture = createOperatorCockpitBenchmarkFixture({
       fixtureId: "read-only",

--- a/packages/gateway-contracts/tests/operator-cockpit-projection.test.ts
+++ b/packages/gateway-contracts/tests/operator-cockpit-projection.test.ts
@@ -49,6 +49,8 @@ describe("operator cockpit read-only projection", () => {
           accountLease: {
             affinityCommitOutcome?: string;
             diagnosticUris: string[];
+            lifecycleState: string;
+            releasedAt?: string;
           };
         };
       };
@@ -74,6 +76,22 @@ describe("operator cockpit read-only projection", () => {
       affinityCommitOutcome: "won",
     });
 
+    payload.managedInvocationEvidence.lifecycle.accountLease.lifecycleState = "held";
+    delete payload.managedInvocationEvidence.lifecycle.accountLease.releasedAt;
+    const premature = projectOperatorCockpitReadOnlyView({
+      projectedAt: "2026-07-28T12:01:00.000Z",
+      attachTargets: [{
+        instanceId: MANAGED_ACCOUNT_LEASE_FIXTURE.instanceId,
+        label: "Synthetic managed account runtime",
+        kind: "local",
+      }],
+      events: [completed],
+    });
+    expect(premature.invocations[0]?.accountLease).toBeUndefined();
+
+    payload.managedInvocationEvidence.lifecycle.accountLease.lifecycleState = "released";
+    payload.managedInvocationEvidence.lifecycle.accountLease.releasedAt =
+      MANAGED_ACCOUNT_LEASE_FIXTURE.releasedAt;
     payload.managedInvocationEvidence.lifecycle.accountLease.affinityCommitOutcome = "overwritten";
     const rejected = projectOperatorCockpitReadOnlyView({
       projectedAt: "2026-07-28T12:01:00.000Z",

--- a/packages/gateway-contracts/tests/operator-event-presentation.test.ts
+++ b/packages/gateway-contracts/tests/operator-event-presentation.test.ts
@@ -5,8 +5,30 @@ import {
   operatorEventTargetsSurface,
   presentOperatorEventPayload,
 } from "../src/operator-event-presentation.js";
+import { managedAccountLeaseEvents } from "./fixtures/managed-account-lease.js";
 
 describe("operator event presentation", () => {
+  it("presents canonical managed account affinity commit evidence", () => {
+    const completed = structuredClone(managedAccountLeaseEvents[1]);
+    const payload = completed.payload as Record<string, unknown> & {
+      managedInvocationEvidence: {
+        lifecycle: {
+          accountLease: {
+            affinityCommitOutcome?: string;
+          };
+        };
+      };
+    };
+    payload.managedInvocationEvidence.lifecycle.accountLease.affinityCommitOutcome = "conflict";
+
+    const presentation = presentOperatorEventPayload(completed.kind, completed.payload);
+
+    expect(presentation.details).toContainEqual({
+      label: "Account affinity commit",
+      value: "conflict",
+    });
+  });
+
   it("projects structured tool errors as diagnostics even when the transport reports success", () => {
     const message = "goal.create cannot combine preferredRouteId and managedAgentProfile.";
     const presentation = presentOperatorEventPayload("tool_call_completed", {

--- a/packages/runtime/src/agents/managed-invocation/index.ts
+++ b/packages/runtime/src/agents/managed-invocation/index.ts
@@ -17,10 +17,12 @@ import {
   defineVerificationUsageReport,
   evaluateManagedAgentAdmission,
   createAttemptCommit,
+  createManagedAccountAffinityKey,
   isManagedAgentWriteAuthorityProfile,
 } from "@kilnai/core";
 import type {
   AttemptCommit,
+  ManagedAccountAffinityPolicy,
   ManagedAgentAdapterDescriptor,
   ManagedAgentAdmissionDecision,
   ManagedAgentCapabilitySnapshot,
@@ -35,6 +37,7 @@ import type {
   ManagedAgentResourceLeaseEvidence,
   ManagedAgentWorktreeConflictEvidence,
   ManagedAgentWorktreeReviewEvidence,
+  ModelGatewayRoute,
   StructuredExecutionResult,
 } from "@kilnai/core";
 import type {
@@ -2032,7 +2035,12 @@ export class RuntimeManagedAgentInvocationService {
       route: resolution.route,
       jobId: entry.request.invocationId,
       runtimeInvocationId: entry.request.invocationId,
-      work: "new",
+      affinityRequest: managedAccountAffinityRequest(
+        entry.request,
+        credentialRoute.accountPolicyId,
+        resolution.route,
+        resolution.affinityPolicy,
+      ),
       candidates: resolution.candidates,
     });
     if (result.status === "unavailable") {
@@ -2142,7 +2150,7 @@ export class RuntimeManagedAgentInvocationService {
       });
       await this.observeManagedAccountLease(entry, entry.accountLease);
       if (entry.executionSettlement !== undefined && entry.accountSettlementFinalization === undefined) {
-        entry.accountSettlementFinalization = entry.executionSettlement.then(() => this.releaseManagedAccountLease(entry));
+        entry.accountSettlementFinalization = entry.executionSettlement.then(() => this.releaseManagedAccountLease(entry, false));
         void entry.accountSettlementFinalization.then(async (lease) => {
           entry.accountLease = lease;
           if (entry.record) {
@@ -2157,7 +2165,7 @@ export class RuntimeManagedAgentInvocationService {
       return defineManagedAgentInvocationRecord({ ...record, accountLease: entry.accountLease });
     }
     if (entry.executionSettlement !== undefined) await entry.executionSettlement;
-    entry.accountLease = await this.releaseManagedAccountLease(entry);
+    entry.accountLease = await this.releaseManagedAccountLease(entry, record.lifecycleState === "completed");
     await this.observeManagedAccountLease(entry, entry.accountLease);
     return defineManagedAgentInvocationRecord({ ...record, accountLease: entry.accountLease });
   }
@@ -2171,6 +2179,7 @@ export class RuntimeManagedAgentInvocationService {
 
   private async releaseManagedAccountLease(
     entry: ManagedAgentRuntimeInvocationEntry,
+    successful: boolean,
   ): Promise<ManagedAccountLeaseEvidence> {
     const identity = entry.accountLeaseIdentity;
     const authority = this.options.accountLeaseAuthority;
@@ -2178,7 +2187,9 @@ export class RuntimeManagedAgentInvocationService {
       throw new ManagedAgentRuntimeAdmissionError("Managed account lease release authority is unavailable");
     }
     try {
-      return authority.release(identity);
+      return successful
+        ? authority.finalizeSuccessful(identity).lease
+        : authority.release(identity);
     } catch {
       return authority.recordReleaseFailure({
         ...identity,
@@ -2654,6 +2665,39 @@ function managedAccountLeaseIdentity(
     route: cloneJson(lease.route),
     jobId: lease.jobId,
     runtimeInvocationId: lease.runtimeInvocationId,
+  };
+}
+
+function managedAccountAffinityRequest(
+  request: ManagedAgentInvocationRequest,
+  accountPolicyId: string,
+  route: ModelGatewayRoute,
+  policy: ManagedAccountAffinityPolicy,
+) {
+  if (policy.continuity === "none") return { continuity: "none" as const };
+  const hash = createHash("sha256");
+  const identity = [
+    "kiln-managed-account-affinity-v1",
+    request.requestedBy,
+    accountPolicyId,
+    route.providerId,
+    route.providerModelId,
+    route.scope,
+    policy.scope,
+    request.parentSessionId,
+    ...(policy.scope === "turn" ? [request.parentTurnId] : []),
+  ];
+  for (const value of identity) {
+    const bytes = Buffer.from(value, "utf8");
+    hash.update(`${bytes.byteLength}:`);
+    hash.update(bytes);
+    hash.update(";");
+  }
+  return {
+    continuity: policy.continuity,
+    scope: policy.scope,
+    ...(policy.allowRebind === undefined ? {} : { allowRebind: policy.allowRebind }),
+    key: createManagedAccountAffinityKey(hash.digest("hex")),
   };
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -23,8 +23,10 @@ export type {
   ManagedAccountLeaseAuthority,
   ManagedAccountLeaseAcquireInput,
   ManagedAccountLeaseAcquireResult,
+  ManagedAccountLeaseSuccessfulFinalization,
   ManagedAccountLeaseIdentity,
   ManagedAccountLeaseRecoveryInput,
+  ManagedAccountAffinityRequest,
   SqliteManagedAccountLeaseAuthorityOptions,
 } from "./managed-account-leases/managed-account-lease-authority.js";
 

--- a/packages/runtime/src/managed-account-leases/configured-managed-account-runtime.ts
+++ b/packages/runtime/src/managed-account-leases/configured-managed-account-runtime.ts
@@ -47,6 +47,7 @@ export interface ConfiguredManagedAccountRuntimeOptions {
   readonly config: ModelGatewayConfig;
   readonly credentialRootDir?: string;
   readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly now?: () => Date;
 }
 
 type ExecutionAccount =
@@ -63,6 +64,7 @@ implements ManagedAccountCandidatePort, ManagedAccountExecutionBindingPort {
   readonly #codexPool: CodexOAuthCredentialPoolService;
   readonly #openCodePool: OpenCodeCredentialPoolService;
   readonly #directPool: DirectProviderCredentialPoolService;
+  readonly #now: () => Date;
   #config: ModelGatewayConfig;
 
   constructor(options: ConfiguredManagedAccountRuntimeOptions) {
@@ -73,6 +75,7 @@ implements ManagedAccountCandidatePort, ManagedAccountExecutionBindingPort {
       rootDir: options.credentialRootDir,
       env: options.env,
     });
+    this.#now = options.now ?? (() => new Date());
   }
 
   updateConfig(config: ModelGatewayConfig): void {
@@ -89,13 +92,18 @@ implements ManagedAccountCandidatePort, ManagedAccountExecutionBindingPort {
     ) {
       throw new Error(`Managed account policy '${policyId}' does not match the admitted provider route.`);
     }
+    const now = this.#now();
+    if (!(now instanceof Date) || !Number.isFinite(now.getTime())) {
+      throw new TypeError("Managed account usage clock must return a valid Date.");
+    }
     const executionAccounts = await this.#listExecutionAccounts(model.providerId);
-    const usage = await this.#listUsage(model.providerId);
+    const usage = await this.#listUsage(model.providerId, now);
     const bound = buildModelGatewayBoundCandidates({
       virtualModel: model,
       accounts: this.#config.accounts,
       executionAccounts,
       usage,
+      now,
       pressure: () => 0,
       reservedForNewWork: () => false,
     });
@@ -105,6 +113,13 @@ implements ManagedAccountCandidatePort, ManagedAccountExecutionBindingPort {
         providerModelId: model.providerModelId,
         scope: `virtual:${model.id}`,
       },
+      affinityPolicy: model.affinity.continuity === "none"
+        ? { continuity: "none" }
+        : {
+            continuity: model.affinity.continuity,
+            scope: requireAffinityScope(model.affinity.scope),
+            ...(model.affinity.allowRebind === undefined ? {} : { allowRebind: model.affinity.allowRebind }),
+          },
       candidates: bound.map((entry) => ({
         candidate: {
           ...entry.candidate,
@@ -191,8 +206,8 @@ implements ManagedAccountCandidatePort, ManagedAccountExecutionBindingPort {
     return [];
   }
 
-  async #listUsage(providerId: DirectProviderId): Promise<readonly ProviderUsageSnapshot[]> {
-    return providerId === "codex-oauth" ? this.#codexPool.listUsage() : [];
+  async #listUsage(providerId: DirectProviderId, now: Date): Promise<readonly ProviderUsageSnapshot[]> {
+    return providerId === "codex-oauth" ? this.#codexPool.listUsage(now) : [];
   }
 
   async #createSelectedAdapter(
@@ -257,5 +272,10 @@ function selectedDirectAdapter(credential: DirectProviderExecutionCredential, mo
 
 function requireApiKey(value: string | undefined): string {
   if (!value) throw new Error("Selected managed provider credential requires an API key.");
+  return value;
+}
+
+function requireAffinityScope(value: "session" | "turn" | undefined): "session" | "turn" {
+  if (value === undefined) throw new Error("Managed account affinity continuity requires an explicit scope.");
   return value;
 }

--- a/packages/runtime/src/managed-account-leases/managed-account-lease-authority.ts
+++ b/packages/runtime/src/managed-account-leases/managed-account-lease-authority.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   createAccountPolicyId,
   createAccountRef,
@@ -8,6 +8,7 @@ import {
   defineModelGatewayAccountRejection,
   selectModelGatewayAccount,
   type AccountPolicyId,
+  type AccountRef,
   type ManagedAccountAffinityCommitOutcome,
   type ManagedAccountAffinityKey,
   type ManagedAccountAffinityPolicy,
@@ -255,9 +256,8 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
       if (binding === undefined) throw new Error("Selected managed account binding is unavailable.");
       const leaseId = randomUUID();
       const acquiredAt = new Date(this.#now()).toISOString();
-      const selectionWasFallbackRebind = affinity.fallbackRebind;
-      const affinityOutcome = selectionWasFallbackRebind ? "rebound" : selection.affinity?.outcome;
-      const selectionReason = selectionWasFallbackRebind ? "affinity-rebind" : selection.selected.reason;
+      const affinityOutcome = selection.affinity?.outcome;
+      const selectionReason = selection.selected.reason;
       const resourceUris = [`kiln://managed-accounts/leases/${encodeURIComponent(leaseId)}`];
       this.#db.query(`
         INSERT INTO account_leases (
@@ -486,7 +486,6 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
       readonly expectedCapacityIdentity: string | null;
       readonly accountAffinity?: ModelGatewayAffinity;
       readonly allowRebind: boolean;
-      readonly fallbackRebind: boolean;
     }
     | {
       readonly status: "unavailable";
@@ -498,7 +497,6 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
         work: "new",
         expectedCapacityIdentity: null,
         allowRebind: false,
-        fallbackRebind: false,
       };
     }
 
@@ -524,29 +522,22 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
         key,
         expectedCapacityIdentity: null,
         allowRebind: false,
-        fallbackRebind: false,
       };
     }
 
     const binding = input.candidates.find((candidate) =>
       candidate.capacityIdentity === affinity.capacity_identity);
     if (!binding) {
-      if (input.affinityRequest.allowRebind !== true) {
-        return {
-          status: "unavailable",
-          result: {
-            status: "unavailable",
-            rejections: [],
-          },
-        };
-      }
       return {
         status: "ready",
-        work: "new",
+        work: "existing",
         key,
         expectedCapacityIdentity: affinity.capacity_identity,
-        allowRebind: true,
-        fallbackRebind: true,
+        accountAffinity: {
+          account: missingAffinityAccountRef(affinity.capacity_identity),
+          route: input.route,
+        },
+        allowRebind: input.affinityRequest.allowRebind === true,
       };
     }
 
@@ -560,7 +551,6 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
         route: input.route,
       },
       allowRebind: input.affinityRequest.allowRebind === true,
-      fallbackRebind: false,
     };
   }
 
@@ -703,6 +693,14 @@ function validateAcquireInput(input: ManagedAccountLeaseAcquireInput): void {
     }
     accounts.add(binding.candidate.account);
   }
+}
+
+function missingAffinityAccountRef(capacityIdentity: string): AccountRef {
+  const digest = createHash("sha256")
+    .update("kiln-missing-managed-account-affinity-v1:")
+    .update(capacityIdentity)
+    .digest("hex");
+  return createAccountRef(`configured:missing-affinity:${digest}`);
 }
 
 function validateCandidateBinding(binding: ManagedAccountCandidateBinding): void {

--- a/packages/runtime/src/managed-account-leases/managed-account-lease-authority.ts
+++ b/packages/runtime/src/managed-account-leases/managed-account-lease-authority.ts
@@ -3,10 +3,14 @@ import { randomUUID } from "node:crypto";
 import {
   createAccountPolicyId,
   createAccountRef,
+  createManagedAccountAffinityKey,
   defineManagedAccountLeaseEvidence,
   defineModelGatewayAccountRejection,
   selectModelGatewayAccount,
   type AccountPolicyId,
+  type ManagedAccountAffinityCommitOutcome,
+  type ManagedAccountAffinityKey,
+  type ManagedAccountAffinityPolicy,
   type ManagedAccountLeaseEvidence,
   type ModelGatewayAccountCandidate,
   type ModelGatewayAffinity,
@@ -36,14 +40,21 @@ export interface ManagedAccountLeaseIdentity {
   readonly runtimeInvocationId: string;
 }
 
+export type ManagedAccountAffinityRequest =
+  | { readonly continuity: "none" }
+  | {
+    readonly continuity: "prefer" | "require";
+    readonly scope: "session" | "turn";
+    readonly allowRebind?: boolean;
+    readonly key: ManagedAccountAffinityKey;
+  };
+
 export interface ManagedAccountLeaseAcquireInput {
   readonly accountPolicyId: AccountPolicyId;
   readonly route: ModelGatewayRoute;
   readonly jobId: string;
   readonly runtimeInvocationId: string;
-  readonly work: "new" | "existing";
-  readonly affinity?: ModelGatewayAffinity;
-  readonly allowAffinityRebind?: boolean;
+  readonly affinityRequest: ManagedAccountAffinityRequest;
   readonly candidates: readonly ManagedAccountCandidateBinding[];
 }
 
@@ -66,6 +77,7 @@ export interface ManagedAccountLeaseRecoveryInput {
 
 export interface ManagedAccountCandidateResolution {
   readonly route: ModelGatewayRoute;
+  readonly affinityPolicy: ManagedAccountAffinityPolicy;
   readonly candidates: readonly ManagedAccountCandidateBinding[];
 }
 
@@ -78,6 +90,7 @@ export interface ManagedAccountCandidatePort {
 
 export interface ManagedAccountLeaseAuthority {
   acquire(input: ManagedAccountLeaseAcquireInput): Promise<ManagedAccountLeaseAcquireResult>;
+  finalizeSuccessful(input: ManagedAccountLeaseIdentity): ManagedAccountLeaseSuccessfulFinalization;
   markSettlementPending(
     input: ManagedAccountLeaseIdentity & { readonly diagnosticUri?: string },
   ): ManagedAccountLeaseEvidence;
@@ -87,6 +100,11 @@ export interface ManagedAccountLeaseAuthority {
   ): ManagedAccountLeaseEvidence;
   recover(input: ManagedAccountLeaseRecoveryInput): readonly ManagedAccountLeaseEvidence[];
   get(leaseId: string): ManagedAccountLeaseEvidence | undefined;
+}
+
+export interface ManagedAccountLeaseSuccessfulFinalization {
+  readonly lease: ManagedAccountLeaseEvidence;
+  readonly affinityCommitOutcome?: ManagedAccountAffinityCommitOutcome;
 }
 
 export interface SqliteManagedAccountLeaseAuthorityOptions {
@@ -117,6 +135,14 @@ type LeaseRow = {
   purpose: "new" | "affinity";
   resource_uris: string;
   diagnostic_uris: string;
+  affinity_key: string | null;
+  affinity_expected_capacity_identity: string | null;
+  affinity_commit_outcome: ManagedAccountAffinityCommitOutcome | null;
+};
+
+type AffinityRow = {
+  affinity_key: string;
+  capacity_identity: string;
 };
 
 const CAPACITY_CONSUMING_STATES = [
@@ -171,9 +197,19 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
           affinity_outcome TEXT,
           purpose TEXT NOT NULL,
           resource_uris TEXT NOT NULL,
-          diagnostic_uris TEXT NOT NULL
+          diagnostic_uris TEXT NOT NULL,
+          affinity_key TEXT,
+          affinity_expected_capacity_identity TEXT,
+          affinity_commit_outcome TEXT
+        );
+        CREATE TABLE IF NOT EXISTS managed_account_affinities (
+          affinity_key TEXT PRIMARY KEY,
+          capacity_identity TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
         );
       `);
+      this.#migrateSliceOneSchema();
       this.#claimOwner();
     } catch (error) {
       this.#db.close();
@@ -197,12 +233,15 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
         throw new Error("Managed account lease job already has an account selection.");
       }
       const bindings = new Map(input.candidates.map((binding) => [binding.candidate.account, binding]));
-      const candidates = input.candidates.map((binding) => this.#candidateWithCurrentCapacity(binding, input.work));
+      const affinity = this.#resolveAffinity(input);
+      if (affinity.status === "unavailable") return affinity.result;
+      const candidates = input.candidates.map((binding) =>
+        this.#candidateWithCurrentCapacity(binding, affinity.work));
       const selection = selectModelGatewayAccount({
         route: input.route,
-        work: input.work,
-        ...(input.affinity !== undefined ? { affinity: input.affinity } : {}),
-        ...(input.allowAffinityRebind === true ? { allowAffinityRebind: true } : {}),
+        work: affinity.work,
+        ...(affinity.accountAffinity !== undefined ? { affinity: affinity.accountAffinity } : {}),
+        ...(affinity.allowRebind ? { allowAffinityRebind: true } : {}),
         candidates,
       });
       if (selection.selected === undefined) {
@@ -216,7 +255,9 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
       if (binding === undefined) throw new Error("Selected managed account binding is unavailable.");
       const leaseId = randomUUID();
       const acquiredAt = new Date(this.#now()).toISOString();
-      const affinityOutcome = selection.affinity?.outcome;
+      const selectionWasFallbackRebind = affinity.fallbackRebind;
+      const affinityOutcome = selectionWasFallbackRebind ? "rebound" : selection.affinity?.outcome;
+      const selectionReason = selectionWasFallbackRebind ? "affinity-rebind" : selection.selected.reason;
       const resourceUris = [`kiln://managed-accounts/leases/${encodeURIComponent(leaseId)}`];
       this.#db.query(`
         INSERT INTO account_leases (
@@ -224,8 +265,9 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
           route_scope, job_id, runtime_invocation_id, credential_revision_id,
           owner_id, acquired_at, lifecycle_state, released_at, selection_reason,
           candidate_rejections, affinity_outcome, purpose, resource_uris,
-          diagnostic_uris
-        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+          diagnostic_uris, affinity_key, affinity_expected_capacity_identity,
+          affinity_commit_outcome
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
       `).run(
         leaseId,
         input.accountPolicyId,
@@ -241,12 +283,15 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
         acquiredAt,
         "held",
         null,
-        selection.selected.reason,
+        selectionReason,
         JSON.stringify(selection.rejections),
         affinityOutcome ?? null,
-        input.work === "existing" ? "affinity" : "new",
+        affinity.work === "existing" ? "affinity" : "new",
         JSON.stringify(resourceUris),
         "[]",
+        affinity.key ?? null,
+        affinity.expectedCapacityIdentity,
+        null,
       );
       const row = this.#rowForLease(leaseId);
       if (row === null) throw new Error("Managed account lease persistence failed.");
@@ -254,6 +299,43 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
         status: "acquired",
         identity: identityFromRow(row),
         lease: evidenceFromRow(row),
+      };
+    });
+  }
+
+  finalizeSuccessful(input: ManagedAccountLeaseIdentity): ManagedAccountLeaseSuccessfulFinalization {
+    return this.#transaction(() => {
+      this.#heartbeat();
+      const row = this.#requireOwnedIdentity(input);
+      if (row.lifecycle_state === "released") {
+        return {
+          lease: evidenceFromRow(row),
+          ...(row.affinity_commit_outcome !== null
+            ? { affinityCommitOutcome: row.affinity_commit_outcome }
+            : {}),
+        };
+      }
+      if (row.lifecycle_state !== "held") {
+        throw new Error(
+          `Managed account successful finalization requires held state, received ${row.lifecycle_state}.`,
+        );
+      }
+
+      const affinityCommitOutcome = row.affinity_key === null
+        ? undefined
+        : this.#commitAffinity(row);
+      const releasedAt = new Date(this.#now()).toISOString();
+      const released = this.#db.query(`
+        UPDATE account_leases
+        SET lifecycle_state='released', released_at=?, affinity_commit_outcome=?
+        WHERE lease_id=? AND owner_id=? AND lifecycle_state!='released'
+      `).run(releasedAt, affinityCommitOutcome ?? null, row.lease_id, this.#ownerId);
+      if (released.changes !== 1) {
+        throw new Error("Managed account lease successful finalization lost its release fence.");
+      }
+      return {
+        lease: evidenceFromRow(this.#requiredRow(row.lease_id)),
+        ...(affinityCommitOutcome !== undefined ? { affinityCommitOutcome } : {}),
       };
     });
   }
@@ -374,7 +456,7 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
 
   #candidateWithCurrentCapacity(
     binding: ManagedAccountCandidateBinding,
-    work: ManagedAccountLeaseAcquireInput["work"],
+    work: "new" | "existing",
   ): ModelGatewayAccountCandidate {
     validateCandidateBinding(binding);
     const placeholders = CAPACITY_CONSUMING_STATES.map(() => "?").join(",");
@@ -394,6 +476,134 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
       pressure: binding.candidate.pressure + total / binding.capacity.maxConcurrency,
       reservedForNewWork: binding.candidate.reservedForNewWork || reservedCapacityUnavailable,
     };
+  }
+
+  #resolveAffinity(input: ManagedAccountLeaseAcquireInput):
+    | {
+      readonly status: "ready";
+      readonly work: "new" | "existing";
+      readonly key?: ManagedAccountAffinityKey;
+      readonly expectedCapacityIdentity: string | null;
+      readonly accountAffinity?: ModelGatewayAffinity;
+      readonly allowRebind: boolean;
+      readonly fallbackRebind: boolean;
+    }
+    | {
+      readonly status: "unavailable";
+      readonly result: ManagedAccountLeaseAcquireResult & { readonly status: "unavailable" };
+    } {
+    if (input.affinityRequest.continuity === "none") {
+      return {
+        status: "ready",
+        work: "new",
+        expectedCapacityIdentity: null,
+        allowRebind: false,
+        fallbackRebind: false,
+      };
+    }
+
+    const key = createManagedAccountAffinityKey(input.affinityRequest.key);
+    const affinity = this.#db.query<AffinityRow, [string]>(`
+      SELECT affinity_key, capacity_identity
+      FROM managed_account_affinities
+      WHERE affinity_key=?
+    `).get(key);
+    if (!affinity) {
+      if (input.affinityRequest.continuity === "require") {
+        return {
+          status: "unavailable",
+          result: {
+            status: "unavailable",
+            rejections: [],
+          },
+        };
+      }
+      return {
+        status: "ready",
+        work: "new",
+        key,
+        expectedCapacityIdentity: null,
+        allowRebind: false,
+        fallbackRebind: false,
+      };
+    }
+
+    const binding = input.candidates.find((candidate) =>
+      candidate.capacityIdentity === affinity.capacity_identity);
+    if (!binding) {
+      if (input.affinityRequest.allowRebind !== true) {
+        return {
+          status: "unavailable",
+          result: {
+            status: "unavailable",
+            rejections: [],
+          },
+        };
+      }
+      return {
+        status: "ready",
+        work: "new",
+        key,
+        expectedCapacityIdentity: affinity.capacity_identity,
+        allowRebind: true,
+        fallbackRebind: true,
+      };
+    }
+
+    return {
+      status: "ready",
+      work: "existing",
+      key,
+      expectedCapacityIdentity: affinity.capacity_identity,
+      accountAffinity: {
+        account: binding.candidate.account,
+        route: input.route,
+      },
+      allowRebind: input.affinityRequest.allowRebind === true,
+      fallbackRebind: false,
+    };
+  }
+
+  #commitAffinity(row: LeaseRow): ManagedAccountAffinityCommitOutcome {
+    const key = createManagedAccountAffinityKey(row.affinity_key!);
+    const current = this.#db.query<AffinityRow, [string]>(`
+      SELECT affinity_key, capacity_identity
+      FROM managed_account_affinities
+      WHERE affinity_key=?
+    `).get(key);
+    if (current?.capacity_identity === row.capacity_identity) {
+      return "already-matched";
+    }
+    if ((current?.capacity_identity ?? null) !== row.affinity_expected_capacity_identity) {
+      return "conflict";
+    }
+
+    const now = new Date(this.#now()).toISOString();
+    if (!current) {
+      const inserted = this.#db.query(`
+        INSERT INTO managed_account_affinities(
+          affinity_key, capacity_identity, created_at, updated_at
+        ) VALUES(?,?,?,?)
+      `).run(key, row.capacity_identity, now, now);
+      if (inserted.changes !== 1) {
+        throw new Error("Managed account affinity first-bind fence was lost.");
+      }
+    } else {
+      const updated = this.#db.query(`
+        UPDATE managed_account_affinities
+        SET capacity_identity=?, updated_at=?
+        WHERE affinity_key=? AND capacity_identity=?
+      `).run(
+        row.capacity_identity,
+        now,
+        key,
+        row.affinity_expected_capacity_identity,
+      );
+      if (updated.changes !== 1) {
+        throw new Error("Managed account affinity rebind fence was lost.");
+      }
+    }
+    return "won";
   }
 
   #requireOwnedIdentity(input: ManagedAccountLeaseIdentity): LeaseRow {
@@ -427,6 +637,26 @@ export class SqliteManagedAccountLeaseAuthority implements ManagedAccountLeaseAu
     `).all(...CAPACITY_CONSUMING_STATES);
   }
 
+  #migrateSliceOneSchema(): void {
+    this.#db.transaction(() => {
+      const columns = new Set(
+        this.#db.query<{ name: string }, []>("PRAGMA table_info(account_leases)").all()
+          .map((column) => column.name),
+      );
+      if (!columns.has("affinity_key")) {
+        this.#db.exec("ALTER TABLE account_leases ADD COLUMN affinity_key TEXT;");
+      }
+      if (!columns.has("affinity_expected_capacity_identity")) {
+        this.#db.exec(
+          "ALTER TABLE account_leases ADD COLUMN affinity_expected_capacity_identity TEXT;",
+        );
+      }
+      if (!columns.has("affinity_commit_outcome")) {
+        this.#db.exec("ALTER TABLE account_leases ADD COLUMN affinity_commit_outcome TEXT;");
+      }
+    }).immediate();
+  }
+
   #claimOwner(): void {
     this.#transaction(() => {
       const now = this.#now();
@@ -458,6 +688,12 @@ function validateAcquireInput(input: ManagedAccountLeaseAcquireInput): void {
   requireRoute(input.route);
   requireCanonicalText(input.jobId, "Managed account lease job id is required.");
   requireCanonicalText(input.runtimeInvocationId, "Managed account lease runtime invocation id is required.");
+  if (input.affinityRequest.continuity !== "none") {
+    createManagedAccountAffinityKey(input.affinityRequest.key);
+    if (input.affinityRequest.scope !== "session" && input.affinityRequest.scope !== "turn") {
+      throw new TypeError("Managed account affinity scope must be session or turn.");
+    }
+  }
   if (input.candidates.length === 0) return;
   const accounts = new Set<string>();
   for (const binding of input.candidates) {
@@ -518,6 +754,9 @@ function evidenceFromRow(row: LeaseRow): ManagedAccountLeaseEvidence {
     selectionReason: row.selection_reason,
     candidateRejections: parseCandidateRejections(row.candidate_rejections),
     ...(row.affinity_outcome !== null ? { affinityOutcome: row.affinity_outcome } : {}),
+    ...(row.affinity_commit_outcome !== null
+      ? { affinityCommitOutcome: row.affinity_commit_outcome }
+      : {}),
     acquiredAt: row.acquired_at,
     lifecycleState: row.lifecycle_state,
     ...(row.released_at !== null ? { releasedAt: row.released_at } : {}),

--- a/packages/runtime/tests/managed-account-leases/configured-managed-account-runtime.test.ts
+++ b/packages/runtime/tests/managed-account-leases/configured-managed-account-runtime.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -48,6 +48,7 @@ describe("ConfiguredManagedAccountRuntime", () => {
       providerRoute: { providerId: "openai", surface: "direct", model: "gpt-test" },
     });
     expect(resolution.candidates).toHaveLength(1);
+    expect(resolution.affinityPolicy).toEqual({ continuity: "none" });
     expect(resolution.candidates[0]).toMatchObject({
       candidate: { pressure: 1 },
       usageEvidence: { freshness: "missing" },
@@ -63,7 +64,7 @@ describe("ConfiguredManagedAccountRuntime", () => {
       route: resolution.route,
       jobId: "job-a",
       runtimeInvocationId: "job-a",
-      work: "new",
+      affinityRequest: { continuity: "none" },
       candidates: resolution.candidates,
     });
     if (acquired.status !== "acquired") throw new Error("expected account lease");
@@ -93,7 +94,7 @@ describe("ConfiguredManagedAccountRuntime", () => {
       route: resolution.route,
       jobId: "job-a",
       runtimeInvocationId: "job-a",
-      work: "new",
+      affinityRequest: { continuity: "none" },
       candidates: resolution.candidates,
     });
     if (acquired.status !== "acquired") throw new Error("expected account lease");
@@ -102,7 +103,112 @@ describe("ConfiguredManagedAccountRuntime", () => {
     await expect(runtime.bind({ lease: acquired.lease, adapter: directTemplate() }))
       .rejects.toThrow("revision changed");
   });
+
+  it("uses one injected clock for configured two-account usage and projects affinity policy", async () => {
+    root = await mkdtemp(join(tmpdir(), "kiln-configured-account-"));
+    await mkdir(join(root, "codex-oauth"), { recursive: true });
+    await Promise.all([
+      writeFile(join(root, "codex-oauth", "credential-a.json"), "{}"),
+      writeFile(join(root, "codex-oauth", "credential-b.json"), "{}"),
+      writeFile(join(root, "codex-oauth", "unconfigured.json"), "{}"),
+    ]);
+    await writeUsage(root, [
+      usage("credential-a", "exhausted"),
+      usage("credential-b", "available"),
+    ]);
+    let now = new Date("2026-07-22T12:00:00.000Z");
+    const runtime = new ConfiguredManagedAccountRuntime({
+      config: twoAccountConfig(),
+      credentialRootDir: root,
+      now: () => now,
+    });
+
+    const fresh = await runtime.resolve({
+      accountPolicyId: "managed-codex",
+      providerRoute: { providerId: "codex-oauth", surface: "direct", model: "gpt-test" },
+    });
+
+    expect(fresh.affinityPolicy).toEqual({
+      continuity: "prefer",
+      scope: "session",
+      allowRebind: true,
+    });
+    expect(fresh.candidates).toHaveLength(2);
+    expect(fresh.candidates.map((candidate) => candidate.capacityIdentity)).toEqual(["account-a", "account-b"]);
+    expect(fresh.candidates.map((candidate) => candidate.usageEvidence)).toMatchObject([
+      { health: "unhealthy", freshness: "fresh", availability: "exhausted" },
+      { health: "healthy", freshness: "fresh", availability: "available" },
+    ]);
+
+    now = new Date("2026-07-22T12:05:01.000Z");
+    const expired = await runtime.resolve({
+      accountPolicyId: "managed-codex",
+      providerRoute: { providerId: "codex-oauth", surface: "direct", model: "gpt-test" },
+    });
+    expect(expired.candidates.map((candidate) => ({
+      health: candidate.candidate.health,
+      pressure: candidate.candidate.pressure,
+      usage: candidate.usageEvidence,
+    }))).toEqual([
+      { health: "healthy", pressure: 1, usage: { health: "healthy", freshness: "missing" } },
+      { health: "healthy", pressure: 1, usage: { health: "healthy", freshness: "missing" } },
+    ]);
+
+    await writeUsage(root, [
+      {
+        ...usage("credential-a", "available"),
+        observedAt: "2026-07-22T12:05:01.000Z",
+        validUntil: "2026-07-22T12:10:01.000Z",
+      },
+    ]);
+    const refreshed = await runtime.resolve({
+      accountPolicyId: "managed-codex",
+      providerRoute: { providerId: "codex-oauth", surface: "direct", model: "gpt-test" },
+    });
+    expect(refreshed.candidates.map((candidate) => candidate.candidate.pressure)).toEqual([0, 1]);
+    expect(refreshed.candidates[0]?.usageEvidence).toMatchObject({
+      health: "healthy",
+      freshness: "fresh",
+      availability: "available",
+    });
+  });
 });
+
+function twoAccountConfig(): ModelGatewayConfig {
+  return {
+    ...config,
+    accounts: [
+      { id: "account-a", providerId: "codex-oauth", credentialId: "credential-a", maxConcurrency: 1, reservedAffinitySlots: 0 },
+      { id: "account-b", providerId: "codex-oauth", credentialId: "credential-b", maxConcurrency: 1, reservedAffinitySlots: 0 },
+    ],
+    virtualModels: [{
+      id: "managed-codex",
+      providerId: "codex-oauth",
+      providerModelId: "gpt-test",
+      accountIds: ["account-a", "account-b"],
+      capabilities: ["text"],
+      affinity: { continuity: "prefer", scope: "session", allowRebind: true },
+    }],
+  };
+}
+
+function usage(credentialId: string, availability: "available" | "exhausted") {
+  return {
+    provider: "codex-oauth" as const,
+    credentialId,
+    availability,
+    observedAt: "2026-07-22T11:59:00.000Z",
+    validUntil: "2026-07-22T12:05:00.000Z",
+    source: "provider-endpoint" as const,
+    confidence: "authoritative" as const,
+  };
+}
+
+async function writeUsage(directory: string, snapshots: readonly ReturnType<typeof usage>[]): Promise<void> {
+  const usageDirectory = join(directory, "provider-usage");
+  await mkdir(usageDirectory, { recursive: true });
+  await writeFile(join(usageDirectory, "codex-oauth.json"), JSON.stringify(snapshots));
+}
 
 function directTemplate(): ManagedDirectProviderRuntimeAdapter {
   const provider: ProviderAdapter = {

--- a/packages/runtime/tests/managed-account-leases/managed-account-invocation.test.ts
+++ b/packages/runtime/tests/managed-account-leases/managed-account-invocation.test.ts
@@ -37,6 +37,8 @@ const authorities: SqliteManagedAccountLeaseAuthority[] = [];
 afterEach(async () => {
   for (const authority of authorities.splice(0)) authority.close();
   for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("managed account invocation lifecycle", () => {
@@ -417,6 +419,13 @@ describe("managed account invocation lifecycle", () => {
       CodexOAuthCredentialPoolService.prototype,
       "resolveExecutionCredential",
     );
+    const providerFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ error: "synthetic transient failure" }),
+        { status: 520, headers: { "content-type": "application/json" } },
+      ))
+      .mockResolvedValueOnce(codexCompletedResponse("Recovered on the selected account."));
+    vi.stubGlobal("fetch", providerFetch);
     const binds: string[] = [];
     const dispatches: string[] = [];
     const service = new RuntimeManagedAgentInvocationService({
@@ -438,30 +447,31 @@ describe("managed account invocation lifecycle", () => {
           const bound = await configured.bind({ lease, adapter });
           return {
             descriptor: bound.descriptor,
-            invoke: vi.fn(async (input) => {
+            invoke: vi.fn((input) => {
               dispatches.push(lease.accountRef);
-              input.registerExecutionSettlement(Promise.resolve());
-              return failedRecord(input.request, input.admission.capabilitySnapshot);
+              return bound.invoke(input);
             }),
           };
         },
       },
     });
 
-    const providerFailure = await service.invoke(
-      configuredRequest("managed-job-provider-failure"),
+    const recovered = await service.invoke(
+      configuredRequest("managed-job-codex-retry"),
       directTemplate(),
       snapshotInput(),
     );
-    expect(providerFailure.status).toBe("completed");
-    if (providerFailure.status !== "completed") throw new Error("expected provider failure projection");
-    expect(providerFailure.record).toMatchObject({
-      lifecycleState: "failed",
+    expect(recovered.status).toBe("completed");
+    if (recovered.status !== "completed") throw new Error("expected recovered Codex projection");
+    expect(recovered.record).toMatchObject({
+      lifecycleState: "completed",
       accountLease: {
         accountRef: accountARef,
         lifecycleState: "released",
+        affinityCommitOutcome: "won",
       },
     });
+    expect(providerFetch).toHaveBeenCalledTimes(2);
     expect(credentialResolutions.mock.calls.map(([selected]) => selected.credentialId)).toEqual([
       "credential-a",
     ]);
@@ -479,8 +489,9 @@ describe("managed account invocation lifecycle", () => {
     expect(binds).toHaveLength(2);
     expect(binds[1]).toMatch(/^configured:account-a:/);
     expect(dispatches).toEqual([accountARef]);
+    expect(providerFetch).toHaveBeenCalledTimes(2);
     expect(authority.list()).toEqual(expect.arrayContaining([
-      { jobId: "managed-job-provider-failure", lifecycleState: "released" },
+      { jobId: "managed-job-codex-retry", lifecycleState: "released" },
       { jobId: "managed-job-binding-failure", lifecycleState: "released" },
     ].map((entry) => expect.objectContaining(entry))));
   });
@@ -583,7 +594,7 @@ function configuredRequest(invocationId: string): ManagedAgentInvocationRequest 
       permissionProfile: "read-only",
       toolAuthority: { allowedToolNames: ["read"], writeAllowed: false, networkAllowed: false },
       workingDirectory: { path: "C:/workspace/kiln", mode: "read-only" },
-      timeoutMs: 1000,
+      timeoutMs: 5000,
       credentialRoute: {
         mode: "account-leased",
         routeId: "credential-route:codex-oauth:primary",
@@ -670,6 +681,32 @@ async function writeCodexCredential(
     `${JSON.stringify(token)}\n`,
     "utf8",
   );
+}
+
+function codexCompletedResponse(text: string): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(
+        `event: response.completed\ndata: ${JSON.stringify({
+          response: {
+            id: "synthetic-response",
+            status: "completed",
+            output: [{
+              type: "message",
+              content: [{ type: "output_text", text }],
+            }],
+            usage: { input_tokens: 2, output_tokens: 1 },
+          },
+        })}\n\n`,
+      ));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
 }
 
 function candidate(

--- a/packages/runtime/tests/managed-account-leases/managed-account-invocation.test.ts
+++ b/packages/runtime/tests/managed-account-leases/managed-account-invocation.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +11,7 @@ import {
   type ManagedAccountAffinityPolicy,
   type ManagedAgentCapabilitySnapshot,
   type ManagedAgentInvocationRecord,
+  type CodexOAuthTokenFile,
   type ModelGatewayConfig,
   type ProviderAdapter,
 } from "@kilnai/core";
@@ -22,10 +23,8 @@ import {
 } from "../../src/agents/managed-invocation/index.js";
 import { ManagedDirectProviderRuntimeAdapter } from "../../src/agents/managed-invocation/direct-runtime-adapter.js";
 import {
-  DirectProviderCredentialPoolService,
-  type DirectProviderAuth,
-} from "../../src/agents/credential-pool/direct-provider-credential-pool.js";
-import { CredentialFileStore } from "../../src/agents/credential-pool/credential-file-store.js";
+  CodexOAuthCredentialPoolService,
+} from "../../src/agents/credential-pool/codex-oauth-credential-pool.js";
 import { ConfiguredManagedAccountRuntime } from "../../src/managed-account-leases/configured-managed-account-runtime.js";
 import {
   SqliteManagedAccountLeaseAuthority,
@@ -379,39 +378,24 @@ describe("managed account invocation lifecycle", () => {
     ]);
   });
 
-  it("composes configured two-account projection through binding and never touches a second credential after selection", async () => {
+  it("keeps Codex internal retries account-bound and never touches a second credential after selection", async () => {
     const root = await mkdtemp(join(tmpdir(), "kiln-managed-account-composed-"));
     roots.push(root);
-    const credentialStore = new CredentialFileStore<DirectProviderAuth>({ rootDir: root });
+    const credentialDirectory = join(root, "codex-oauth");
+    await mkdir(credentialDirectory, { recursive: true });
     await Promise.all([
-      credentialStore.writeCredential({
-        providerId: "openai",
-        id: "credential-a",
-        label: "Synthetic A",
-        auth: { apiKey: "synthetic-a" },
-      }),
-      credentialStore.writeCredential({
-        providerId: "openai",
-        id: "credential-b",
-        label: "Synthetic B",
-        auth: { apiKey: "synthetic-b" },
-      }),
-      credentialStore.writeCredential({
-        providerId: "openai",
-        id: "unconfigured",
-        label: "Must remain excluded",
-        auth: { apiKey: "synthetic-unconfigured" },
-      }),
+      writeCodexCredential(credentialDirectory, "credential-a", codexToken("provider-account-a")),
+      writeCodexCredential(credentialDirectory, "credential-b", codexToken("provider-account-b")),
+      writeCodexCredential(credentialDirectory, "unconfigured", codexToken("provider-account-unconfigured")),
     ]);
     const configured = new ConfiguredManagedAccountRuntime({
       config: composedAccountConfig(),
       credentialRootDir: root,
-      env: {},
       now: () => new Date("2026-07-28T20:00:00.000Z"),
     });
     const projected = await configured.resolve({
-      accountPolicyId: "managed-openai",
-      providerRoute: { providerId: "openai", surface: "direct", model: "gpt-test" },
+      accountPolicyId: "managed-codex",
+      providerRoute: { providerId: "codex-oauth", surface: "direct", model: "gpt-test" },
     });
     expect(projected.candidates.map((entry) => entry.capacityIdentity)).toEqual([
       "account-b",
@@ -430,14 +414,14 @@ describe("managed account invocation lifecycle", () => {
     });
     authorities.push(authority);
     const credentialResolutions = vi.spyOn(
-      DirectProviderCredentialPoolService.prototype,
+      CodexOAuthCredentialPoolService.prototype,
       "resolveExecutionCredential",
     );
     const binds: string[] = [];
     const dispatches: string[] = [];
     const service = new RuntimeManagedAgentInvocationService({
       credentialRouteLeaseManager: new ManagedRuntimeCredentialRouteLeaseManager({
-        allowedRouteIds: ["credential-route:openai:primary"],
+        allowedRouteIds: ["credential-route:codex-oauth:primary"],
       }),
       accountLeaseAuthority: authority,
       accountCandidatePort: configured,
@@ -445,12 +429,11 @@ describe("managed account invocation lifecycle", () => {
         bind: async ({ lease, adapter }) => {
           binds.push(lease.accountRef);
           if (lease.jobId === "managed-job-binding-failure") {
-            await credentialStore.writeCredential({
-              providerId: "openai",
-              id: "credential-a",
-              label: "Synthetic A changed",
-              auth: { apiKey: "synthetic-a-revision-changed" },
-            });
+            await writeCodexCredential(
+              credentialDirectory,
+              "credential-a",
+              codexToken("provider-account-a", "revision-changed"),
+            );
           }
           const bound = await configured.bind({ lease, adapter });
           return {
@@ -592,7 +575,7 @@ function configuredRequest(invocationId: string): ManagedAgentInvocationRequest 
     profile: "foundation-readonly-plan",
     requestedBy: "operator",
     requestSource: "managed-job",
-    providerRoute: { providerId: "openai", model: "gpt-test", surface: "direct-provider" },
+    providerRoute: { providerId: "codex-oauth", model: "gpt-test", surface: "direct-provider" },
     adapterKind: "direct",
     executionMode: "direct-provider",
     authority: {
@@ -603,8 +586,8 @@ function configuredRequest(invocationId: string): ManagedAgentInvocationRequest 
       timeoutMs: 1000,
       credentialRoute: {
         mode: "account-leased",
-        routeId: "credential-route:openai:primary",
-        accountPolicyId: "managed-openai",
+        routeId: "credential-route:codex-oauth:primary",
+        accountPolicyId: "managed-codex",
       },
       memoryScope: { scope: { kind: "project", id: "kiln" }, access: "read-only" },
     },
@@ -618,14 +601,14 @@ function composedAccountConfig(): ModelGatewayConfig {
     accounts: [
       {
         id: "account-a",
-        providerId: "openai",
+        providerId: "codex-oauth",
         credentialId: "credential-a",
         maxConcurrency: 1,
         reservedAffinitySlots: 0,
       },
       {
         id: "account-b",
-        providerId: "openai",
+        providerId: "codex-oauth",
         credentialId: "credential-b",
         maxConcurrency: 1,
         reservedAffinitySlots: 0,
@@ -635,8 +618,8 @@ function composedAccountConfig(): ModelGatewayConfig {
     surfaces: { openAIResponses: { maxBodyBytes: 1024, maxConcurrentRequests: 1 } },
     principals: [],
     virtualModels: [{
-      id: "managed-openai",
-      providerId: "openai",
+      id: "managed-codex",
+      providerId: "codex-oauth",
       providerModelId: "gpt-test",
       accountIds: ["account-b", "account-a"],
       capabilities: ["text"],
@@ -656,12 +639,37 @@ function directTemplate(): ManagedDirectProviderRuntimeAdapter {
     },
   };
   return new ManagedDirectProviderRuntimeAdapter({
-    providerId: "openai",
+    providerId: "codex-oauth",
     model: "gpt-test",
     provider,
     tools: [],
     builtinTools: new Map(),
   });
+}
+
+function codexToken(accountId: string, revision = "initial"): CodexOAuthTokenFile {
+  const payload = Buffer.from(JSON.stringify({
+    exp: 4_070_908_800,
+    "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+  })).toString("base64url");
+  return {
+    access_token: `header.${payload}.signature-${revision}`,
+    refresh_token: `synthetic-refresh-${revision}`,
+    expires_at: "2099-01-01T00:00:00.000Z",
+    client_id: "synthetic-client",
+  };
+}
+
+async function writeCodexCredential(
+  directory: string,
+  credentialId: string,
+  token: CodexOAuthTokenFile,
+): Promise<void> {
+  await writeFile(
+    join(directory, `${credentialId}.json`),
+    `${JSON.stringify(token)}\n`,
+    "utf8",
+  );
 }
 
 function candidate(

--- a/packages/runtime/tests/managed-account-leases/managed-account-invocation.test.ts
+++ b/packages/runtime/tests/managed-account-leases/managed-account-invocation.test.ts
@@ -7,8 +7,12 @@ import {
   defineManagedAgentAdapterDescriptor,
   defineManagedAgentInvocationRecord,
   defineManagedAgentInvocationRequest,
+  type ManagedAgentInvocationRequest,
+  type ManagedAccountAffinityPolicy,
   type ManagedAgentCapabilitySnapshot,
   type ManagedAgentInvocationRecord,
+  type ModelGatewayConfig,
+  type ProviderAdapter,
 } from "@kilnai/core";
 import {
   ManagedRuntimeCredentialRouteLeaseManager,
@@ -16,6 +20,13 @@ import {
   RuntimeManagedAgentInvocationService,
   type ManagedAgentRuntimeAdapter,
 } from "../../src/agents/managed-invocation/index.js";
+import { ManagedDirectProviderRuntimeAdapter } from "../../src/agents/managed-invocation/direct-runtime-adapter.js";
+import {
+  DirectProviderCredentialPoolService,
+  type DirectProviderAuth,
+} from "../../src/agents/credential-pool/direct-provider-credential-pool.js";
+import { CredentialFileStore } from "../../src/agents/credential-pool/credential-file-store.js";
+import { ConfiguredManagedAccountRuntime } from "../../src/managed-account-leases/configured-managed-account-runtime.js";
 import {
   SqliteManagedAccountLeaseAuthority,
   type ManagedAccountCandidateBinding,
@@ -65,7 +76,16 @@ describe("managed account invocation lifecycle", () => {
       input.registerExecutionSettlement(settlement);
       return timedOutRecord(input.request, input.admission.capabilitySnapshot);
     });
-    const service = createService(authority, adapter);
+    const boundAccounts: string[] = [];
+    const service = createService(
+      authority,
+      adapter,
+      [],
+      undefined,
+      [candidate("account-a"), candidate("account-b")],
+      { continuity: "none" },
+      boundAccounts,
+    );
 
     const result = await service.invoke(request(), adapter, snapshotInput());
 
@@ -74,12 +94,36 @@ describe("managed account invocation lifecycle", () => {
     expect(result.record.lifecycleState).toBe("timed_out");
     expect(result.record.accountLease?.lifecycleState).toBe("settlement-pending");
     expect(authority.list()[0]?.lifecycleState).toBe("settlement-pending");
+    const other = await service.invoke(
+      request({ invocationId: "managed-job-timeout-other" }),
+      adapter,
+      snapshotInput(),
+    );
+    expect(other.status).toBe("completed");
+    if (other.status !== "completed") throw new Error("expected second timeout projection");
+    expect(other.record.accountLease).toMatchObject({
+      accountRef: "configured:account-b",
+      lifecycleState: "settlement-pending",
+    });
+    await expect(service.start(
+      request({ invocationId: "managed-job-timeout-third" }),
+      adapter,
+      snapshotInput(),
+    )).rejects.toMatchObject({
+      rejections: [
+        { account: "configured:account-a", reason: "lease-conflict" },
+        { account: "configured:account-b", reason: "lease-conflict" },
+      ],
+    });
+    expect(boundAccounts).toEqual(["configured:account-a", "configured:account-b"]);
 
     settle();
     await vi.waitFor(() => {
-      expect(authority.list()[0]?.lifecycleState).toBe("released");
+      expect(authority.list().every((lease) => lease.lifecycleState === "released")).toBe(true);
     });
     expect(service.status("managed-job-0001")?.record?.accountLease?.lifecycleState).toBe("released");
+    expect(service.status("managed-job-timeout-other")?.record?.accountLease?.lifecycleState).toBe("released");
+    expect(authority.list().every((lease) => lease.affinityCommitOutcome === undefined)).toBe(true);
   });
 
   it("retains capacity after cancellation until the registered execution settles", async () => {
@@ -92,7 +136,16 @@ describe("managed account invocation lifecycle", () => {
       input.registerExecutionSettlement(settlement);
       return new Promise<ManagedAgentInvocationRecord>(() => undefined);
     });
-    const service = createService(authority, adapter);
+    const boundAccounts: string[] = [];
+    const service = createService(
+      authority,
+      adapter,
+      [],
+      undefined,
+      [candidate("account-a"), candidate("account-b")],
+      { continuity: "none" },
+      boundAccounts,
+    );
 
     const started = await service.start(request(), adapter, snapshotInput());
     expect(started.status).toBe("started");
@@ -100,11 +153,34 @@ describe("managed account invocation lifecycle", () => {
 
     expect(cancelled.record.accountLease?.lifecycleState).toBe("settlement-pending");
     expect(authority.list()[0]?.lifecycleState).toBe("settlement-pending");
+    const other = await service.start(
+      request({ invocationId: "managed-job-cancel-other" }),
+      adapter,
+      snapshotInput(),
+    );
+    expect(other.status).toBe("started");
+    await expect(service.start(
+      request({ invocationId: "managed-job-cancel-third" }),
+      adapter,
+      snapshotInput(),
+    )).rejects.toMatchObject({
+      rejections: [
+        { account: "configured:account-a", reason: "lease-conflict" },
+        { account: "configured:account-b", reason: "lease-conflict" },
+      ],
+    });
+    const otherCancelled = await service.cancel("managed-job-cancel-other");
+    expect(otherCancelled.record.accountLease).toMatchObject({
+      accountRef: "configured:account-b",
+      lifecycleState: "settlement-pending",
+    });
+    expect(boundAccounts).toEqual(["configured:account-a", "configured:account-b"]);
 
     settle();
     await vi.waitFor(() => {
-      expect(authority.list()[0]?.lifecycleState).toBe("released");
+      expect(authority.list().every((lease) => lease.lifecycleState === "released")).toBe(true);
     });
+    expect(authority.list().every((lease) => lease.affinityCommitOutcome === undefined)).toBe(true);
   });
 
   it("releases a failed provider attempt only after its execution settles", async () => {
@@ -147,6 +223,284 @@ describe("managed account invocation lifecycle", () => {
     expect(authority.list()).toHaveLength(1);
     expect(authority.list()[0]?.lifecycleState).toBe("released");
   });
+
+  it("derives managed affinity from admitted lineage and commits it only after success", async () => {
+    const authority = await createAuthority();
+    const boundAccounts: string[] = [];
+    const adapter = makeAdapter(async (input) => {
+      input.registerExecutionSettlement(Promise.resolve());
+      return completedRecord(input.request, input.admission.capabilitySnapshot);
+    });
+    const candidates = [
+      candidate("account-a", { maxConcurrency: 2, reservedAffinitySlots: 1 }),
+      candidate("account-b"),
+    ];
+    const service = createService(
+      authority,
+      adapter,
+      [],
+      undefined,
+      candidates,
+      { continuity: "prefer", scope: "session", allowRebind: true },
+      boundAccounts,
+    );
+
+    const first = await service.invoke(request({ invocationId: "managed-job-affinity-1" }), adapter, snapshotInput());
+    const second = await service.invoke(request({ invocationId: "managed-job-affinity-2" }), adapter, snapshotInput());
+
+    expect(first.status).toBe("completed");
+    expect(second.status).toBe("completed");
+    if (first.status !== "completed" || second.status !== "completed") throw new Error("expected completions");
+    expect(first.record.accountLease).toMatchObject({
+      accountRef: "configured:account-a",
+      selectionReason: "least-pressure",
+      affinityCommitOutcome: "won",
+    });
+    expect(second.record.accountLease).toMatchObject({
+      accountRef: "configured:account-a",
+      selectionReason: "existing-affinity",
+      affinityOutcome: "honored",
+      affinityCommitOutcome: "already-matched",
+    });
+    const requiredService = createService(
+      authority,
+      adapter,
+      [],
+      undefined,
+      candidates,
+      { continuity: "require", scope: "session" },
+      boundAccounts,
+    );
+    const required = await requiredService.invoke(
+      request({ invocationId: "managed-job-affinity-required" }),
+      adapter,
+      snapshotInput(),
+    );
+    expect(required.status).toBe("completed");
+    if (required.status !== "completed") throw new Error("expected required affinity completion");
+    expect(required.record.accountLease).toMatchObject({
+      accountRef: "configured:account-a",
+      selectionReason: "existing-affinity",
+      affinityOutcome: "honored",
+      affinityCommitOutcome: "already-matched",
+    });
+    await expect(requiredService.start(
+      request({
+        invocationId: "managed-job-affinity-required-new-lineage",
+        parentSessionId: "different-parent-session",
+      }),
+      adapter,
+      snapshotInput(),
+    )).rejects.toMatchObject({ rejections: [] });
+    expect(boundAccounts).toEqual([
+      "configured:account-a",
+      "configured:account-a",
+      "configured:account-a",
+    ]);
+  });
+
+  it("preserves provider success and the winning mapping when concurrent first affinity commits conflict", async () => {
+    const authority = await createAuthority();
+    const completions = new Map<string, {
+      readonly resolve: (record: ManagedAgentInvocationRecord) => void;
+      readonly snapshot: ManagedAgentCapabilitySnapshot;
+    }>();
+    const adapter = makeAdapter((input) => {
+      const execution = new Promise<ManagedAgentInvocationRecord>((resolve) => {
+        completions.set(input.request.invocationId, {
+          resolve,
+          snapshot: input.admission.capabilitySnapshot,
+        });
+      });
+      input.registerExecutionSettlement(execution);
+      return execution;
+    });
+    const boundAccounts: string[] = [];
+    const service = createService(
+      authority,
+      adapter,
+      [],
+      undefined,
+      [candidate("account-a"), candidate("account-b")],
+      { continuity: "prefer", scope: "session" },
+      boundAccounts,
+    );
+    const firstRequest = request({ invocationId: "managed-job-affinity-conflict-a" });
+    const secondRequest = request({ invocationId: "managed-job-affinity-conflict-b" });
+
+    await service.start(firstRequest, adapter, snapshotInput());
+    await service.start(secondRequest, adapter, snapshotInput());
+    expect(boundAccounts).toEqual(["configured:account-a", "configured:account-b"]);
+
+    const secondCompletion = completions.get(secondRequest.invocationId);
+    if (!secondCompletion) throw new Error("second execution did not start");
+    secondCompletion.resolve(completedRecord(secondRequest, secondCompletion.snapshot));
+    await vi.waitFor(() => {
+      expect(service.status(secondRequest.invocationId)?.record).toMatchObject({
+        lifecycleState: "completed",
+        accountLease: {
+          accountRef: "configured:account-b",
+          affinityCommitOutcome: "won",
+          lifecycleState: "released",
+        },
+      });
+    });
+
+    const firstCompletion = completions.get(firstRequest.invocationId);
+    if (!firstCompletion) throw new Error("first execution did not start");
+    firstCompletion.resolve(completedRecord(firstRequest, firstCompletion.snapshot));
+    await vi.waitFor(() => {
+      expect(service.status(firstRequest.invocationId)?.record).toMatchObject({
+        lifecycleState: "completed",
+        accountLease: {
+          accountRef: "configured:account-a",
+          affinityCommitOutcome: "conflict",
+          lifecycleState: "released",
+        },
+      });
+    });
+    const continuedRequest = request({ invocationId: "managed-job-affinity-winner-check" });
+    await service.start(continuedRequest, adapter, snapshotInput());
+    const continuedCompletion = completions.get(continuedRequest.invocationId);
+    if (!continuedCompletion) throw new Error("continued execution did not start");
+    continuedCompletion.resolve(completedRecord(continuedRequest, continuedCompletion.snapshot));
+    await vi.waitFor(() => {
+      expect(service.status(continuedRequest.invocationId)?.record?.accountLease).toMatchObject({
+        accountRef: "configured:account-b",
+        selectionReason: "existing-affinity",
+        affinityOutcome: "honored",
+        lifecycleState: "released",
+      });
+    });
+    expect(boundAccounts).toEqual([
+      "configured:account-a",
+      "configured:account-b",
+      "configured:account-b",
+    ]);
+  });
+
+  it("composes configured two-account projection through binding and never touches a second credential after selection", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kiln-managed-account-composed-"));
+    roots.push(root);
+    const credentialStore = new CredentialFileStore<DirectProviderAuth>({ rootDir: root });
+    await Promise.all([
+      credentialStore.writeCredential({
+        providerId: "openai",
+        id: "credential-a",
+        label: "Synthetic A",
+        auth: { apiKey: "synthetic-a" },
+      }),
+      credentialStore.writeCredential({
+        providerId: "openai",
+        id: "credential-b",
+        label: "Synthetic B",
+        auth: { apiKey: "synthetic-b" },
+      }),
+      credentialStore.writeCredential({
+        providerId: "openai",
+        id: "unconfigured",
+        label: "Must remain excluded",
+        auth: { apiKey: "synthetic-unconfigured" },
+      }),
+    ]);
+    const configured = new ConfiguredManagedAccountRuntime({
+      config: composedAccountConfig(),
+      credentialRootDir: root,
+      env: {},
+      now: () => new Date("2026-07-28T20:00:00.000Z"),
+    });
+    const projected = await configured.resolve({
+      accountPolicyId: "managed-openai",
+      providerRoute: { providerId: "openai", surface: "direct", model: "gpt-test" },
+    });
+    expect(projected.candidates.map((entry) => entry.capacityIdentity)).toEqual([
+      "account-b",
+      "account-a",
+    ]);
+    expect(JSON.stringify(projected.candidates)).not.toContain("unconfigured");
+    expect(JSON.stringify(projected.candidates)).not.toContain("synthetic-");
+    const accountARef = projected.candidates.find((entry) =>
+      entry.capacityIdentity === "account-a")?.candidate.account;
+    if (!accountARef) throw new Error("configured account A was not projected");
+
+    const authority = new SqliteManagedAccountLeaseAuthority({
+      path: join(root, "leases.sqlite"),
+      ownerId: "runtime-owner",
+      now: () => Date.parse("2026-07-28T20:00:00.000Z"),
+    });
+    authorities.push(authority);
+    const credentialResolutions = vi.spyOn(
+      DirectProviderCredentialPoolService.prototype,
+      "resolveExecutionCredential",
+    );
+    const binds: string[] = [];
+    const dispatches: string[] = [];
+    const service = new RuntimeManagedAgentInvocationService({
+      credentialRouteLeaseManager: new ManagedRuntimeCredentialRouteLeaseManager({
+        allowedRouteIds: ["credential-route:openai:primary"],
+      }),
+      accountLeaseAuthority: authority,
+      accountCandidatePort: configured,
+      accountExecutionBindingPort: {
+        bind: async ({ lease, adapter }) => {
+          binds.push(lease.accountRef);
+          if (lease.jobId === "managed-job-binding-failure") {
+            await credentialStore.writeCredential({
+              providerId: "openai",
+              id: "credential-a",
+              label: "Synthetic A changed",
+              auth: { apiKey: "synthetic-a-revision-changed" },
+            });
+          }
+          const bound = await configured.bind({ lease, adapter });
+          return {
+            descriptor: bound.descriptor,
+            invoke: vi.fn(async (input) => {
+              dispatches.push(lease.accountRef);
+              input.registerExecutionSettlement(Promise.resolve());
+              return failedRecord(input.request, input.admission.capabilitySnapshot);
+            }),
+          };
+        },
+      },
+    });
+
+    const providerFailure = await service.invoke(
+      configuredRequest("managed-job-provider-failure"),
+      directTemplate(),
+      snapshotInput(),
+    );
+    expect(providerFailure.status).toBe("completed");
+    if (providerFailure.status !== "completed") throw new Error("expected provider failure projection");
+    expect(providerFailure.record).toMatchObject({
+      lifecycleState: "failed",
+      accountLease: {
+        accountRef: accountARef,
+        lifecycleState: "released",
+      },
+    });
+    expect(credentialResolutions.mock.calls.map(([selected]) => selected.credentialId)).toEqual([
+      "credential-a",
+    ]);
+    expect(binds).toEqual([accountARef]);
+    expect(dispatches).toEqual([accountARef]);
+
+    await expect(service.start(
+      configuredRequest("managed-job-binding-failure"),
+      directTemplate(),
+      snapshotInput(),
+    )).rejects.toThrow("revision changed");
+    expect(credentialResolutions.mock.calls.map(([selected]) => selected.credentialId)).toEqual([
+      "credential-a",
+    ]);
+    expect(binds).toHaveLength(2);
+    expect(binds[1]).toMatch(/^configured:account-a:/);
+    expect(dispatches).toEqual([accountARef]);
+    expect(authority.list()).toEqual(expect.arrayContaining([
+      { jobId: "managed-job-provider-failure", lifecycleState: "released" },
+      { jobId: "managed-job-binding-failure", lifecycleState: "released" },
+    ].map((entry) => expect.objectContaining(entry))));
+  });
 });
 
 async function createAuthority(): Promise<SqliteManagedAccountLeaseAuthority> {
@@ -166,27 +520,9 @@ function createService(
   boundAdapter: ManagedAgentRuntimeAdapter,
   events: string[] = [],
   bindingFailure?: Error,
-  candidates: readonly ManagedAccountCandidateBinding[] = [{
-    candidate: {
-      account: createAccountRef("configured:account-a"),
-      route: {
-        providerId: "opencode",
-        providerModelId: "sonic",
-        scope: "virtual:managed-opencode",
-      },
-      health: "healthy",
-      leaseCapacity: "available",
-      pressure: 0,
-      reservedForNewWork: false,
-    },
-    capacityIdentity: "account-a",
-    credentialRevisionId: "a".repeat(64),
-    usageEvidence: {
-      health: "healthy",
-      freshness: "missing",
-    },
-    capacity: { maxConcurrency: 1, reservedAffinitySlots: 0 },
-  }],
+  candidates: readonly ManagedAccountCandidateBinding[] = [candidate("account-a")],
+  affinityPolicy: ManagedAccountAffinityPolicy = { continuity: "none" },
+  boundAccounts?: string[],
 ): RuntimeManagedAgentInvocationService {
   return new RuntimeManagedAgentInvocationService({
     credentialRouteLeaseManager: new ManagedRuntimeCredentialRouteLeaseManager({
@@ -202,13 +538,15 @@ function createService(
             providerModelId: "sonic",
             scope: "virtual:managed-opencode",
           },
+          affinityPolicy,
           candidates,
         };
       },
     },
     accountExecutionBindingPort: {
-      bind: async () => {
+      bind: async ({ lease }) => {
         events.push("bind");
+        boundAccounts?.push(lease.accountRef);
         if (bindingFailure) throw bindingFailure;
         return boundAdapter;
       },
@@ -216,12 +554,12 @@ function createService(
   });
 }
 
-function request() {
+function request(overrides: { readonly invocationId?: string; readonly parentSessionId?: string; readonly parentTurnId?: string } = {}) {
   return defineManagedAgentInvocationRequest({
-    invocationId: "managed-job-0001",
+    invocationId: overrides.invocationId ?? "managed-job-0001",
     agentId: "reviewer",
-    parentSessionId: "parent-session",
-    parentTurnId: "parent-turn",
+    parentSessionId: overrides.parentSessionId ?? "parent-session",
+    parentTurnId: overrides.parentTurnId ?? "parent-turn",
     profile: "foundation-readonly-plan",
     requestedBy: "operator",
     requestSource: "managed-job",
@@ -243,6 +581,117 @@ function request() {
     },
     input: { summary: "Inspect the project." },
   });
+}
+
+function configuredRequest(invocationId: string): ManagedAgentInvocationRequest {
+  return defineManagedAgentInvocationRequest({
+    invocationId,
+    agentId: "reviewer",
+    parentSessionId: "parent-session",
+    parentTurnId: "parent-turn",
+    profile: "foundation-readonly-plan",
+    requestedBy: "operator",
+    requestSource: "managed-job",
+    providerRoute: { providerId: "openai", model: "gpt-test", surface: "direct-provider" },
+    adapterKind: "direct",
+    executionMode: "direct-provider",
+    authority: {
+      authorityProfileId: "foundation-readonly",
+      permissionProfile: "read-only",
+      toolAuthority: { allowedToolNames: ["read"], writeAllowed: false, networkAllowed: false },
+      workingDirectory: { path: "C:/workspace/kiln", mode: "read-only" },
+      timeoutMs: 1000,
+      credentialRoute: {
+        mode: "account-leased",
+        routeId: "credential-route:openai:primary",
+        accountPolicyId: "managed-openai",
+      },
+      memoryScope: { scope: { kind: "project", id: "kiln" }, access: "read-only" },
+    },
+    input: { summary: "Inspect the project." },
+  });
+}
+
+function composedAccountConfig(): ModelGatewayConfig {
+  return {
+    port: 4819,
+    accounts: [
+      {
+        id: "account-a",
+        providerId: "openai",
+        credentialId: "credential-a",
+        maxConcurrency: 1,
+        reservedAffinitySlots: 0,
+      },
+      {
+        id: "account-b",
+        providerId: "openai",
+        credentialId: "credential-b",
+        maxConcurrency: 1,
+        reservedAffinitySlots: 0,
+      },
+    ],
+    replay: { ttlMs: 60_000, maxEntries: 10, hmacKeyEnv: "REPLAY_SECRET" },
+    surfaces: { openAIResponses: { maxBodyBytes: 1024, maxConcurrentRequests: 1 } },
+    principals: [],
+    virtualModels: [{
+      id: "managed-openai",
+      providerId: "openai",
+      providerModelId: "gpt-test",
+      accountIds: ["account-b", "account-a"],
+      capabilities: ["text"],
+      affinity: { continuity: "prefer", scope: "session", allowRebind: true },
+    }],
+  };
+}
+
+function directTemplate(): ManagedDirectProviderRuntimeAdapter {
+  const provider: ProviderAdapter = {
+    name: "unbound",
+    createMessage: async () => {
+      throw new Error("unbound");
+    },
+    streamMessage: async function* () {
+      throw new Error("unbound");
+    },
+  };
+  return new ManagedDirectProviderRuntimeAdapter({
+    providerId: "openai",
+    model: "gpt-test",
+    provider,
+    tools: [],
+    builtinTools: new Map(),
+  });
+}
+
+function candidate(
+  accountId: string,
+  capacity: { readonly maxConcurrency: number; readonly reservedAffinitySlots: number } = {
+    maxConcurrency: 1,
+    reservedAffinitySlots: 0,
+  },
+): ManagedAccountCandidateBinding {
+  return {
+    candidate: {
+      account: createAccountRef(`configured:${accountId}`),
+      route: {
+        providerId: "opencode",
+        providerModelId: "sonic",
+        scope: "virtual:managed-opencode",
+      },
+      health: "healthy",
+      leaseCapacity: "available",
+      pressure: 0,
+      reservedForNewWork: false,
+    },
+    capacityIdentity: accountId,
+    credentialRevisionId: accountId === "account-a" ? "a".repeat(64) : "b".repeat(64),
+    usageEvidence: {
+      health: "healthy",
+      freshness: "missing",
+    },
+    capacity,
+  };
 }
 
 function makeAdapter(
@@ -292,28 +741,28 @@ function snapshotInput() {
 }
 
 function completedRecord(
-  managedRequest: ReturnType<typeof request>,
+  managedRequest: ManagedAgentInvocationRequest,
   capabilitySnapshot: ManagedAgentCapabilitySnapshot,
 ): ManagedAgentInvocationRecord {
   return record(managedRequest, capabilitySnapshot, "completed");
 }
 
 function timedOutRecord(
-  managedRequest: ReturnType<typeof request>,
+  managedRequest: ManagedAgentInvocationRequest,
   capabilitySnapshot: ManagedAgentCapabilitySnapshot,
 ): ManagedAgentInvocationRecord {
   return record(managedRequest, capabilitySnapshot, "timed_out");
 }
 
 function failedRecord(
-  managedRequest: ReturnType<typeof request>,
+  managedRequest: ManagedAgentInvocationRequest,
   capabilitySnapshot: ManagedAgentCapabilitySnapshot,
 ): ManagedAgentInvocationRecord {
   return record(managedRequest, capabilitySnapshot, "failed");
 }
 
 function record(
-  managedRequest: ReturnType<typeof request>,
+  managedRequest: ManagedAgentInvocationRequest,
   capabilitySnapshot: ManagedAgentCapabilitySnapshot,
   lifecycleState: "completed" | "timed_out" | "failed",
 ): ManagedAgentInvocationRecord {

--- a/packages/runtime/tests/managed-account-leases/managed-account-lease-authority.test.ts
+++ b/packages/runtime/tests/managed-account-leases/managed-account-lease-authority.test.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createAccountPolicyId,
   createAccountRef,
+  createManagedAccountAffinityKey,
+  type ManagedAccountAffinityKey,
   type ModelGatewayRoute,
 } from "@kilnai/core";
 import {
@@ -82,27 +85,29 @@ describe("SqliteManagedAccountLeaseAuthority", () => {
     jobId: string,
     candidates: readonly ManagedAccountCandidateBinding[],
     overrides: {
-      readonly work?: "new" | "existing";
-      readonly affinityAccount?: string;
-      readonly allowAffinityRebind?: boolean;
+      readonly affinity?: {
+        readonly continuity: "prefer" | "require";
+        readonly key: ManagedAccountAffinityKey;
+        readonly scope?: "session" | "turn";
+        readonly allowRebind?: boolean;
+      };
     } = {},
   ) => authority.acquire({
     accountPolicyId: policyId,
     route,
     jobId,
     runtimeInvocationId: `invocation-${jobId}`,
-    work: overrides.work ?? "new",
-    ...(overrides.affinityAccount
+    affinityRequest: overrides.affinity
       ? {
-          affinity: {
-            account: createAccountRef(`configured:${overrides.affinityAccount}`),
-            route,
-          },
+          ...overrides.affinity,
+          scope: overrides.affinity.scope ?? "session",
         }
-      : {}),
-    ...(overrides.allowAffinityRebind === true ? { allowAffinityRebind: true } : {}),
+      : { continuity: "none" },
     candidates,
   });
+
+  const affinityKey = (suffix: string) =>
+    createManagedAccountAffinityKey(suffix.repeat(64).slice(0, 64));
 
   it("serializes concurrent acquisition and enforces max concurrency", async () => {
     const authority = create("owner-a");
@@ -191,15 +196,23 @@ describe("SqliteManagedAccountLeaseAuthority", () => {
 
   it("preserves reserved affinity slots for existing work", async () => {
     const authority = create("owner-a");
+    const key = affinityKey("a");
     const reserved = binding("account-a", {
       capacity: { maxConcurrency: 2, reservedAffinitySlots: 1 },
     });
+    const bootstrap = await acquire(authority, "bootstrap", [reserved], {
+      affinity: { continuity: "prefer", key },
+    });
+    if (bootstrap.status !== "acquired") throw new Error("fixture");
+    authority.finalizeSuccessful(bootstrap.identity);
 
     await expect(acquire(authority, "new-a", [reserved])).resolves.toMatchObject({ status: "acquired" });
     await expect(acquire(authority, "new-b", [reserved])).resolves.toMatchObject({ status: "unavailable" });
     await expect(acquire(authority, "existing", [reserved], {
-      work: "existing",
-      affinityAccount: "account-a",
+      affinity: {
+        continuity: "prefer",
+        key,
+      },
     })).resolves.toMatchObject({
       status: "acquired",
       lease: {
@@ -209,20 +222,77 @@ describe("SqliteManagedAccountLeaseAuthority", () => {
     });
   });
 
+  it("atomically fills two accounts, rejects a third, and restores only the released slot", async () => {
+    const authority = create("owner-a");
+    const candidates = [binding("account-b"), binding("account-a")];
+    const acquired = await Promise.all([
+      acquire(authority, "job-a", candidates),
+      acquire(authority, "job-b", candidates),
+    ]);
+    const leases = acquired.flatMap((result) =>
+      result.status === "acquired" ? [result] : []);
+
+    expect(leases.map((result) => result.lease.accountRef).sort()).toEqual([
+      "configured:account-a",
+      "configured:account-b",
+    ]);
+    clockMs += 60_000;
+    await expect(acquire(authority, "job-c", candidates)).resolves.toMatchObject({
+      status: "unavailable",
+      rejections: [
+        { account: "configured:account-a", reason: "lease-conflict" },
+        { account: "configured:account-b", reason: "lease-conflict" },
+      ],
+    });
+
+    const released = leases.find((result) =>
+      result.lease.accountRef === "configured:account-a");
+    if (!released) throw new Error("fixture");
+    const firstRelease = authority.release(released.identity);
+    expect(authority.release(released.identity)).toEqual(firstRelease);
+    await expect(acquire(authority, "job-d", candidates)).resolves.toMatchObject({
+      status: "acquired",
+      lease: {
+        accountRef: "configured:account-a",
+        candidateRejections: [{
+          account: "configured:account-b",
+          reason: "lease-conflict",
+        }],
+      },
+    });
+    await expect(acquire(authority, "job-e", candidates)).resolves.toMatchObject({
+      status: "unavailable",
+      rejections: [
+        { account: "configured:account-a", reason: "lease-conflict" },
+        { account: "configured:account-b", reason: "lease-conflict" },
+      ],
+    });
+  });
+
   it("never lets existing affinity exceed total account concurrency", async () => {
     const authority = create("owner-a");
+    const key = affinityKey("a");
     const bounded = binding("account-a", {
       capacity: { maxConcurrency: 2, reservedAffinitySlots: 1 },
     });
+    const bootstrap = await acquire(authority, "bootstrap", [bounded], {
+      affinity: { continuity: "prefer", key },
+    });
+    if (bootstrap.status !== "acquired") throw new Error("fixture");
+    authority.finalizeSuccessful(bootstrap.identity);
 
     await expect(acquire(authority, "new", [bounded])).resolves.toMatchObject({ status: "acquired" });
     await expect(acquire(authority, "existing-a", [bounded], {
-      work: "existing",
-      affinityAccount: "account-a",
+      affinity: {
+        continuity: "prefer",
+        key,
+      },
     })).resolves.toMatchObject({ status: "acquired" });
     await expect(acquire(authority, "existing-b", [bounded], {
-      work: "existing",
-      affinityAccount: "account-a",
+      affinity: {
+        continuity: "prefer",
+        key,
+      },
     })).resolves.toMatchObject({
       status: "unavailable",
       rejections: [{ account: "configured:account-a", reason: "lease-conflict" }],
@@ -231,23 +301,206 @@ describe("SqliteManagedAccountLeaseAuthority", () => {
 
   it("requires explicit affinity rebind and records the rebound", async () => {
     const authority = create("owner-a");
-    const candidates = [binding("account-b")];
+    const key = affinityKey("a");
+    const initial = await acquire(authority, "initial", [binding("account-a")], {
+      affinity: { continuity: "prefer", key },
+    });
+    if (initial.status !== "acquired") throw new Error("fixture");
+    authority.finalizeSuccessful(initial.identity);
+    const candidates = [
+      binding("account-a", {
+        candidate: {
+          account: createAccountRef("configured:account-a"),
+          route,
+          health: "unhealthy",
+          leaseCapacity: "available",
+          pressure: 0,
+          reservedForNewWork: false,
+        },
+      }),
+      binding("account-b"),
+    ];
 
     await expect(acquire(authority, "strict", candidates, {
-      work: "existing",
-      affinityAccount: "account-a",
+      affinity: { continuity: "prefer", key },
     })).resolves.toMatchObject({ status: "unavailable" });
     await expect(acquire(authority, "rebound", candidates, {
-      work: "existing",
-      affinityAccount: "account-a",
-      allowAffinityRebind: true,
+      affinity: {
+        continuity: "prefer",
+        key,
+        allowRebind: true,
+      },
     })).resolves.toMatchObject({
       status: "acquired",
       lease: {
         accountRef: "configured:account-b",
         selectionReason: "affinity-rebind",
         affinityOutcome: "rebound",
+        candidateRejections: [{
+          account: "configured:account-a",
+          reason: "unhealthy",
+        }],
       },
+    });
+  });
+
+  it("fails closed for required affinity without a durable mapping", async () => {
+    const authority = create("owner-a");
+
+    await expect(acquire(authority, "required", [binding("account-a")], {
+      affinity: {
+        continuity: "require",
+        key: affinityKey("a"),
+      },
+    })).resolves.toEqual({
+      status: "unavailable",
+      rejections: [],
+    });
+    expect(authority.list()).toEqual([]);
+  });
+
+  it("resolves durable affinity by stable capacity identity after credential revision", async () => {
+    const authority = create("owner-a");
+    const key = affinityKey("a");
+    const initial = await acquire(authority, "initial", [binding("account-a")], {
+      affinity: { continuity: "prefer", key },
+    });
+    if (initial.status !== "acquired") throw new Error("fixture");
+    authority.finalizeSuccessful(initial.identity);
+    const refreshed = binding("account-a-revision-2", {
+      capacityIdentity: "account-a",
+      credentialRevisionId: "c".repeat(64),
+    });
+
+    await expect(acquire(authority, "continued", [refreshed], {
+      affinity: { continuity: "require", key },
+    })).resolves.toMatchObject({
+      status: "acquired",
+      lease: {
+        accountRef: "configured:account-a-revision-2",
+        credentialRevisionId: "c".repeat(64),
+        selectionReason: "existing-affinity",
+        affinityOutcome: "honored",
+      },
+    });
+  });
+
+  it("atomically commits first binding and records won, already-matched, and conflict", async () => {
+    const authority = create("owner-a");
+    const candidates = [
+      binding("account-a", { capacity: { maxConcurrency: 3, reservedAffinitySlots: 0 } }),
+      binding("account-b", { capacity: { maxConcurrency: 3, reservedAffinitySlots: 0 } }),
+    ];
+    const wonKey = affinityKey("a");
+    const won = await acquire(authority, "won", [candidates[0]!], {
+      affinity: { continuity: "prefer", key: wonKey },
+    });
+    const matched = await acquire(authority, "matched", [candidates[0]!], {
+      affinity: { continuity: "prefer", key: wonKey },
+    });
+    const conflict = await acquire(authority, "conflict", [candidates[1]!], {
+      affinity: { continuity: "prefer", key: wonKey },
+    });
+    if (won.status !== "acquired" || matched.status !== "acquired" || conflict.status !== "acquired") {
+      throw new Error("fixture");
+    }
+
+    const wonFinalization = authority.finalizeSuccessful(won.identity);
+    expect(wonFinalization).toMatchObject({
+      affinityCommitOutcome: "won",
+      lease: { lifecycleState: "released", affinityCommitOutcome: "won" },
+    });
+    expect(authority.finalizeSuccessful(won.identity)).toEqual(wonFinalization);
+    expect(authority.finalizeSuccessful(matched.identity)).toMatchObject({
+      affinityCommitOutcome: "already-matched",
+      lease: { lifecycleState: "released", affinityCommitOutcome: "already-matched" },
+    });
+    expect(authority.finalizeSuccessful(conflict.identity)).toMatchObject({
+      affinityCommitOutcome: "conflict",
+      lease: { lifecycleState: "released", affinityCommitOutcome: "conflict" },
+    });
+
+    await expect(acquire(authority, "winner-check", candidates, {
+      affinity: { continuity: "require", key: wonKey },
+    })).resolves.toMatchObject({
+      status: "acquired",
+      lease: {
+        accountRef: "configured:account-a",
+        selectionReason: "existing-affinity",
+        affinityOutcome: "honored",
+      },
+    });
+  });
+
+  it("rolls back release when affinity persistence fails", async () => {
+    const authority = create("owner-a");
+    const acquired = await acquire(authority, "job-a", [binding("account-a")], {
+      affinity: { continuity: "prefer", key: affinityKey("a") },
+    });
+    if (acquired.status !== "acquired" || !root) throw new Error("fixture");
+    const blocker = new Database(join(root, "leases.sqlite"), { strict: true });
+    blocker.exec(`
+      CREATE TRIGGER reject_affinity_insert
+      BEFORE INSERT ON managed_account_affinities
+      BEGIN
+        SELECT RAISE(ABORT, 'synthetic affinity persistence failure');
+      END;
+    `);
+    blocker.close();
+
+    expect(() => authority.finalizeSuccessful(acquired.identity))
+      .toThrow("synthetic affinity persistence failure");
+    expect(authority.get(acquired.identity.leaseId)).toMatchObject({
+      lifecycleState: "held",
+    });
+    await expect(acquire(authority, "job-b", [binding("account-a")]))
+      .resolves.toMatchObject({ status: "unavailable" });
+  });
+
+  it("migrates a Slice 1 database before acquiring and finalizing affinity", async () => {
+    if (!root) throw new Error("fixture");
+    const path = join(root, "leases.sqlite");
+    const legacy = new Database(path, { create: true, strict: true });
+    legacy.exec(`
+      CREATE TABLE runtime_owner (
+        singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+        owner_id TEXT NOT NULL,
+        heartbeat INTEGER NOT NULL
+      );
+      CREATE TABLE account_leases (
+        lease_id TEXT PRIMARY KEY,
+        account_policy_id TEXT NOT NULL,
+        account_ref TEXT NOT NULL,
+        capacity_identity TEXT NOT NULL,
+        provider_id TEXT NOT NULL,
+        model_id TEXT NOT NULL,
+        route_scope TEXT NOT NULL,
+        job_id TEXT NOT NULL UNIQUE,
+        runtime_invocation_id TEXT NOT NULL UNIQUE,
+        credential_revision_id TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        acquired_at TEXT NOT NULL,
+        lifecycle_state TEXT NOT NULL,
+        released_at TEXT,
+        selection_reason TEXT NOT NULL,
+        candidate_rejections TEXT NOT NULL,
+        affinity_outcome TEXT,
+        purpose TEXT NOT NULL,
+        resource_uris TEXT NOT NULL,
+        diagnostic_uris TEXT NOT NULL
+      );
+    `);
+    legacy.close();
+
+    const authority = create("owner-a");
+    const acquired = await acquire(authority, "job-a", [binding("account-a")], {
+      affinity: { continuity: "prefer", key: affinityKey("a") },
+    });
+    if (acquired.status !== "acquired") throw new Error("fixture");
+
+    expect(authority.finalizeSuccessful(acquired.identity)).toMatchObject({
+      affinityCommitOutcome: "won",
+      lease: { lifecycleState: "released" },
     });
   });
 
@@ -262,6 +515,8 @@ describe("SqliteManagedAccountLeaseAuthority", () => {
       diagnosticUri: `kiln://managed-accounts/leases/${acquired.identity.leaseId}/settlement-pending`,
     });
     expect(pending.lifecycleState).toBe("settlement-pending");
+    expect(() => authority.finalizeSuccessful(acquired.identity))
+      .toThrow("successful finalization requires held state");
     await expect(acquire(authority, "job-b", candidates)).resolves.toMatchObject({ status: "unavailable" });
 
     clockMs += 1000;
@@ -325,6 +580,56 @@ describe("SqliteManagedAccountLeaseAuthority", () => {
       lifecycleState: "settlement-pending",
     }]);
     await expect(acquire(restarted, "job-b", candidates)).resolves.toMatchObject({ status: "unavailable" });
+  });
+
+  it("recovers two occupied accounts without erasing or merging their lifecycle evidence", async () => {
+    const first = create("owner-a");
+    const candidates = [binding("account-a"), binding("account-b")];
+    const pending = await acquire(first, "job-pending", candidates);
+    const failed = await acquire(first, "job-release-failed", candidates);
+    if (pending.status !== "acquired" || failed.status !== "acquired") throw new Error("fixture");
+    first.markSettlementPending({
+      ...pending.identity,
+      diagnosticUri: `kiln://managed-accounts/leases/${pending.identity.leaseId}/settlement-pending`,
+    });
+    first.recordReleaseFailure({
+      ...failed.identity,
+      diagnosticUri: `kiln://managed-accounts/leases/${failed.identity.leaseId}/release-failed`,
+    });
+    first.close();
+    authorities.splice(authorities.indexOf(first), 1);
+
+    clockMs += 2000;
+    const restarted = create("owner-b");
+    const recovered = restarted.recover({
+      reconcilableRuntimeInvocationIds: [failed.identity.runtimeInvocationId],
+      settlementPendingRuntimeInvocationIds: [pending.identity.runtimeInvocationId],
+    });
+
+    expect(recovered).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        leaseId: pending.identity.leaseId,
+        accountRef: pending.identity.accountRef,
+        lifecycleState: "settlement-pending",
+        diagnosticUris: expect.arrayContaining([
+          expect.stringContaining("settlement-pending"),
+          expect.stringContaining("settlement-unknown"),
+        ]),
+      }),
+      expect.objectContaining({
+        leaseId: failed.identity.leaseId,
+        accountRef: failed.identity.accountRef,
+        lifecycleState: "release-failed",
+        diagnosticUris: [expect.stringContaining("release-failed")],
+      }),
+    ]));
+    await expect(acquire(restarted, "job-after-recovery", candidates)).resolves.toMatchObject({
+      status: "unavailable",
+      rejections: [
+        { account: "configured:account-a", reason: "lease-conflict" },
+        { account: "configured:account-b", reason: "lease-conflict" },
+      ],
+    });
   });
 
   it("classifies unmatchable recovered work as leaked and keeps capacity unavailable", async () => {

--- a/packages/runtime/tests/managed-account-leases/managed-account-lease-authority.test.ts
+++ b/packages/runtime/tests/managed-account-leases/managed-account-lease-authority.test.ts
@@ -344,6 +344,62 @@ describe("SqliteManagedAccountLeaseAuthority", () => {
     });
   });
 
+  it("treats a missing mapped account as existing work so explicit rebind can use reserved capacity", async () => {
+    const authority = create("owner-a");
+    const key = affinityKey("a");
+    const initial = await acquire(authority, "initial", [binding("account-a")], {
+      affinity: { continuity: "prefer", key },
+    });
+    if (initial.status !== "acquired") throw new Error("fixture");
+    authority.finalizeSuccessful(initial.identity);
+    const replacement = binding("account-b", {
+      capacity: { maxConcurrency: 2, reservedAffinitySlots: 1 },
+    });
+
+    await expect(acquire(authority, "new", [replacement])).resolves.toMatchObject({
+      status: "acquired",
+    });
+    await expect(acquire(authority, "strict", [replacement], {
+      affinity: { continuity: "prefer", key },
+    })).resolves.toMatchObject({
+      status: "unavailable",
+      affinity: {
+        outcome: "missing",
+        reason: "missing-affinity-account",
+      },
+    });
+    const rebound = await acquire(authority, "rebound", [replacement], {
+      affinity: {
+        continuity: "prefer",
+        key,
+        allowRebind: true,
+      },
+    });
+    expect(rebound).toMatchObject({
+      status: "acquired",
+      lease: {
+        accountRef: "configured:account-b",
+        selectionReason: "affinity-rebind",
+        affinityOutcome: "rebound",
+      },
+    });
+    if (rebound.status !== "acquired") throw new Error("fixture");
+    expect(authority.finalizeSuccessful(rebound.identity)).toMatchObject({
+      affinityCommitOutcome: "won",
+      lease: { lifecycleState: "released", affinityCommitOutcome: "won" },
+    });
+    await expect(acquire(authority, "required-after-rebind", [replacement], {
+      affinity: { continuity: "require", key },
+    })).resolves.toMatchObject({
+      status: "acquired",
+      lease: {
+        accountRef: "configured:account-b",
+        selectionReason: "existing-affinity",
+        affinityOutcome: "honored",
+      },
+    });
+  });
+
   it("fails closed for required affinity without a durable mapping", async () => {
     const authority = create("owner-a");
 
@@ -428,6 +484,43 @@ describe("SqliteManagedAccountLeaseAuthority", () => {
         accountRef: "configured:account-a",
         selectionReason: "existing-affinity",
         affinityOutcome: "honored",
+      },
+    });
+  });
+
+  it("fences concurrent rebind finalization against the exact previously observed identity", async () => {
+    const authority = create("owner-a");
+    const key = affinityKey("a");
+    const initial = await acquire(authority, "initial", [binding("account-a")], {
+      affinity: { continuity: "prefer", key },
+    });
+    if (initial.status !== "acquired") throw new Error("fixture");
+    authority.finalizeSuccessful(initial.identity);
+    const accountB = binding("account-b");
+    const accountC = binding("account-c");
+    const first = await acquire(authority, "rebind-b", [accountB], {
+      affinity: { continuity: "prefer", key, allowRebind: true },
+    });
+    const second = await acquire(authority, "rebind-c", [accountC], {
+      affinity: { continuity: "prefer", key, allowRebind: true },
+    });
+    if (first.status !== "acquired" || second.status !== "acquired") throw new Error("fixture");
+
+    expect(authority.finalizeSuccessful(first.identity)).toMatchObject({
+      affinityCommitOutcome: "won",
+      lease: { accountRef: "configured:account-b", lifecycleState: "released" },
+    });
+    expect(authority.finalizeSuccessful(second.identity)).toMatchObject({
+      affinityCommitOutcome: "conflict",
+      lease: { accountRef: "configured:account-c", lifecycleState: "released" },
+    });
+    await expect(acquire(authority, "winner-check", [accountC, accountB], {
+      affinity: { continuity: "require", key },
+    })).resolves.toMatchObject({
+      status: "acquired",
+      lease: {
+        accountRef: "configured:account-b",
+        selectionReason: "existing-affinity",
       },
     });
   });

--- a/packages/runtime/tests/managed-agent/invocation-service.test.ts
+++ b/packages/runtime/tests/managed-agent/invocation-service.test.ts
@@ -381,6 +381,7 @@ function managedAccountPorts(boundAdapter: ManagedAgentRuntimeAdapter) {
     accountCandidatePort: {
       resolve: async () => ({
         route,
+        affinityPolicy: { continuity: "none" as const },
         candidates: [{
           candidate: {
             account: identity.accountRef,
@@ -399,6 +400,7 @@ function managedAccountPorts(boundAdapter: ManagedAgentRuntimeAdapter) {
     },
     accountLeaseAuthority: {
       acquire: async () => ({ status: "acquired" as const, identity, lease: held }),
+      finalizeSuccessful: () => ({ lease: released }),
       markSettlementPending: () => held,
       release: () => released,
       recordReleaseFailure: () => held,

--- a/packages/runtime/tests/managed-jobs/managed-job-application.test.ts
+++ b/packages/runtime/tests/managed-jobs/managed-job-application.test.ts
@@ -78,6 +78,7 @@ async function observeAccountLease(
     acquiredAt: now.toISOString(),
     lifecycleState,
     ...(lifecycleState === "released" ? { releasedAt: now.toISOString() } : {}),
+    ...(lifecycleState === "released" ? { affinityCommitOutcome: "won" as const } : {}),
     resourceUris: [`kiln://managed-accounts/leases/lease-${input.jobId}`],
     diagnosticUris: lifecycleState === "settlement-pending"
       ? [`kiln://managed-accounts/leases/lease-${input.jobId}/settlement-pending`]
@@ -167,6 +168,7 @@ describe("ManagedJobApplicationService", () => {
     const submitted = await service.submit(request);
     const status = await service.getStatus(query, submitted.id);
     const result = await service.getResult(query, submitted.id);
+    const replay = await service.getReplay(query, submitted.id);
 
     expect(submitted).toMatchObject({ id: "job-000000001", state: "succeeded", projectId: "kiln", configuredAgentProfileId: "scout", admissionProfileId: "foundation-readonly-plan", routeId: "opencode-go-scout-readonly", providerId: "opencode-go", governanceSource: "kiln-config-status", timeoutSource: "explicit-route" });
     expect(submitted).toMatchObject({
@@ -175,8 +177,9 @@ describe("ManagedJobApplicationService", () => {
         accountPolicyId: "managed-opencode",
         accountRef: "configured:account-a",
         lifecycleState: "released",
+        affinityCommitOutcome: "won",
       },
-      accountLeaseHistory: [{ lifecycleState: "released" }],
+      accountLeaseHistory: [{ lifecycleState: "released", affinityCommitOutcome: "won" }],
     });
     expect(status).toEqual(submitted);
     expect(result).toMatchObject({
@@ -185,6 +188,11 @@ describe("ManagedJobApplicationService", () => {
       configuredAgentProfileId: "scout",
       provenance: { source: "runtime-managed-invocation", trust: "untrusted-child-output" },
       handoff: { summary: "done", resourceUris: [], memoryWriteProposalUris: [] },
+      accountLease: { lifecycleState: "released", affinityCommitOutcome: "won" },
+    });
+    expect(replay).toMatchObject({
+      accountLease: { lifecycleState: "released", affinityCommitOutcome: "won" },
+      accountLeaseHistory: [{ lifecycleState: "released", affinityCommitOutcome: "won" }],
     });
     expect(runtime.invoke).toHaveBeenCalledWith(expect.objectContaining({ jobId: "job-000000001", route: expect.objectContaining({ providerId: "opencode-go" }) }));
   });
@@ -615,6 +623,7 @@ describe("ManagedJobApplicationService", () => {
     await store.recordAccountLease(job.id, {
       ...base,
       lifecycleState: "released",
+      affinityCommitOutcome: "won",
       releasedAt: new Date(now.getTime() + 2000).toISOString(),
       diagnosticUris: [pendingUri, unknownUri],
     }, new Date(now.getTime() + 2000).toISOString());


### PR DESCRIPTION
## Summary
- project configured affinity policy into managed invocation and derive opaque keys from admitted lineage
- persist stable-capacity affinity beside managed lease capacity and atomically finalize release plus fenced CAS
- add deterministic two-account proofs for usage time, concurrency, reservations, affinity races, settlement, recovery, and account-scoped Codex retry containment
- project affinity commit evidence through V4 job status/result/replay and operator cockpit
- document managed-path guarantees and the separate cross-path authority convergence slice

## Verification
- exact candidate: `8c9ac72bb81b30fe2857880eb47b46da0fe6320f`
- full workspace test suite: passed
- full workspace typecheck: passed
- production build: 11 workspaces passed
- GUI E2E: 18/18 passed
- focused final review suite: 6 files, 220/220 tests passed
- GitHub Actions CI: passed
- `git diff --check`: passed
- PR merge state: clean

## Independent high review
No high- or medium-severity findings on the exact candidate.

Prior review findings were closed:
- stale mapped-account rebind remains existing work and retains reserved affinity capacity
- cockpit rejects commit outcomes before capacity release
- Codex retry proof now invokes the real configured adapter with a transient 520 followed by SSE success while resolving and dispatching exactly one account

## Residual scope
- live provider proof remains operator-authorized Slice 3
- ingress and managed capacity/affinity authority convergence remains a documented later slice
- no operator credentials, paths, or live payloads are persisted in deterministic fixtures

Closes #30