### PR TITLE
feat: establish economic managed route precommit

### DIFF
--- a/docs/adr/ADR-010-native-credential-projection.md
+++ b/docs/adr/ADR-010-native-credential-projection.md
@@ -1,0 +1,98 @@
+# ADR-010: Native Credential Projection
+
+## Status
+
+Accepted
+
+## Context
+
+Kiln holds multiple subscription accounts for one provider in a credential
+pool and selects among them per call. Operators also run the provider's own
+native tools beside Kiln, such as the Codex CLI and desktop app. Those tools
+keep a single-account credential store, so when the active subscription is
+exhausted the operator re-authenticates by hand to continue working, while
+Kiln already holds other usable accounts for the same provider.
+
+Harness-home selection already lets a credential entry point at a harness home
+directory, but it only governs child processes Kiln launches. It does not
+change which account the operator's own native application runs as.
+
+The gap is common enough that third-party tools exist solely to swap the
+native credential file or to run each account under a separate home directory.
+Both approaches keep account state outside Kiln, so Kiln cannot reason about
+quota, health, or identity for accounts the operator switches between.
+
+Writing into a store owned by another application is a different risk class
+from anything else the credential pool does. The store's schema belongs to
+that application, it can change across upstream releases, and a malformed
+write breaks a working login rather than degrading Kiln alone.
+
+## Decision
+
+Kiln may project one pooled credential into a native harness credential store
+as an explicit operator action. `codex-oauth` is the first provider with this
+capability, projecting into `~/.codex/auth.json` resolved through `CODEX_HOME`.
+
+The pool remains the source of truth. The native file is a projection, and
+projecting never removes the credential from the pool.
+
+Projection is bound by these invariants:
+
+- Absorb before overwrite. The account currently active in the native store is
+  admitted into the pool before it is replaced, so switching away never
+  destroys an account Kiln does not already hold. Absorption reuses normal
+  credential linking, so an already-pooled account is deduplicated rather than
+  duplicated.
+- Back up before overwrite, through the canonical projection-backup path, with
+  bounded retention and owner-only file mode.
+- Fail closed on shape. A native store may require fields Kiln does not need
+  for its own provider calls. When a required field cannot be produced, the
+  native file is not written at all, and the operator is told which accounts
+  are blocked. A partially valid credential file is worse than an unchanged
+  one.
+- Write atomically through a temporary file and rename, so an interrupted
+  projection cannot leave a truncated credential file.
+- Projection does not change Kiln's own routing. Which account Kiln uses for
+  its own calls stays governed by pool selection and routing config.
+
+Native file shape knowledge lives in `@kilnai/cli` beside the other native
+projection writers. Runtime exposes the pooled credential and the recovery of
+provider-required fields; it does not encode native file layouts.
+
+## Consequences
+
+Operators switch native accounts from Kiln, and every account they switch
+through becomes visible to Kiln's pool, including quota and health evidence
+that was previously invisible.
+
+Kiln accepts responsibility for mutating state owned by another application.
+That responsibility is discharged by validating the parsed native shape,
+failing closed when a required field is missing, and keeping a recoverable
+backup rather than by assuming upstream stability.
+
+Secret-bearing material now exists outside `~/.kiln/auth/` in projection
+backups. Bounded retention and owner-only mode keep that exposure finite
+rather than accumulating indefinitely. Owner-only mode is enforced by POSIX;
+on Windows these paths rely on the user-profile ACL, consistent with how the
+credential store itself is protected.
+
+Adding this capability for another provider requires a new native shape
+translation and the same invariants. It is deliberately not a generic
+"write any credential anywhere" mechanism.
+
+## Verification
+
+- `packages/cli/tests/config/codex-native-account-sync.test.ts` covers native
+  shape translation in both directions and rejection of malformed native files.
+- `packages/cli/tests/commands/auth.test.ts` covers absorb, backup location,
+  bounded retention, atomic replacement, fail-closed behavior when a required
+  field cannot be recovered, and the distinct failure diagnostics.
+- `packages/cli/tests/config/native-projection-backup.test.ts` covers retention
+  limits, per-source pruning scope, default unbounded retention for config
+  projections, and owner-only mode on POSIX.
+
+## Related
+
+- [Provider Credential Pools](../architecture/provider-credential-pools.md)
+- [Credential Governance](../architecture/credential-governance.md)
+- [Provider Credentials](../guides/provider-credentials.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,3 +21,4 @@ Execution sequencing belongs in `docs/roadmap/`. Stable doctrine belongs in
 | [ADR-007](ADR-007-multimodal-transport-and-capability-delegation.md) | Multimodal transport and capability delegation |
 | [ADR-008](ADR-008-managed-invocation-caller-identity.md) | Managed invocation caller identity |
 | [ADR-009](ADR-009-canonical-mcp-ownership-and-execution.md) | Canonical MCP ownership, execution, and projection |
+| [ADR-010](ADR-010-native-credential-projection.md) | Native credential projection into harness credential stores |

--- a/docs/architecture/managed-agents.md
+++ b/docs/architecture/managed-agents.md
@@ -169,7 +169,7 @@ explicit retention decision.
 The project-local Codex App MCP adapter exposes exactly
 `kiln_managed_agent_invoke`, `kiln_managed_agent_status`,
 `kiln_managed_agent_result`, `kiln_managed_agent_cancel`, and
-`kiln_managed_agent_replay`, alongside its three inspection tools. Invoke
+`kiln_managed_agent_replay`, alongside its four inspection tools. Invoke
 accepts only `objective`,
 `configuredAgentProfileId`, and
 `idempotencyKey`; status, result, cancel, and replay each accept only `jobId`.
@@ -180,13 +180,13 @@ configuration, environment, credentials, or timeout inputs.
 
 Production composition creates the Runtime `ManagedJobApplicationService`,
 uses the persistent `.kiln/managed-jobs` owner, canonical governance status,
-configured-agent catalog and route resolution, Runtime invocation service, and
-existing direct-provider adapter. The application boundary refreshes canonical
-eligibility for every submission, uses the selected configured agent's exact
-route hint, then validates the route-owned admission profile and scope before
-persisting the job. Slice 3's explicit application admission requirement is
-`foundation-readonly-plan`; a route must supply that profile. The MCP adapter
-never makes either decision. Capability inspection
+and a candidate-admission-only configured-agent catalog. It does not construct
+the Runtime invocation service, account lease authority, or direct-provider
+adapter. The application boundary refreshes canonical eligibility for every
+submission, resolves the configured policy and narrow-only route constraints,
+then persists the V5 precommit record. Slice 3's explicit application admission
+requirement is `foundation-readonly-plan`; a candidate route must supply that
+profile. The MCP adapter never selects a route. Capability inspection
 projects safe configured-agent identity, optional role/display name, availability,
 provider family, admission profile, and stable action; it does not expose route
 configuration. Status, result, cancellation, and replay operations are
@@ -194,7 +194,7 @@ authorized by the application owner
 against the trusted project, trusted Codex App caller/harness identity, and
 canonical job ownership; knowing a job identifier is insufficient. Responses
 project only opaque job/lifecycle, configured-agent, admission-profile and
-route/provider evidence, completion timestamp, untrusted-result provenance,
+policy evidence or historical route/provider evidence, completion timestamp, untrusted-result provenance,
 bounded normalized handoff or admitted safe resource references,
 caller/request evidence, and stable diagnostics. They never return objectives,
 prompts, transcripts, hidden reasoning, raw provider data, storage paths,
@@ -739,10 +739,36 @@ children as missing evidence during comparisons. Surfaces must not add
 surface-local managed-agent prompt rules that diverge from this generated tool
 contract.
 
-The model supplies a bounded task, a configured provider route, a requested
-managed invocation profile, and optionally a child agent profile, child skills,
-resource URIs, and context mode. The runtime maps that input to a
-`ManagedAgentInvocationRequest` using configured route defaults for adapter,
+The model supplies a bounded task, a requested managed invocation profile, and
+optionally narrowing route/provider/model constraints, a child agent profile,
+child skills, resource URIs, and context mode. For a policy-bearing agent,
+`providerRoute` is optional and can only remove candidates already admitted by
+the configured policy.
+
+Policy execution has three distinct contracts:
+
+1. `ManagedEconomicInvocationCommand` carries policy identity and optional
+   narrowing constraints, but no execution identity.
+2. `ManagedEconomicCandidateSet` carries non-economically admitted route
+   descriptors and Runtime-owned rejection evidence. Its only rejection stage
+   is `managed-candidate-admission`, with reasons `not-in-policy`,
+   `caller-constraint-excluded`, `non-economic-admission-failed`, and
+   `economic-capability-unverified`.
+3. `ManagedCommittedInvocationRequest` is the only contract accepted by the
+   deferred adapter boundary. It requires the durable commitment and dispatch
+   fence, exact route/provider/model and capability revision, account or
+   accountless identity, tariff, envelope, and reservation evidence.
+
+Candidate collection cannot construct an adapter, resolve a credential, launch
+a process, acquire a lease, reserve capacity, or call a provider. A new managed
+job is persisted as V5 with policy/revision and constraints but without
+`routeId` or `providerId`. V3/V4 remain historical reader/recovery formats and
+are never used for a new submission. Until the atomic commitment owner is
+available, V5 terminates deterministically as
+`economic_commitment_unavailable`; no candidate is treated as a default.
+
+For a retained non-policy invocation, the runtime maps the configured input to
+a `ManagedAgentInvocationRequest` using configured route defaults for adapter,
 execution mode, credential route, memory scope, timeout, working directory, and
 authority. Requested agent profiles and skills are resolved by the host context
 resolver and recorded as admitted context before execution. The model does not
@@ -787,7 +813,7 @@ The runtime may attach an agent profile only when exactly one configured
 profile has an explicit route hint matching the request route. This preserves
 fail-closed profile admission while removing model-side sequencing from the
 managed child lifecycle.
-When a request has no exact route, runtime route selection first filters by the
+For a retained non-policy invocation with no exact route, runtime route selection first filters by the
 requested authority profile and `requiredToolNames`. A single compatible route
 is admissible. When several routes remain, the runtime may select only a unique
 highest-scoring route from the phase `taskAffinity` and configured

--- a/docs/architecture/provider-credential-pools.md
+++ b/docs/architecture/provider-credential-pools.md
@@ -314,6 +314,7 @@ contracts without changing the pool boundary.
 
 ## Related
 
+- [ADR-010: Native Credential Projection](../adr/ADR-010-native-credential-projection.md)
 - [Provider Credentials](../guides/provider-credentials.md)
 - [Observability](../guides/observability.md)
 - [Provider Model Discovery](provider-model-discovery.md)

--- a/docs/architecture/provider-credential-pools.md
+++ b/docs/architecture/provider-credential-pools.md
@@ -197,6 +197,37 @@ environment, such as `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, or
 `OPENCODE_CONFIG_DIR`. Harness token refresh remains the harness adapter's
 responsibility.
 
+## Native Credential Projection
+
+Harness-home selection projects a whole directory for a child process. Native
+credential projection is the narrower inverse case: Kiln writes one pooled
+credential into a native harness's own credential store so the operator's
+existing native CLI or desktop app runs as that account. `codex-oauth` is the
+first provider with this capability, projecting into `~/.codex/auth.json`
+resolved through `CODEX_HOME`.
+
+The Kiln pool remains the source of truth. The native file is a projection, and
+projecting never removes the credential from the pool.
+
+Invariants:
+
+- Absorb before overwrite. Whatever account is already active in the native
+  store is admitted into the pool first, so switching away never destroys an
+  account Kiln does not already hold. Absorption reuses normal linking, so an
+  account already pooled is deduplicated rather than duplicated.
+- Back up before overwrite, through the canonical projection-backup path with
+  bounded retention and owner-only file mode.
+- Fail closed on shape. A native store may require fields Kiln does not need
+  for its own API calls. When a required field cannot be produced, the native
+  file is not written at all. A partially valid native credential file is worse
+  than an unchanged one, because it can break a working native login.
+- Write atomically, through a temporary file and rename, so an interrupted
+  projection cannot leave a truncated credential file.
+
+Native credential shape knowledge lives in `@kilnai/cli`, next to the other
+native projection writers. Runtime exposes the pooled credential and the
+recovery of provider fields; it does not encode native file layouts.
+
 ## Cross-Process Reload
 
 `CredentialWatcher` scans `~/.kiln/auth/**/*.json`, ignores `.health/`, and
@@ -259,6 +290,9 @@ separate observations. This preserves tiered or route-specific views such as
   payloads.
 - Provider credential pools are per Kiln instance. Cross-instance credential
   sharing requires explicit future policy and audit support.
+- Secret-bearing material leaves `~/.kiln/auth/` only through an explicit
+  operator action such as native credential projection. Copies written by that
+  action, including backups, use owner-only file mode and bounded retention.
 - Local endpoint providers do not imply cloud auth, and cloud credentials do
   not imply local daemon availability.
 

--- a/docs/architecture/provider-credential-pools.md
+++ b/docs/architecture/provider-credential-pools.md
@@ -293,6 +293,12 @@ separate observations. This preserves tiered or route-specific views such as
 - Secret-bearing material leaves `~/.kiln/auth/` only through an explicit
   operator action such as native credential projection. Copies written by that
   action, including backups, use owner-only file mode and bounded retention.
+- Credential files are owner-only. Every write path applies the mode, so a
+  credential written before the invariant repairs itself on its next persist
+  rather than requiring a migration command. Files that are never rewritten are
+  reported by `kiln auth status` instead of being repaired during inspection.
+  POSIX enforces the mode; Windows has no mode bits and relies on the
+  user-profile ACL.
 - Local endpoint providers do not imply cloud auth, and cloud credentials do
   not imply local daemon availability.
 

--- a/docs/guides/global-config.md
+++ b/docs/guides/global-config.md
@@ -615,6 +615,81 @@ used when the parent supplies explicit governed resource URIs. `contextMode:
 fork` is reserved for a future policy slice and currently fails closed in
 CLI-owned GUI, TUI, and CLI sessions.
 
+### Managed economic policy schema v2
+
+Economic governance uses one canonical, one-way configuration boundary:
+
+- `modelGateway.accounts[].economics` owns stable capacity identity,
+  subscription/quota classification, and explicit credit/overage posture.
+- `modelGateway.virtualModels[].economics` owns the exact billing channel,
+  adapter capability ID/version, execution mode and tier, rate-card basis and
+  evidence, auxiliary charges, envelope semantics, and bounded execution
+  envelope for that provider/model route.
+- `managedAgents.economicPolicies[]` owns candidate route IDs, comparison
+  domains, configured priority, exact or explicitly non-comparable worst-case
+  reservations, exact ceilings, evidence requirements, and the fail-closed
+  `noRouteAction: deny`.
+- each project or global agent with `mode: managed-child` or `mode: all`
+  references exactly one policy through `economicPolicyId`.
+
+Declare `managedAgents.schemaVersion: 2` whenever `economicPolicies` is
+present. The loader rejects unknown keys, aliases, duplicate identities,
+duplicate candidate routes, non-canonical decimals, incompatible ceiling
+units/schemes, unbounded route envelopes, unsupported providers, missing
+route/model/account economics, and fallback or overage that is not explicitly
+disabled.
+
+For a metered candidate, Core derives the minimum comparable reservation from
+each unit price and its matching unit-scheme usage limit, then adds fixed
+auxiliary charges in the comparison-domain unit and currency/credit scheme.
+The configured exact reservation may include a conservative buffer, but it
+cannot be below that derived minimum or above its finite ceiling. The
+calculation uses canonical decimal atoms and `bigint`; configuration never
+passes through binary floating-point arithmetic. Extra bounded envelope
+dimensions may remain unpriced, but every configured unit rate must have one
+matching usage limit.
+
+A `free` route requires current free evidence, an exact zero reservation, and
+no separately charged auxiliary calls. Subscription, included, estimated, and
+unknown price classes remain explicitly non-comparable with their matching
+reason; they are never rewritten as numeric zero.
+
+Migration is not an inference step. Add complete account and exact-route
+economics, add the versioned policy, then replace each governed agent's
+route-authority frontmatter with `economicPolicyId`. An explicit `routeId` or
+`providerRoute` may remain only as a narrowing constraint admitted by that
+policy. It cannot add a candidate, choose an account, or create a default.
+Malformed or widening bindings stop composition before adapter construction or
+credential resolution.
+
+Native Codex, OpenCode, and Claude projections intentionally omit capacity,
+quota, tariff, and billing evidence. Native picker configuration is not a
+second economic authority. Policy-based candidate dispatch is activated by the
+next managed-routing slice; schema v2 validation does not preselect a route.
+Unconfigured builtin agents are therefore absent from the schema-v2 managed
+catalog. A project or global definition, including an override with the same
+name as a builtin, is admitted only with a valid `economicPolicyId`.
+Policy-only agents are also absent from native managed-job submission until
+Slice 3 adds a policy-bearing pre-commit job contract; Kiln does not retain or
+invent a hidden `routeId` to make them executable early.
+Non-managed session-turn budgeting remains owned by its existing configuration
+until its separate migration closes.
+
+Example agent binding:
+
+```markdown
+---
+name: architecture-reviewer
+role: Architecture reviewer
+goal: Review architecture within the admitted economic policy.
+tier: reasoning
+mode: managed-child
+economicPolicyId: bounded-review
+---
+
+Report findings without selecting a provider or account.
+```
+
 ### Timeout proof routes
 
 Use explicit route configuration to prove timeout behavior. Do not add a

--- a/docs/guides/global-config.md
+++ b/docs/guides/global-config.md
@@ -664,14 +664,21 @@ credential resolution.
 
 Native Codex, OpenCode, and Claude projections intentionally omit capacity,
 quota, tariff, and billing evidence. Native picker configuration is not a
-second economic authority. Policy-based candidate dispatch is activated by the
-next managed-routing slice; schema v2 validation does not preselect a route.
+second economic authority. Runtime now admits a policy-owned candidate set
+without preselecting a route. Candidate admission applies governance,
+authority/profile, tool, network, workspace, caller, route-health, policy
+membership, and verified economic-capability checks before any economic
+decision.
 Unconfigured builtin agents are therefore absent from the schema-v2 managed
 catalog. A project or global definition, including an override with the same
 name as a builtin, is admitted only with a valid `economicPolicyId`.
-Policy-only agents are also absent from native managed-job submission until
-Slice 3 adds a policy-bearing pre-commit job contract; Kiln does not retain or
-invent a hidden `routeId` to make them executable early.
+Policy agents are exposed to native managed-job submission through the V5
+pre-commit record. V5 persists the policy id/revision, normalized narrowing
+constraints, governance evidence, and admitted candidate set. It deliberately
+contains no selected route, provider, account, lease, reservation, or dispatch
+identity. Until the atomic commitment authority is installed, policy work
+terminates with `economic_commitment_unavailable`; Kiln does not queue it
+indefinitely or invent a hidden `routeId`.
 Non-managed session-turn budgeting remains owned by its existing configuration
 until its separate migration closes.
 

--- a/docs/guides/provider-credentials.md
+++ b/docs/guides/provider-credentials.md
@@ -154,6 +154,22 @@ endpoint is a configuration/runtime error, not a request for OAuth.
 Logout commands remove the provider's linked credential files. They do not
 modify unrelated provider directories.
 
+## File Permissions
+
+Credential files are owner-only. Every Kiln write path applies that mode, so a
+credential linked before this invariant existed is repaired the next time Kiln
+writes it, which for an actively used account happens on its next token
+refresh. There is no migration command to run.
+
+A credential that is never rewritten keeps its original mode, so `kiln auth
+status` reports any credential file readable beyond its owner and prints the
+`chmod` needed to fix it now. Inspection commands report the exposure rather
+than silently repairing it, so the finding is visible rather than erased.
+
+This applies to POSIX systems. Windows does not implement POSIX mode bits;
+these paths are protected by the user-profile ACL, and the report is empty
+there rather than misleading.
+
 ## Direct Providers
 
 Direct providers can be configured by placing credential files under their

--- a/docs/guides/provider-credentials.md
+++ b/docs/guides/provider-credentials.md
@@ -34,8 +34,9 @@ Codex OAuth:
 
 ```bash
 kiln auth codex login
-kiln auth codex status
-kiln auth codex logout
+kiln auth codex status [--usage] [--emails]
+kiln auth codex activate <id> | --auto
+kiln auth codex logout [--id <id>]
 ```
 
 OpenCode:
@@ -70,6 +71,45 @@ authorization remains the explicit fallback for CLI/TUI and remote or headless
 environments; it is not the GUI default. If an OAuth endpoint returns HTML or
 another non-JSON payload, Kiln reports a provider-boundary authentication error
 without exposing the response body or a raw `JSON.parse` exception.
+
+`kiln auth codex status` reports credential presence, expiry, and health.
+`--usage` additionally refreshes live quota from the provider and prints plan
+and window usage. `--emails` prints the account email for each credential,
+decoded from claims already stored in the local token file; no provider call is
+made for it. Both are opt-in so that default status output stays free of quota
+calls and personal identifiers, which matters when status output is pasted into
+issues, shared terminals, or CI logs.
+
+### Switching The Native Codex Account
+
+`kiln auth codex activate` points the operator's own Codex CLI and desktop app
+at a pooled account, replacing manual re-login when one subscription is
+exhausted. Pass a credential id, or `--auto` to select the available account
+with the most remaining quota:
+
+```bash
+kiln auth codex activate account-1720ceb0e92edbe2
+kiln auth codex activate --auto
+```
+
+Activation absorbs the account currently active in `~/.codex/auth.json` into
+the Kiln pool before overwriting it, so switching away never loses an account.
+If that account is already pooled it is deduplicated, not duplicated. The
+previous native file is backed up under
+`~/.kiln/backups/codex-native-auth/` with owner-only permissions and bounded
+retention, and the replacement is written atomically.
+
+Native Codex requires an `id_token` that Kiln's own provider calls do not need.
+Credentials linked before Kiln began storing that field are repaired
+automatically by refreshing the token during activation. When it cannot be
+recovered, Kiln reports which accounts are blocked and leaves the native file
+untouched rather than writing a credential the native app would reject; relink
+those accounts with `kiln auth codex login`.
+
+Activation targets `CODEX_HOME` when set, matching the directory the native
+Codex CLI itself reads. It does not change Kiln's own routing: which account
+Kiln uses for its own provider calls stays governed by pool selection and
+routing config.
 
 `kiln auth opencode link` stores an OpenCode API key under
 `~/.kiln/auth/opencode/`. Without `--key`, Kiln first tries to import the key

--- a/packages/cli/src/application/agent-loader.ts
+++ b/packages/cli/src/application/agent-loader.ts
@@ -32,6 +32,7 @@ export interface KilnAgentDefinition {
   readonly sandbox?: boolean;
   readonly modalities?: readonly string[];
   readonly authorityProfile?: ManagedAgentAdmissionProfile;
+  readonly economicPolicyId?: string;
   readonly routeId?: string;
   readonly providerRoute?: KilnAgentProviderRoute;
   readonly workClassification?: WorkClassification;
@@ -198,6 +199,7 @@ function parseAgentDefinition(raw: string, scope: "global" | "project"): KilnAge
     return undefined;
   }
   const routeId = asNonEmptyString(record.routeId);
+  const economicPolicyId = asNonEmptyString(record.economicPolicyId);
   const providerRoute = asProviderRoute(record.providerRoute);
   let workClassification: WorkClassification | undefined;
   try {
@@ -227,6 +229,7 @@ function parseAgentDefinition(raw: string, scope: "global" | "project"): KilnAge
     ...(sandbox !== undefined ? { sandbox } : {}),
     ...(modalities ? { modalities } : {}),
     ...(authorityProfile ? { authorityProfile } : {}),
+    ...(economicPolicyId ? { economicPolicyId } : {}),
     ...(routeId ? { routeId } : {}),
     ...(providerRoute ? { providerRoute } : {}),
     ...(workClassification ? { workClassification } : {}),
@@ -280,13 +283,14 @@ function readDefinitionsFromDirectory(
 
 export interface LoadAgentDefinitionsOptions {
   readonly includeBuiltins?: boolean;
+  readonly userHome?: string;
 }
 
 export async function loadAgentDefinitions(
   projectPath: string,
   options: LoadAgentDefinitionsOptions = {},
 ): Promise<KilnAgentDefinition[]> {
-  const globalDirectory = join(homedir(), ".kiln", "agents");
+  const globalDirectory = join(options.userHome ?? homedir(), ".kiln", "agents");
   const projectDirectory = join(projectPath, ".kiln", "agents");
 
   const merged = new Map<string, KilnAgentDefinition>();

--- a/packages/cli/src/application/codex-app-managed-jobs.ts
+++ b/packages/cli/src/application/codex-app-managed-jobs.ts
@@ -1,17 +1,14 @@
 import { join } from "node:path";
 import { createHash } from "node:crypto";
-import { createSessionBuiltinToolOptions, defineManagedAgentInvocationRequest, type ManagedAgentAdmissionProfile } from "@kilnai/core";
+import { createSessionBuiltinToolOptions } from "@kilnai/core";
 import {
+  collectManagedEconomicCandidates,
   FilesystemManagedJobStore,
   ManagedJobApplicationError,
   ManagedJobApplicationService,
-  createRuntimeManagedJobInvocationPort,
   type ManagedJobRecord,
   type ManagedJobReplayQuery,
   type ManagedJobResultQuery,
-  type ManagedJobProfile,
-  type ManagedJobRoute,
-  type ManagedJobRuntimeInvocationResolver,
 } from "@kilnai/runtime";
 import { findAgent, loadAgentDefinitions, type KilnAgentDefinition } from "./agent-loader.js";
 import { createManagedDirectProviderAdapterFactory } from "../config/managed-agent-direct-adapters.js";
@@ -104,6 +101,7 @@ export async function createNativeHarnessManagedJobApplicationComposition(
       cwd: root.rootPath,
       registry,
       surface: "operator",
+      compositionMode: "candidate-admission",
       directAdapterFactory: createManagedDirectProviderAdapterFactory({
         builtinToolOptions: createSessionBuiltinToolOptions(),
         canonicalMcpServers: admittedMcpServers,
@@ -123,12 +121,6 @@ export async function createNativeHarnessManagedJobApplicationComposition(
   };
   const managedInvocation = await freshManagedInvocation();
   const configuredAgents = await loadAgentDefinitions(root.rootPath);
-  const admittedRoutes = new Map<string, {
-    readonly route: NonNullable<ManagedInvocationRouteResolution["managedInvocation"]>["routes"][number];
-    readonly invocationService: NonNullable<NonNullable<ManagedInvocationRouteResolution["managedInvocation"]>["invocationService"]>;
-  }>();
-  const activeInvocationServices = new Map<string, NonNullable<NonNullable<ManagedInvocationRouteResolution["managedInvocation"]>["invocationService"]>>();
-
   const project = { id: `project-${createHash("sha256").update(root.rootPath).digest("hex").slice(0, 32)}` };
   const managedJobStore = new FilesystemManagedJobStore(join(root.rootPath, ".kiln", "managed-jobs"));
   const service = new ManagedJobApplicationService({
@@ -164,50 +156,59 @@ export async function createNativeHarnessManagedJobApplicationComposition(
     profiles: {
       resolve: async (id) => {
         const agent = findAgent(await loadAgentDefinitions(root.rootPath), id);
-        return agent?.routeId ? { id: agent.name, routeId: agent.routeId } : undefined;
+        if (!agent?.economicPolicyId) return undefined;
+        const current = await freshManagedInvocation();
+        const catalogEntry = current.agentCatalog?.find(
+          (candidate) => candidate.name === agent.name,
+        );
+        if (
+          !catalogEntry?.economicPolicyId
+          || !catalogEntry.economicPolicyRevision
+        ) {
+          return undefined;
+        }
+        return {
+          id: agent.name,
+          economicPolicyId: catalogEntry.economicPolicyId,
+          economicPolicyRevision: catalogEntry.economicPolicyRevision,
+          admissionProfileId: agent.authorityProfile ?? REQUIRED_ADMISSION_PROFILE_ID,
+          constraints: {
+            ...(agent.routeId ? { routeId: agent.routeId } : {}),
+            ...(agent.providerRoute?.providerId
+              ? { providerId: agent.providerRoute.providerId }
+              : {}),
+            ...(agent.providerRoute?.model ? { model: agent.providerRoute.model } : {}),
+          },
+        };
       },
     },
     routes: {
       resolve: async (profile) => {
         const current = await freshManagedInvocation();
-        const route = routeForProfile(current, profile);
-        if (route) {
-          const selected = current.routes.find((candidate) => candidate.routeId === route.id);
-          if (selected && current.invocationService) admittedRoutes.set(`${profile.id}:${route.id}`, { route: selected, invocationService: current.invocationService });
-        }
-        return route;
-      },
-    },
-    runtime: {
-      invoke: async (input) => {
-        const admitted = admittedRoutes.get(`${input.profile.id}:${input.route.id}`);
-        if (!admitted) {
-          throw new ManagedJobApplicationError("route_unavailable", "Configure an admitted managed-agent route.");
-        }
-        const port = createRuntimeManagedJobInvocationPort({ service: admitted.invocationService, resolver: runtimeResolver(admitted.route, options.harness) });
-        activeInvocationServices.set(input.jobId, admitted.invocationService);
-        try {
-          return await port.invoke(input);
-        } finally {
-          activeInvocationServices.delete(input.jobId);
-        }
-      },
-      cancel: async ({ jobId, reason }) => {
-        const invocationService = activeInvocationServices.get(jobId);
-        if (!invocationService) throw new ManagedJobApplicationError("invocation_failed", "Cancel only an active Runtime-owned managed invocation.");
-        await invocationService.cancel(jobId, reason);
+        return collectManagedEconomicCandidates({
+          economicPolicyId: profile.economicPolicyId,
+          economicPolicyRevision: profile.economicPolicyRevision,
+          configuredAgentProfileId: profile.id,
+          admissionProfileId: profile.admissionProfileId,
+          ...(profile.constraints?.routeId
+            ? { routeId: profile.constraints.routeId }
+            : {}),
+          ...(profile.constraints?.providerId
+            ? {
+                providerRoute: {
+                  providerId: profile.constraints.providerId,
+                  surface: "configured",
+                  ...(profile.constraints.model
+                    ? { model: profile.constraints.model }
+                    : {}),
+                },
+              }
+            : {}),
+        }, current.routes, current.unavailableRoutes);
       },
     },
     store: managedJobStore,
   });
-  const recoveredInvocations = await managedInvocation.invocationService?.recoverPersistedInvocations();
-  for (const accountLease of recoveredInvocations?.accountLeases ?? []) {
-    const managedJob = await managedJobStore.get(accountLease.runtimeInvocationId);
-    if (managedJob?.version !== 4 || managedJob.projectId !== project.id) {
-      continue;
-    }
-    await managedJobStore.recordAccountLease(accountLease.runtimeInvocationId, accountLease);
-  }
   await service.recoverInterrupted();
   const application: NativeHarnessManagedJobApplicationPort = {
     submit: (input) => service.start(input),
@@ -219,91 +220,10 @@ export async function createNativeHarnessManagedJobApplicationComposition(
   return { service, application, configuredAgents: summarizeNativeHarnessManagedAgents(configuredAgents, managedInvocation) };
 }
 
-function routeForProfile(resolution: ManagedInvocationRouteResolution["managedInvocation"], profile: ManagedJobProfile): ManagedJobRoute | undefined {
-  const routes = resolution?.routes.filter((candidate) => candidate.routeId === profile.routeId) ?? [];
-  if (routes.length !== 1) return undefined;
-  const route = routes[0];
-  if (!route) return undefined;
-  const admissionProfileId = selectAdmissionProfile(route);
-  if (!admissionProfileId) return undefined;
-  const routeProfile = route.profiles[admissionProfileId];
-  if (!routeProfile || !route.accountPolicyId) return undefined;
-  const observedAt = new Date();
-  return {
-    id: route.routeId,
-    accountPolicyId: route.accountPolicyId,
-    admissionProfileId,
-    supportedAdmissionProfileIds: Object.keys(route.profiles),
-    providerId: route.providerId,
-    timeoutSource: routeProfile.timeoutSource ?? "default",
-    scope: { project: "validated", read: "validated", tools: "validated", network: "validated", write: "validated" },
-    eligibility: { authority: "authoritative", observedAt: observedAt.toISOString(), validUntil: new Date(observedAt.getTime() + 60_000).toISOString() },
-    authority: managedJobAuthority(routeProfile),
-  };
-}
-
-function runtimeResolver(
-  route: NonNullable<ManagedInvocationRouteResolution["managedInvocation"]>["routes"][number],
-  harness: NativeHarnessId,
-): ManagedJobRuntimeInvocationResolver {
-  return {
-    async resolve(input) {
-      const profile = route?.profiles[input.route.admissionProfileId as ManagedAgentAdmissionProfile];
-      if (!profile || route.routeId !== input.route.id || !input.route.supportedAdmissionProfileIds.includes(input.route.admissionProfileId)) {
-        throw new ManagedJobApplicationError("route_unavailable", "Configure the configured agent's admitted managed-agent route.");
-      }
-      const request = defineManagedAgentInvocationRequest({
-        invocationId: input.jobId,
-        agentId: `${route.routeId}:${input.profile.id}`,
-        parentSessionId: `${harness}-native-harness`,
-        parentTurnId: input.jobId,
-        profile: input.route.admissionProfileId as ManagedAgentAdmissionProfile,
-        requestedBy: `${harness}-native-harness`,
-        requestSource: `${harness}-control-plane-mcp`,
-        providerRoute: { providerId: route.providerId, surface: "direct-provider", ...(route.model ? { model: route.model } : {}) },
-        adapterKind: route.adapter.descriptor.adapterKind,
-        executionMode: "direct-provider",
-        authority: input.route.authority,
-        input: { summary: input.objective.slice(0, 512), prompt: input.objective, context: { mode: "isolated" } },
-      });
-      return {
-        request,
-        adapter: route.adapter,
-        capabilitySnapshot: {
-          routeId: route.routeId,
-          routeSource: route.routeSource,
-          callerIdentity: { kind: "external-harness", harness, attachmentId: "kiln-control-plane-mcp", evidenceId: `${harness}-control-plane-mcp` },
-          routeHealth: { status: "healthy", reason: `Configured ${harness} managed-job route.` },
-          providerModelProof: { status: "configured", source: "configured-managed-route", requiresToolCalls: true },
-          resourcePlane: { available: true, resourceUris: [] },
-          childIdentity: { agentId: request.agentId, requestedAgentProfile: input.profile.id },
-        },
-      };
-    },
-  };
-}
-
 function selectAdmissionProfile(
   route: NonNullable<ManagedInvocationRouteResolution["managedInvocation"]>["routes"][number],
-): ManagedAgentAdmissionProfile | undefined {
+): typeof REQUIRED_ADMISSION_PROFILE_ID | undefined {
   return route.profiles[REQUIRED_ADMISSION_PROFILE_ID] ? REQUIRED_ADMISSION_PROFILE_ID : undefined;
-}
-
-function managedJobAuthority(
-  profile: NonNullable<NonNullable<ManagedInvocationRouteResolution["managedInvocation"]>["routes"][number]["profiles"][ManagedAgentAdmissionProfile]>,
-): ManagedJobRoute["authority"] {
-  return {
-    authorityProfileId: profile.authorityProfileId,
-    permissionProfile: profile.permissionProfile,
-    toolAuthority: { allowedToolNames: profile.allowedToolNames, writeAllowed: profile.writeAllowed === true, networkAllowed: profile.networkAllowed === true },
-    workingDirectory: profile.workingDirectory,
-    timeoutMs: profile.timeoutMs,
-    ...(profile.timeoutSource ? { timeoutSource: profile.timeoutSource } : {}),
-    credentialRoute: profile.credentialRoute,
-    memoryScope: profile.memoryScope,
-    ...(profile.readAuthority ? { readAuthority: profile.readAuthority } : {}),
-    ...(profile.writeAuthority ? { writeAuthority: profile.writeAuthority } : {}),
-  };
 }
 
 export function summarizeNativeHarnessManagedAgents(
@@ -311,21 +231,49 @@ export function summarizeNativeHarnessManagedAgents(
   resolution: ManagedInvocationRouteResolution["managedInvocation"],
 ): readonly NativeHarnessManagedAgentSummary[] {
   return configuredAgents.flatMap((agent): readonly NativeHarnessManagedAgentSummary[] => {
-    if (!agent.routeId) return [];
+    if (!agent.economicPolicyId) return [];
     const base = {
       configuredAgentProfileId: agent.name,
       ...(agent.displayName ? { displayName: agent.displayName } : {}),
       ...(agent.role ? { role: agent.role } : {}),
       admissionProfileId: REQUIRED_ADMISSION_PROFILE_ID,
     };
-    const routes = resolution?.routes.filter((route) => route.routeId === agent.routeId) ?? [];
-    const route = routes.length === 1 ? routes[0] : undefined;
-    const admissionProfileId = route ? selectAdmissionProfile(route) : undefined;
-    if (route && admissionProfileId) {
-      return [{ ...base, availability: "admitted", providerFamily: route.providerId }];
+    const catalogEntry = resolution?.agentCatalog?.find(
+      (candidate) =>
+        candidate.name === agent.name
+        && candidate.economicPolicyId === agent.economicPolicyId,
+    );
+    const policyRouteIds = new Set(
+      catalogEntry?.economicPolicyCandidateRouteIds ?? [],
+    );
+    const admittedRoutes = (resolution?.routes ?? []).filter(
+      (route) =>
+        policyRouteIds.has(route.routeId)
+        && (!agent.routeId || route.routeId === agent.routeId)
+        && (
+          !agent.providerRoute
+          || (
+            route.providerId === agent.providerRoute.providerId
+            && (
+              !agent.providerRoute.model
+              || route.model === agent.providerRoute.model
+            )
+          )
+        )
+        && selectAdmissionProfile(route) !== undefined
+        && route.economicCapability?.status === "verified",
+    );
+    if (admittedRoutes.length > 0) {
+      const providers = [...new Set(admittedRoutes.map((route) => route.providerId))];
+      return [{
+        ...base,
+        availability: "admitted",
+        ...(providers.length === 1 ? { providerFamily: providers[0] } : {}),
+      }];
     }
     const unavailable = resolution?.unavailableRoutes?.find((candidate) =>
-      candidate.routeId === agent.routeId && candidate.profiles.includes(REQUIRED_ADMISSION_PROFILE_ID));
+      policyRouteIds.has(candidate.routeId)
+      && candidate.profiles.includes(REQUIRED_ADMISSION_PROFILE_ID));
     if (unavailable) {
       return [{
         ...base,
@@ -339,7 +287,7 @@ export function summarizeNativeHarnessManagedAgents(
       ...base,
       availability: "unavailable",
       diagnostic: "route_unavailable",
-      operatorAction: "Restore the configured route hint and its admitted managed-agent route.",
+      operatorAction: "Restore at least one non-economically admitted route in the configured economic policy.",
     }];
   });
 }

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -88,17 +88,22 @@ async function runCodexLogin(): Promise<void> {
 }
 
 async function runCodexStatus(rest: string[]): Promise<void> {
-  const usageRequested = parseCodexStatusOptions(rest);
+  const options = parseCodexStatusOptions(rest);
   const pool = new CodexOAuthCredentialPoolService();
   const entries = await pool.listStatus();
   if (entries.length === 0) {
     console.log("Not authenticated");
     return;
   }
-  const usage = usageRequested ? await pool.refreshUsage() : [];
+  const usage = options.usage ? await pool.refreshUsage() : [];
+  // Emails are decoded from already-local token claims, never fetched from the provider,
+  // and stay behind their own flag so they never merge into --usage's guarded output.
+  const emails = options.emails ? await pool.listCredentialEmails() : new Map<string, string>();
   console.log("Codex OAuth");
   for (const entry of entries) {
     console.log(`  ${entry.id}`);
+    const email = emails.get(entry.id);
+    if (email) console.log(`    Email: ${email}`);
     console.log(`    Token expiry: ${entry.expiresAt}`);
     console.log(`    Status: ${entry.status}`);
     if (entry.invalidReason) {
@@ -131,10 +136,18 @@ async function runCodexLogout(rest: string[]): Promise<void> {
   console.log("Logged out of all Codex credentials");
 }
 
-function parseCodexStatusOptions(rest: string[]): boolean {
-  if (rest.length === 0) return false;
-  if (rest.length === 1 && rest[0] === "--usage") return true;
-  throw new Error("Usage: kiln auth codex status [--usage]");
+interface CodexStatusOptions {
+  readonly usage: boolean;
+  readonly emails: boolean;
+}
+
+function parseCodexStatusOptions(rest: string[]): CodexStatusOptions {
+  const flags = new Set(rest);
+  const recognized = new Set(["--usage", "--emails"]);
+  if (rest.length !== flags.size || [...flags].some((flag) => !recognized.has(flag))) {
+    throw new Error("Usage: kiln auth codex status [--usage] [--emails]");
+  }
+  return { usage: flags.has("--usage"), emails: flags.has("--emails") };
 }
 
 function parseCodexLogoutOptions(rest: string[]): string | undefined {
@@ -418,7 +431,7 @@ function formatStatusRow(cells: readonly string[]): string {
 function printUsage(): void {
   console.log("Usage: kiln auth <subcommand>");
   console.log("  kiln auth codex login");
-  console.log("  kiln auth codex status [--usage]");
+  console.log("  kiln auth codex status [--usage] [--emails]");
   console.log("  kiln auth codex logout [--id <id>]");
   console.log("  kiln auth opencode link [--tier go|zen] [--id <id>] [--key <key>]    Link OpenCode API key (imports from OpenCode config if present)");
   console.log("  kiln auth opencode import [--tier go|zen] [--id <id>]                Import OpenCode API key from native OpenCode config");

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -2,10 +2,11 @@ import { randomBytes } from "node:crypto";
 import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { OpenCodeAuth, type CodexOAuthTokenFile, type OpenCodeTier } from "@kilnai/core";
+import { CREDENTIAL_FILE_MODE, OpenCodeAuth, type CodexOAuthTokenFile, type OpenCodeTier } from "@kilnai/core";
 import {
   CodexOAuthCredentialPoolService,
   OpenCodeCredentialPoolService,
+  listOverPermissiveCredentialFiles,
   startProviderAuthRequest,
 } from "@kilnai/runtime";
 import { resolveNativeHarnessDir } from "../config/native-harness-home.js";
@@ -23,8 +24,6 @@ const EXPIRING_SOON_MS = 120 * 1000;
 const NATIVE_CODEX_AUTH_BACKUP_TARGET_ID = "codex-native-auth";
 /** Enough history to recover across a few bad switches without retaining token material indefinitely. */
 const NATIVE_CODEX_AUTH_BACKUP_RETENTION = 5;
-/** Owner-only; a credential copy must never be more readable than its source. */
-const CREDENTIAL_FILE_MODE = 0o600;
 const POOLED_PROVIDER_AUTH_FILES = new Set(["opencode.json", "codex-oauth.json"]);
 const DIRECT_OPENCODE_AUTH_DIR = "opencode-api";
 
@@ -552,6 +551,24 @@ async function printAllProviderStatuses(): Promise<void> {
       : "unknown";
     console.log(`${provider}: ${status}${expiry === "unknown" ? "" : ` (expires ${expiry})`}`);
   }
+
+  await printCredentialPermissionWarnings();
+}
+
+/**
+ * Store-wide finding, so it belongs on the store-wide command rather than being
+ * repeated by each provider status.
+ */
+async function printCredentialPermissionWarnings(): Promise<void> {
+  const findings = await listOverPermissiveCredentialFiles({ rootDir: AUTH_DIR });
+  if (findings.length === 0) return;
+  console.log("");
+  console.log("Warning: credential files readable beyond their owner:");
+  for (const finding of findings) {
+    console.log(`  ${finding.relativePath} (mode ${finding.mode})`);
+  }
+  console.log("These repair themselves the next time Kiln writes them. To fix now:");
+  console.log(`  chmod 600 ${findings.map((finding) => `${AUTH_DIR}/${finding.relativePath}`).join(" ")}`);
 }
 
 async function loadGenericTokenFile(path: string): Promise<Partial<CodexOAuthTokenFile> | null> {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { copyFile, mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { OpenCodeAuth, type CodexOAuthTokenFile, type OpenCodeTier } from "@kilnai/core";
@@ -9,6 +9,7 @@ import {
   startProviderAuthRequest,
 } from "@kilnai/runtime";
 import { resolveNativeHarnessDir } from "../config/native-harness-home.js";
+import { backupNativeProjectionFile } from "../config/native-projection-backup.js";
 import {
   fromNativeCodexAuthFile,
   parseNativeCodexAuthFile,
@@ -16,8 +17,14 @@ import {
   type NativeCodexAuthFile,
 } from "../config/codex-native-account-sync.js";
 
-const AUTH_DIR = join(homedir(), ".kiln", "auth");
+const KILN_DIR = join(homedir(), ".kiln");
+const AUTH_DIR = join(KILN_DIR, "auth");
 const EXPIRING_SOON_MS = 120 * 1000;
+const NATIVE_CODEX_AUTH_BACKUP_TARGET_ID = "codex-native-auth";
+/** Enough history to recover across a few bad switches without retaining token material indefinitely. */
+const NATIVE_CODEX_AUTH_BACKUP_RETENTION = 5;
+/** Owner-only; a credential copy must never be more readable than its source. */
+const CREDENTIAL_FILE_MODE = 0o600;
 const POOLED_PROVIDER_AUTH_FILES = new Set(["opencode.json", "codex-oauth.json"]);
 const DIRECT_OPENCODE_AUTH_DIR = "opencode-api";
 
@@ -135,15 +142,25 @@ async function runCodexStatus(rest: string[]): Promise<void> {
   }
 }
 
-interface CodexActivateSelection {
-  readonly auto: boolean;
-  readonly id?: string;
-}
+type CodexActivateSelection =
+  | { readonly kind: "auto" }
+  | { readonly kind: "explicit"; readonly id: string };
 
+/**
+ * A credential proven activatable: `id_token` is required by the type, so a
+ * native auth file can never be written from a credential lacking one.
+ */
 interface CodexActivationTarget {
   readonly id: string;
-  readonly tokenFile: CodexOAuthTokenFile;
+  readonly tokenFile: CodexOAuthTokenFile & { readonly id_token: string };
 }
+
+/** Distinguishes "nothing had quota" from "something had quota but could not be made activatable". */
+type CodexActivationOutcome =
+  | { readonly kind: "selected"; readonly target: CodexActivationTarget }
+  | { readonly kind: "unknown-credential"; readonly id: string }
+  | { readonly kind: "no-available-credential" }
+  | { readonly kind: "no-activatable-credential"; readonly blockedIds: readonly string[] };
 
 async function runCodexActivate(rest: string[]): Promise<void> {
   const selection = parseCodexActivateOptions(rest);
@@ -155,21 +172,20 @@ async function runCodexActivate(rest: string[]): Promise<void> {
     console.log(`Absorbed currently active native Codex account (${absorbedAccountId}) into the Kiln pool.`);
   }
 
-  const target = await resolveActivationTarget(pool, selection);
-  if (!target) {
-    console.log(selection.auto
-      ? "No available Codex OAuth credential found to activate."
-      : `Unknown or unusable Codex OAuth credential: ${selection.id}`);
+  const outcome = await resolveActivationTarget(pool, selection);
+  if (outcome.kind !== "selected") {
+    console.log(describeActivationFailure(outcome));
     return;
   }
+  const target = outcome.target;
 
-  // Native Codex CLI/App requires id_token in auth.json; never write a native file without one.
-  if (!target.tokenFile.id_token) {
-    console.log(`Credential ${target.id} has no id_token even after a refresh attempt. Native Codex CLI/App requires one. Run 'kiln auth codex login' to relink this account, then try activate again.`);
-    return;
-  }
-
-  const backupPath = await backupNativeAuthFile(nativeAuthPath);
+  const backupPath = backupNativeProjectionFile({
+    kilnDir: KILN_DIR,
+    targetId: NATIVE_CODEX_AUTH_BACKUP_TARGET_ID,
+    filePath: nativeAuthPath,
+    retain: NATIVE_CODEX_AUTH_BACKUP_RETENTION,
+    mode: CREDENTIAL_FILE_MODE,
+  });
   if (backupPath) {
     console.log(`Backed up previous native Codex auth to ${backupPath}`);
   }
@@ -181,9 +197,11 @@ async function runCodexActivate(rest: string[]): Promise<void> {
 }
 
 function parseCodexActivateOptions(rest: string[]): CodexActivateSelection {
-  if (rest.length === 1 && rest[0] === "--auto") return { auto: true };
-  if (rest.length === 1 && rest[0] && !rest[0].startsWith("-")) return { auto: false, id: rest[0] };
-  throw new Error("Usage: kiln auth codex activate <id> | --auto");
+  const [only] = rest;
+  if (rest.length !== 1 || !only) throw new Error("Usage: kiln auth codex activate <id> | --auto");
+  if (only === "--auto") return { kind: "auto" };
+  if (only.startsWith("-")) throw new Error("Usage: kiln auth codex activate <id> | --auto");
+  return { kind: "explicit", id: only };
 }
 
 /** Never fails the activation flow; a missing or unreadable native auth file just means nothing to absorb. */
@@ -212,12 +230,16 @@ async function absorbCurrentNativeAccount(
 async function resolveActivationTarget(
   pool: CodexOAuthCredentialPoolService,
   selection: CodexActivateSelection,
-): Promise<CodexActivationTarget | null> {
-  if (!selection.auto) {
-    const id = selection.id ?? "";
+): Promise<CodexActivationOutcome> {
+  if (selection.kind === "explicit") {
+    const id = selection.id;
     const tokenFile = await pool.ensureCredentialIdToken(id);
-    return tokenFile ? { id, tokenFile } : null;
+    if (!tokenFile) return { kind: "unknown-credential", id };
+    return tokenFile.id_token
+      ? { kind: "selected", target: { id, tokenFile: { ...tokenFile, id_token: tokenFile.id_token } } }
+      : { kind: "no-activatable-credential", blockedIds: [id] };
   }
+
   const [usage, status] = await Promise.all([pool.refreshUsage(), pool.listStatus()]);
   const executableIds = new Set(
     status.filter((entry) => entry.status === "valid" || entry.status === "expiring-soon").map((entry) => entry.id),
@@ -225,33 +247,44 @@ async function resolveActivationTarget(
   const ranked = usage
     .filter((entry) => executableIds.has(entry.credentialId) && entry.availability === "available")
     .sort((a, b) => (a.primary?.usedPercent ?? 0) - (b.primary?.usedPercent ?? 0));
+  if (ranked.length === 0) return { kind: "no-available-credential" };
+
+  const blockedIds: string[] = [];
   for (const candidate of ranked) {
     const tokenFile = await pool.ensureCredentialIdToken(candidate.credentialId);
-    if (tokenFile?.id_token) return { id: candidate.credentialId, tokenFile };
+    if (tokenFile?.id_token) {
+      return {
+        kind: "selected",
+        target: { id: candidate.credentialId, tokenFile: { ...tokenFile, id_token: tokenFile.id_token } },
+      };
+    }
+    blockedIds.push(candidate.credentialId);
   }
-  return null;
+  return { kind: "no-activatable-credential", blockedIds };
 }
 
-async function backupNativeAuthFile(nativeAuthPath: string): Promise<string | undefined> {
-  const backupPath = `${nativeAuthPath}.bak-${Date.now()}`;
-  try {
-    await copyFile(nativeAuthPath, backupPath);
-    return backupPath;
-  } catch (error) {
-    if (isNodeEnoent(error)) return undefined;
-    throw error;
+function describeActivationFailure(outcome: Exclude<CodexActivationOutcome, { kind: "selected" }>): string {
+  switch (outcome.kind) {
+    case "unknown-credential":
+      return `Unknown Codex OAuth credential: ${outcome.id}. Run 'kiln auth codex status' to list linked credentials.`;
+    case "no-available-credential":
+      return "No Codex OAuth credential currently has available quota. Run 'kiln auth codex status --usage' to see reset times.";
+    case "no-activatable-credential":
+      return `Native Codex CLI/App requires an id_token, and none could be recovered for: ${outcome.blockedIds.join(", ")}. Run 'kiln auth codex login' to relink ${outcome.blockedIds.length === 1 ? "this account" : "these accounts"}, then activate again.`;
   }
 }
 
 async function writeNativeAuthFileAtomically(nativeAuthPath: string, native: NativeCodexAuthFile): Promise<void> {
   await mkdir(dirname(nativeAuthPath), { recursive: true });
-  const tempPath = `${nativeAuthPath}.${randomBytes(8).toString("hex")}.tmp`;
-  await writeFile(tempPath, `${JSON.stringify(native, null, 2)}\n`, "utf8");
-  await rename(tempPath, nativeAuthPath);
-}
-
-function isNodeEnoent(error: unknown): boolean {
-  return error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT";
+  const tempPath = join(dirname(nativeAuthPath), `.auth.json.${randomBytes(8).toString("hex")}.tmp`);
+  let renamed = false;
+  try {
+    await writeFile(tempPath, `${JSON.stringify(native, null, 2)}\n`, { encoding: "utf8", mode: CREDENTIAL_FILE_MODE });
+    await rename(tempPath, nativeAuthPath);
+    renamed = true;
+  } finally {
+    if (!renamed) await rm(tempPath, { force: true });
+  }
 }
 
 async function runCodexLogout(rest: string[]): Promise<void> {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,12 +1,20 @@
-import { readdir, readFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { copyFile, mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { OpenCodeAuth, type CodexOAuthTokenFile, type OpenCodeTier } from "@kilnai/core";
 import {
   CodexOAuthCredentialPoolService,
   OpenCodeCredentialPoolService,
   startProviderAuthRequest,
 } from "@kilnai/runtime";
+import { resolveNativeHarnessDir } from "../config/native-harness-home.js";
+import {
+  fromNativeCodexAuthFile,
+  parseNativeCodexAuthFile,
+  toNativeCodexAuthFile,
+  type NativeCodexAuthFile,
+} from "../config/codex-native-account-sync.js";
 
 const AUTH_DIR = join(homedir(), ".kiln", "auth");
 const EXPIRING_SOON_MS = 120 * 1000;
@@ -49,6 +57,9 @@ export async function runAuth(args: string[]): Promise<void> {
         return;
       case "status":
         await runCodexStatus(args.slice(2));
+        return;
+      case "activate":
+        await runCodexActivate(args.slice(2));
         return;
       case "logout":
         await runCodexLogout(args.slice(2));
@@ -122,6 +133,116 @@ async function runCodexStatus(rest: string[]): Promise<void> {
       console.log(`    Usage observed: ${entryUsage.observedAt}`);
     }
   }
+}
+
+interface CodexActivateSelection {
+  readonly auto: boolean;
+  readonly id?: string;
+}
+
+interface CodexActivationTarget {
+  readonly id: string;
+  readonly tokenFile: CodexOAuthTokenFile;
+}
+
+async function runCodexActivate(rest: string[]): Promise<void> {
+  const selection = parseCodexActivateOptions(rest);
+  const pool = new CodexOAuthCredentialPoolService();
+  const nativeAuthPath = join(resolveNativeHarnessDir("codex"), "auth.json");
+
+  const absorbedAccountId = await absorbCurrentNativeAccount(pool, nativeAuthPath);
+  if (absorbedAccountId) {
+    console.log(`Absorbed currently active native Codex account (${absorbedAccountId}) into the Kiln pool.`);
+  }
+
+  const target = await resolveActivationTarget(pool, selection);
+  if (!target) {
+    console.log(selection.auto
+      ? "No available Codex OAuth credential found to activate."
+      : `Unknown or unusable Codex OAuth credential: ${selection.id}`);
+    return;
+  }
+
+  const backupPath = await backupNativeAuthFile(nativeAuthPath);
+  if (backupPath) {
+    console.log(`Backed up previous native Codex auth to ${backupPath}`);
+  }
+
+  await writeNativeAuthFileAtomically(nativeAuthPath, toNativeCodexAuthFile(target.tokenFile, new Date().toISOString()));
+
+  const email = (await pool.listCredentialEmails()).get(target.id);
+  console.log(`Activated Codex OAuth credential ${target.id}${email ? ` (${email})` : ""} in native Codex CLI/App.`);
+}
+
+function parseCodexActivateOptions(rest: string[]): CodexActivateSelection {
+  if (rest.length === 1 && rest[0] === "--auto") return { auto: true };
+  if (rest.length === 1 && rest[0] && !rest[0].startsWith("-")) return { auto: false, id: rest[0] };
+  throw new Error("Usage: kiln auth codex activate <id> | --auto");
+}
+
+/** Never fails the activation flow; a missing or unreadable native auth file just means nothing to absorb. */
+async function absorbCurrentNativeAccount(
+  pool: CodexOAuthCredentialPoolService,
+  nativeAuthPath: string,
+): Promise<string | undefined> {
+  let raw: string;
+  try {
+    raw = await readFile(nativeAuthPath, "utf8");
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  const native: NativeCodexAuthFile | null = parseNativeCodexAuthFile(parsed);
+  if (!native) return undefined;
+  await pool.linkCredential({ tokenFile: fromNativeCodexAuthFile(native) });
+  return native.tokens.account_id ?? undefined;
+}
+
+async function resolveActivationTarget(
+  pool: CodexOAuthCredentialPoolService,
+  selection: CodexActivateSelection,
+): Promise<CodexActivationTarget | null> {
+  if (!selection.auto) {
+    const tokenFile = await pool.getCredentialTokenFile(selection.id ?? "");
+    return tokenFile ? { id: selection.id ?? "", tokenFile } : null;
+  }
+  const [usage, status] = await Promise.all([pool.refreshUsage(), pool.listStatus()]);
+  const executableIds = new Set(
+    status.filter((entry) => entry.status === "valid" || entry.status === "expiring-soon").map((entry) => entry.id),
+  );
+  const best = usage
+    .filter((entry) => executableIds.has(entry.credentialId) && entry.availability === "available")
+    .sort((a, b) => (a.primary?.usedPercent ?? 0) - (b.primary?.usedPercent ?? 0))[0];
+  if (!best) return null;
+  const tokenFile = await pool.getCredentialTokenFile(best.credentialId);
+  return tokenFile ? { id: best.credentialId, tokenFile } : null;
+}
+
+async function backupNativeAuthFile(nativeAuthPath: string): Promise<string | undefined> {
+  const backupPath = `${nativeAuthPath}.bak-${Date.now()}`;
+  try {
+    await copyFile(nativeAuthPath, backupPath);
+    return backupPath;
+  } catch (error) {
+    if (isNodeEnoent(error)) return undefined;
+    throw error;
+  }
+}
+
+async function writeNativeAuthFileAtomically(nativeAuthPath: string, native: NativeCodexAuthFile): Promise<void> {
+  await mkdir(dirname(nativeAuthPath), { recursive: true });
+  const tempPath = `${nativeAuthPath}.${randomBytes(8).toString("hex")}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(native, null, 2)}\n`, "utf8");
+  await rename(tempPath, nativeAuthPath);
+}
+
+function isNodeEnoent(error: unknown): boolean {
+  return error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
 async function runCodexLogout(rest: string[]): Promise<void> {
@@ -432,6 +553,7 @@ function printUsage(): void {
   console.log("Usage: kiln auth <subcommand>");
   console.log("  kiln auth codex login");
   console.log("  kiln auth codex status [--usage] [--emails]");
+  console.log("  kiln auth codex activate <id> | --auto                              Point native Codex CLI/App at a pooled account (backs up the previous one)");
   console.log("  kiln auth codex logout [--id <id>]");
   console.log("  kiln auth opencode link [--tier go|zen] [--id <id>] [--key <key>]    Link OpenCode API key (imports from OpenCode config if present)");
   console.log("  kiln auth opencode import [--tier go|zen] [--id <id>]                Import OpenCode API key from native OpenCode config");

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -163,6 +163,12 @@ async function runCodexActivate(rest: string[]): Promise<void> {
     return;
   }
 
+  // Native Codex CLI/App requires id_token in auth.json; never write a native file without one.
+  if (!target.tokenFile.id_token) {
+    console.log(`Credential ${target.id} has no id_token even after a refresh attempt. Native Codex CLI/App requires one. Run 'kiln auth codex login' to relink this account, then try activate again.`);
+    return;
+  }
+
   const backupPath = await backupNativeAuthFile(nativeAuthPath);
   if (backupPath) {
     console.log(`Backed up previous native Codex auth to ${backupPath}`);
@@ -208,19 +214,22 @@ async function resolveActivationTarget(
   selection: CodexActivateSelection,
 ): Promise<CodexActivationTarget | null> {
   if (!selection.auto) {
-    const tokenFile = await pool.getCredentialTokenFile(selection.id ?? "");
-    return tokenFile ? { id: selection.id ?? "", tokenFile } : null;
+    const id = selection.id ?? "";
+    const tokenFile = await pool.ensureCredentialIdToken(id);
+    return tokenFile ? { id, tokenFile } : null;
   }
   const [usage, status] = await Promise.all([pool.refreshUsage(), pool.listStatus()]);
   const executableIds = new Set(
     status.filter((entry) => entry.status === "valid" || entry.status === "expiring-soon").map((entry) => entry.id),
   );
-  const best = usage
+  const ranked = usage
     .filter((entry) => executableIds.has(entry.credentialId) && entry.availability === "available")
-    .sort((a, b) => (a.primary?.usedPercent ?? 0) - (b.primary?.usedPercent ?? 0))[0];
-  if (!best) return null;
-  const tokenFile = await pool.getCredentialTokenFile(best.credentialId);
-  return tokenFile ? { id: best.credentialId, tokenFile } : null;
+    .sort((a, b) => (a.primary?.usedPercent ?? 0) - (b.primary?.usedPercent ?? 0));
+  for (const candidate of ranked) {
+    const tokenFile = await pool.ensureCredentialIdToken(candidate.credentialId);
+    if (tokenFile?.id_token) return { id: candidate.credentialId, tokenFile };
+  }
+  return null;
 }
 
 async function backupNativeAuthFile(nativeAuthPath: string): Promise<string | undefined> {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -2022,6 +2022,7 @@ function resolveParallelWorkerAdmissionLimits(
     if (flags.model && route.model !== flags.model) return false;
     const profile = route.profiles["foundation-apply-approved-writes"];
     return profile !== undefined
+      && route.adapter !== undefined
       && profile.workingDirectory.mode === "isolated-worktree"
       && profile.workingDirectoryLease !== undefined
       && route.adapter.descriptor.lifecycle.exposesStart

--- a/packages/cli/src/config/codex-native-account-sync.ts
+++ b/packages/cli/src/config/codex-native-account-sync.ts
@@ -1,0 +1,97 @@
+import type { CodexOAuthTokenFile } from "@kilnai/core";
+import { CODEX_OAUTH_CLIENT_ID } from "@kilnai/core";
+
+/**
+ * Shape of `~/.codex/auth.json` as written/read by the native Codex CLI/App
+ * (see `codex-rs/login/src/token_data.rs` `TokenData` / `AuthDotJson`).
+ * Kiln never assumes this is stable across upstream Codex releases beyond
+ * what's validated here.
+ */
+export interface NativeCodexAuthFile {
+  readonly auth_mode: "chatgpt";
+  readonly OPENAI_API_KEY: string | null;
+  readonly tokens: {
+    readonly id_token?: string;
+    readonly access_token: string;
+    readonly refresh_token: string;
+    readonly account_id: string | null;
+  };
+  readonly last_refresh: string;
+}
+
+export function parseNativeCodexAuthFile(value: unknown): NativeCodexAuthFile | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  const tokens = record.tokens;
+  if (typeof tokens !== "object" || tokens === null) return null;
+  const tokensRecord = tokens as Record<string, unknown>;
+  const accessToken = tokensRecord.access_token;
+  const refreshToken = tokensRecord.refresh_token;
+  if (typeof accessToken !== "string" || accessToken.trim().length === 0) return null;
+  if (typeof refreshToken !== "string" || refreshToken.trim().length === 0) return null;
+  const idToken = typeof tokensRecord.id_token === "string" && tokensRecord.id_token.trim().length > 0
+    ? tokensRecord.id_token
+    : undefined;
+  const accountId = typeof tokensRecord.account_id === "string" ? tokensRecord.account_id : null;
+  return {
+    auth_mode: "chatgpt",
+    OPENAI_API_KEY: null,
+    tokens: {
+      ...(idToken ? { id_token: idToken } : {}),
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      account_id: accountId,
+    },
+    last_refresh: typeof record.last_refresh === "string" ? record.last_refresh : new Date(0).toISOString(),
+  };
+}
+
+/** Absorb whatever account is currently active in native `auth.json` into Kiln's pool shape. */
+export function fromNativeCodexAuthFile(native: NativeCodexAuthFile): CodexOAuthTokenFile {
+  return {
+    access_token: native.tokens.access_token,
+    refresh_token: native.tokens.refresh_token,
+    expires_at: readJwtExpiry(native.tokens.access_token) ?? new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    client_id: CODEX_OAUTH_CLIENT_ID,
+    ...(native.tokens.id_token ? { id_token: native.tokens.id_token } : {}),
+  };
+}
+
+/** Project a pooled Kiln credential into the shape native Codex CLI/App expects at `~/.codex/auth.json`. */
+export function toNativeCodexAuthFile(tokenFile: CodexOAuthTokenFile, nowIso: string): NativeCodexAuthFile {
+  return {
+    auth_mode: "chatgpt",
+    OPENAI_API_KEY: null,
+    tokens: {
+      ...(tokenFile.id_token ? { id_token: tokenFile.id_token } : {}),
+      access_token: tokenFile.access_token,
+      refresh_token: tokenFile.refresh_token,
+      account_id: readChatgptAccountId(tokenFile.access_token),
+    },
+    last_refresh: nowIso,
+  };
+}
+
+function readChatgptAccountId(accessToken: string): string | null {
+  const claims = decodeJwtPayload(accessToken);
+  const auth = claims?.["https://api.openai.com/auth"];
+  if (typeof auth !== "object" || auth === null || Array.isArray(auth)) return null;
+  const accountId = (auth as Record<string, unknown>).chatgpt_account_id;
+  return typeof accountId === "string" && accountId.trim().length > 0 ? accountId.trim() : null;
+}
+
+function readJwtExpiry(accessToken: string): string | null {
+  const claims = decodeJwtPayload(accessToken);
+  const exp = claims?.exp;
+  return typeof exp === "number" && Number.isFinite(exp) && exp > 0 ? new Date(exp * 1000).toISOString() : null;
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/config/global-config.ts
+++ b/packages/cli/src/config/global-config.ts
@@ -2,7 +2,16 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { parse, stringify } from "yaml";
-import { parseGatewayYaml, validateVoiceConfig, type ModelGatewayConfig, type VoiceConfig } from "@kilnai/core";
+import {
+  compareManagedEconomicAmounts,
+  deriveManagedEconomicMinimumReservation,
+  parseGatewayYaml,
+  validateManagedEconomicAmount,
+  validateVoiceConfig,
+  type ManagedEconomicAmount,
+  type ModelGatewayConfig,
+  type VoiceConfig,
+} from "@kilnai/core";
 import { KilnYamlError } from "../kiln-yaml.js";
 import { DEFAULT_WORK_GOVERNANCE_CONFIG } from "../kiln-yaml-types.js";
 import { readMcpConfigurationSource } from "./mcp-config.js";
@@ -621,22 +630,67 @@ function validateManagedAgents(value: unknown, operatorVoice: VoiceConfig | unde
   if (!isRecord(value)) {
     throw new KilnYamlError("managedAgents must be an object");
   }
+  rejectUnknownFields(value, [
+    "schemaVersion",
+    "enabled",
+    "defaultProfile",
+    "defaultProvider",
+    "defaultVoiceProfile",
+    "model",
+    "worktreeLease",
+    "requireApproval",
+    "routes",
+    "economicPolicies",
+  ], "managedAgents");
+  if (value.economicPolicies !== undefined && value.schemaVersion !== 2) {
+    throw new KilnYamlError("managedAgents.schemaVersion must be 2 when economicPolicies are declared");
+  }
+  if (value.schemaVersion !== undefined && value.schemaVersion !== 2) {
+    throw new KilnYamlError("managedAgents.schemaVersion must be 2");
+  }
+  if (value.schemaVersion === 2 && (!Array.isArray(value.economicPolicies) || value.economicPolicies.length === 0)) {
+    throw new KilnYamlError("managedAgents.schemaVersion 2 requires non-empty economicPolicies");
+  }
   validateManagedAgentWorktreeLease(value.worktreeLease);
   validateManagedAgentVoiceProfile(value.defaultVoiceProfile, "managedAgents.defaultVoiceProfile", operatorVoice);
+  const routeIds = new Set<string>();
   if (value.routes !== undefined) {
     if (!Array.isArray(value.routes)) {
       throw new KilnYamlError("managedAgents.routes must be an array");
     }
     for (let index = 0; index < value.routes.length; index += 1) {
       validateManagedAgentRoute(value.routes[index], index, operatorVoice);
+      const route = value.routes[index];
+      if (isRecord(route) && routeIds.has(String(route.id))) {
+        throw new KilnYamlError(`managedAgents.routes[${index}].id must be unique`);
+      }
+      if (isRecord(route)) routeIds.add(String(route.id));
     }
   }
+  validateManagedEconomicPolicies(value.economicPolicies);
 }
 
 function validateManagedAgentRoute(value: unknown, index: number, operatorVoice: VoiceConfig | undefined): void {
   if (!isRecord(value)) {
     throw new KilnYamlError(`managedAgents.routes[${index}] must be an object`);
   }
+  rejectUnknownFields(value, [
+    "id",
+    "kind",
+    "provider",
+    "model",
+    "voiceProfile",
+    "profiles",
+    "workingDirectory",
+    "timeoutMs",
+    "tools",
+    "memory",
+    "readAuthority",
+    "writeAuthority",
+    "credentials",
+    "remoteHarness",
+    "externalRuntimeAttachment",
+  ], `managedAgents.routes[${index}]`);
   if (typeof value.id !== "string" || value.id.trim().length === 0) {
     throw new KilnYamlError(`managedAgents.routes[${index}].id is required`);
   }
@@ -662,6 +716,174 @@ function validateManagedAgentRoute(value: unknown, index: number, operatorVoice:
   validateManagedAgentWriteAuthority(value.writeAuthority, `managedAgents.routes[${index}].writeAuthority`);
   validateManagedAgentCredentials(value.credentials, `managedAgents.routes[${index}].credentials`);
   validateManagedAgentRemoteHarness(value.remoteHarness, value.kind, `managedAgents.routes[${index}].remoteHarness`);
+}
+
+function validateManagedEconomicPolicies(value: unknown): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new KilnYamlError("managedAgents.economicPolicies must be a non-empty array");
+  }
+  const policyIds = new Set<string>();
+  for (let policyIndex = 0; policyIndex < value.length; policyIndex += 1) {
+    const path = `managedAgents.economicPolicies[${policyIndex}]`;
+    const policy = value[policyIndex];
+    if (!isRecord(policy)) throw new KilnYamlError(`${path} must be an object`);
+    rejectUnknownFields(policy, ["id", "revision", "evidenceRequirements", "noRouteAction", "comparisonDomains", "candidates"], path);
+    validateCanonicalId(policy.id, `${path}.id`);
+    if (policyIds.has(String(policy.id))) throw new KilnYamlError(`${path}.id must be unique`);
+    policyIds.add(String(policy.id));
+    validateCanonicalId(policy.revision, `${path}.revision`);
+    if (policy.noRouteAction !== "deny") throw new KilnYamlError(`${path}.noRouteAction must be "deny"`);
+    validateEconomicEvidenceRequirements(policy.evidenceRequirements, `${path}.evidenceRequirements`);
+    const domains = validateEconomicComparisonDomains(policy.comparisonDomains, `${path}.comparisonDomains`);
+    validateEconomicCandidates(policy.candidates, domains, `${path}.candidates`);
+  }
+}
+
+function validateEconomicEvidenceRequirements(value: unknown, path: string): void {
+  if (!isRecord(value)) throw new KilnYamlError(`${path} must be an object`);
+  rejectUnknownFields(value, ["quota", "price"], path);
+  if (value.quota !== "optional" && value.quota !== "required-for-account-bound") {
+    throw new KilnYamlError(`${path}.quota is invalid`);
+  }
+  if (value.price !== "optional" && value.price !== "required") {
+    throw new KilnYamlError(`${path}.price is invalid`);
+  }
+}
+
+function validateEconomicComparisonDomains(value: unknown, path: string): Map<string, Record<string, unknown>> {
+  if (!Array.isArray(value) || value.length === 0) throw new KilnYamlError(`${path} must be a non-empty array`);
+  const domains = new Map<string, Record<string, unknown>>();
+  const ranks = new Set<number>();
+  for (let index = 0; index < value.length; index += 1) {
+    const domainPath = `${path}[${index}]`;
+    const domain = value[index];
+    if (!isRecord(domain)) throw new KilnYamlError(`${domainPath} must be an object`);
+    rejectUnknownFields(domain, ["id", "rank", "unit", "scheme", "rateCardBasis", "envelopeSemantics"], domainPath);
+    validateCanonicalId(domain.id, `${domainPath}.id`);
+    validateCanonicalId(domain.unit, `${domainPath}.unit`);
+    validateCanonicalId(domain.rateCardBasis, `${domainPath}.rateCardBasis`);
+    validateCanonicalId(domain.envelopeSemantics, `${domainPath}.envelopeSemantics`);
+    if (!Number.isSafeInteger(domain.rank) || Number(domain.rank) < 0) throw new KilnYamlError(`${domainPath}.rank must be a non-negative integer`);
+    if (domains.has(String(domain.id))) throw new KilnYamlError(`${domainPath}.id must be unique`);
+    if (ranks.has(Number(domain.rank))) throw new KilnYamlError(`${domainPath}.rank must be unique`);
+    validateEconomicScheme(domain.scheme, `${domainPath}.scheme`);
+    domains.set(String(domain.id), domain);
+    ranks.add(Number(domain.rank));
+  }
+  return domains;
+}
+
+function validateEconomicCandidates(
+  value: unknown,
+  domains: ReadonlyMap<string, Record<string, unknown>>,
+  path: string,
+): void {
+  if (!Array.isArray(value) || value.length === 0) throw new KilnYamlError(`${path} must be a non-empty array`);
+  const routeIds = new Set<string>();
+  for (let index = 0; index < value.length; index += 1) {
+    const candidatePath = `${path}[${index}]`;
+    const candidate = value[index];
+    if (!isRecord(candidate)) throw new KilnYamlError(`${candidatePath} must be an object`);
+    rejectUnknownFields(candidate, ["routeId", "comparisonDomainId", "priorityRank", "ceiling", "worstCaseReservation"], candidatePath);
+    validateCanonicalId(candidate.routeId, `${candidatePath}.routeId`);
+    validateCanonicalId(candidate.comparisonDomainId, `${candidatePath}.comparisonDomainId`);
+    if (routeIds.has(String(candidate.routeId))) throw new KilnYamlError(`${candidatePath}.routeId must be unique within the policy`);
+    routeIds.add(String(candidate.routeId));
+    const domain = domains.get(String(candidate.comparisonDomainId));
+    if (!domain) throw new KilnYamlError(`${candidatePath}.comparisonDomainId must reference a policy comparison domain`);
+    if (!Number.isSafeInteger(candidate.priorityRank) || Number(candidate.priorityRank) < 0) {
+      throw new KilnYamlError(`${candidatePath}.priorityRank must be a non-negative integer`);
+    }
+    validateEconomicCeiling(candidate.ceiling, domain, `${candidatePath}.ceiling`);
+    validateEconomicReservation(candidate.worstCaseReservation, domain, `${candidatePath}.worstCaseReservation`);
+    if (isRecord(candidate.ceiling) && candidate.ceiling.kind === "finite") {
+      if (!isRecord(candidate.worstCaseReservation) || candidate.worstCaseReservation.kind !== "exact") {
+        throw new KilnYamlError(`${candidatePath}.worstCaseReservation must be exact when ceiling is finite`);
+      }
+      const reservation = candidate.worstCaseReservation.amount as ManagedEconomicAmount;
+      const ceiling = candidate.ceiling.amount as ManagedEconomicAmount;
+      if (compareManagedEconomicAmounts(reservation, ceiling) > 0) {
+        throw new KilnYamlError(`${candidatePath}.worstCaseReservation must not exceed its finite ceiling`);
+      }
+    }
+  }
+}
+
+function validateEconomicReservation(
+  value: unknown,
+  domain: Readonly<Record<string, unknown>>,
+  path: string,
+): void {
+  if (!isRecord(value)) throw new KilnYamlError(`${path} must be an object`);
+  if (value.kind === "exact") {
+    rejectUnknownFields(value, ["kind", "amount"], path);
+    validateEconomicAmount(value.amount, `${path}.amount`);
+    const amount = value.amount as ManagedEconomicAmount;
+    if (amount.unit !== domain.unit || !economicSchemesEqual(amount.scheme, domain.scheme)) {
+      throw new KilnYamlError(`${path}.amount must use the comparison domain unit and scheme`);
+    }
+    return;
+  }
+  if (value.kind !== "not-comparable") {
+    throw new KilnYamlError(`${path}.kind must be "exact" or "not-comparable"`);
+  }
+  rejectUnknownFields(value, ["kind", "reason"], path);
+  if (![
+    "subscription-basis",
+    "included-basis",
+    "estimated-basis",
+    "unknown-basis",
+    "economic-basis-unavailable",
+  ].includes(String(value.reason))) {
+    throw new KilnYamlError(`${path}.reason is invalid`);
+  }
+}
+
+function validateEconomicCeiling(
+  value: unknown,
+  domain: Readonly<Record<string, unknown>>,
+  path: string,
+): void {
+  if (!isRecord(value)) throw new KilnYamlError(`${path} must be an object`);
+  if (value.kind === "none") {
+    rejectUnknownFields(value, ["kind"], path);
+    return;
+  }
+  if (value.kind !== "finite") throw new KilnYamlError(`${path}.kind must be "none" or "finite"`);
+  rejectUnknownFields(value, ["kind", "amount"], path);
+  validateEconomicAmount(value.amount, `${path}.amount`);
+  const amount = value.amount as ManagedEconomicAmount;
+  if (amount.unit !== domain.unit || !economicSchemesEqual(amount.scheme, domain.scheme)) {
+    throw new KilnYamlError(`${path}.amount must use the comparison domain unit and scheme`);
+  }
+}
+
+function validateEconomicAmount(value: unknown, path: string): void {
+  if (!isRecord(value)) throw new KilnYamlError(`${path} must be an object`);
+  rejectUnknownFields(value, ["atoms", "scale", "unit", "scheme"], path);
+  validateEconomicScheme(value.scheme, `${path}.scheme`);
+  try {
+    validateManagedEconomicAmount(value as unknown as ManagedEconomicAmount);
+  } catch (error) {
+    throw new KilnYamlError(`${path} is invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function validateEconomicScheme(value: unknown, path: string): void {
+  if (!isRecord(value)) throw new KilnYamlError(`${path} must be an object`);
+  if (value.kind === "currency") {
+    rejectUnknownFields(value, ["kind", "currency"], path);
+    validateCanonicalId(value.currency, `${path}.currency`);
+    return;
+  }
+  if (value.kind === "credit") {
+    rejectUnknownFields(value, ["kind", "creditSchemeId"], path);
+    validateCanonicalId(value.creditSchemeId, `${path}.creditSchemeId`);
+    return;
+  }
+  if (value.kind !== "unit") throw new KilnYamlError(`${path}.kind is invalid`);
+  rejectUnknownFields(value, ["kind"], path);
 }
 
 function validateManagedAgentCredentials(value: unknown, path: string): void {
@@ -691,12 +913,13 @@ function validateManagedAgentCredentials(value: unknown, path: string): void {
 }
 
 function validateManagedAccountPolicyReferences(managedAgents: unknown, modelGateway: unknown): void {
-  if (!isRecord(managedAgents) || !Array.isArray(managedAgents.routes)) return;
+  if (!isRecord(managedAgents)) return;
+  const routes = Array.isArray(managedAgents.routes) ? managedAgents.routes.filter(isRecord) : [];
   const policies = isRecord(modelGateway) && Array.isArray(modelGateway.virtualModels)
     ? modelGateway.virtualModels.filter(isRecord)
     : [];
-  for (let index = 0; index < managedAgents.routes.length; index += 1) {
-    const route = managedAgents.routes[index];
+  for (let index = 0; index < routes.length; index += 1) {
+    const route = routes[index];
     if (!isRecord(route) || !isRecord(route.credentials) || route.credentials.mode !== "runtime-selected") {
       continue;
     }
@@ -717,6 +940,183 @@ function validateManagedAccountPolicyReferences(managedAgents: unknown, modelGat
         `managedAgents.routes[${index}] provider and model must match its modelGateway account policy`,
       );
     }
+  }
+  if (!Array.isArray(managedAgents.economicPolicies)) return;
+  const accounts = isRecord(modelGateway) && Array.isArray(modelGateway.accounts)
+    ? modelGateway.accounts.filter(isRecord)
+    : [];
+  const directProviders = new Set(["codex-oauth", "opencode-go", "opencode-zen"]);
+  for (let policyIndex = 0; policyIndex < managedAgents.economicPolicies.length; policyIndex += 1) {
+    const economicPolicy = managedAgents.economicPolicies[policyIndex];
+    if (!isRecord(economicPolicy) || !Array.isArray(economicPolicy.candidates)) continue;
+    for (let candidateIndex = 0; candidateIndex < economicPolicy.candidates.length; candidateIndex += 1) {
+      const candidate = economicPolicy.candidates[candidateIndex];
+      if (!isRecord(candidate)) continue;
+      const path = `managedAgents.economicPolicies[${policyIndex}].candidates[${candidateIndex}]`;
+      const route = routes.find((entry) => entry.id === candidate.routeId);
+      if (!route) throw new KilnYamlError(`${path}.routeId must reference managedAgents.routes`);
+      if (route.kind !== "direct" || !directProviders.has(String(route.provider))) {
+        throw new KilnYamlError(`${path}.routeId must reference a supported direct economic route`);
+      }
+      if (!isRecord(route.credentials) || route.credentials.mode !== "runtime-selected") {
+        throw new KilnYamlError(`${path}.routeId must reference a runtime-selected account policy`);
+      }
+      const accountPolicyId = route.credentials.accountPolicyId;
+      const virtualModel = policies.find((entry) => entry.id === accountPolicyId);
+      if (!virtualModel || !isRecord(virtualModel.economics)) {
+        throw new KilnYamlError(`${path}.routeId must reference a virtual model with economics`);
+      }
+      const domain = Array.isArray(economicPolicy.comparisonDomains)
+        ? economicPolicy.comparisonDomains.find((entry) =>
+            isRecord(entry) && entry.id === candidate.comparisonDomainId)
+        : undefined;
+      if (!isRecord(domain)) {
+        throw new KilnYamlError(`${path}.comparisonDomainId must reference a policy comparison domain`);
+      }
+      if (domain.rateCardBasis !== virtualModel.economics.rateCardBasis) {
+        throw new KilnYamlError(`${path} comparison domain rateCardBasis must match route economics`);
+      }
+      if (domain.envelopeSemantics !== virtualModel.economics.envelopeSemantics) {
+        throw new KilnYamlError(`${path} comparison domain envelopeSemantics must match route economics`);
+      }
+      validateReservationPriceClass(
+        candidate.worstCaseReservation,
+        isRecord(virtualModel.economics.priceEvidence)
+          ? virtualModel.economics.priceEvidence.kind
+          : undefined,
+        path,
+      );
+      validateRouteEconomicSchemes(virtualModel.economics, domain, path);
+      validateDerivedRouteReservation(candidate.worstCaseReservation, virtualModel.economics, domain, path);
+      if (virtualModel.economics.fallbackPosture !== "disabled" || virtualModel.economics.overagePosture !== "disabled") {
+        throw new KilnYamlError(`${path}.routeId cannot activate uncommitted fallback or overage`);
+      }
+      const accountIds = Array.isArray(virtualModel.accountIds) ? virtualModel.accountIds : [];
+      for (const accountId of accountIds) {
+        const account = accounts.find((entry) => entry.id === accountId);
+        if (!account || !isRecord(account.economics)) {
+          throw new KilnYamlError(`${path}.routeId requires economics for every account candidate`);
+        }
+        if (account.economics.creditPosture !== "disabled" || account.economics.overagePosture !== "disabled") {
+          throw new KilnYamlError(`${path}.routeId cannot activate account credit or overage subcommitments`);
+        }
+      }
+    }
+  }
+}
+
+function validateRouteEconomicSchemes(
+  economics: Readonly<Record<string, unknown>>,
+  domain: Readonly<Record<string, unknown>>,
+  path: string,
+): void {
+  const priceEvidence = economics.priceEvidence;
+  if (isRecord(priceEvidence) && Array.isArray(priceEvidence.unitPrices)) {
+    for (const unitPrice of priceEvidence.unitPrices) {
+      if (
+        !isRecord(unitPrice)
+        || !isRecord(unitPrice.price)
+        || !economicSchemesEqual(unitPrice.price.scheme, domain.scheme)
+      ) {
+        throw new KilnYamlError(`${path} route price scheme must match its comparison domain`);
+      }
+    }
+  }
+  if (Array.isArray(economics.auxiliaryCharges)) {
+    for (const charge of economics.auxiliaryCharges) {
+      if (
+        !isRecord(charge)
+        || !isRecord(charge.amount)
+        || charge.amount.unit !== domain.unit
+        || !economicSchemesEqual(charge.amount.scheme, domain.scheme)
+      ) {
+        throw new KilnYamlError(`${path} auxiliary charge unit and scheme must match its comparison domain`);
+      }
+    }
+  }
+}
+
+function validateDerivedRouteReservation(
+  reservation: unknown,
+  economics: Readonly<Record<string, unknown>>,
+  domain: Readonly<Record<string, unknown>>,
+  path: string,
+): void {
+  const priceEvidence = economics.priceEvidence;
+  if (!isRecord(priceEvidence) || !isRecord(reservation)) return;
+  const auxiliaryCharges = Array.isArray(economics.auxiliaryCharges) ? economics.auxiliaryCharges : [];
+  if (priceEvidence.kind === "free") {
+    if (auxiliaryCharges.length > 0) {
+      throw new KilnYamlError(`${path} free route cannot declare separately charged auxiliary calls`);
+    }
+    if (reservation.kind !== "exact" || !isRecord(reservation.amount)) return;
+    const amount = reservation.amount as unknown as ManagedEconomicAmount;
+    const zero: ManagedEconomicAmount = {
+      atoms: "0",
+      scale: 0,
+      unit: amount.unit,
+      scheme: amount.scheme,
+    };
+    if (compareManagedEconomicAmounts(amount, zero) !== 0) {
+      throw new KilnYamlError(`${path} free route requires an exact zero worst-case reservation`);
+    }
+    return;
+  }
+  if (priceEvidence.kind !== "metered" || reservation.kind !== "exact" || !isRecord(reservation.amount)) return;
+  const envelope = economics.executionEnvelope;
+  if (!isRecord(envelope) || !Array.isArray(envelope.limits) || !Array.isArray(priceEvidence.unitPrices)) return;
+  try {
+    const minimum = deriveManagedEconomicMinimumReservation({
+      unitRates: priceEvidence.unitPrices.map((entry) => {
+        if (!isRecord(entry) || !isRecord(entry.price)) throw new KilnYamlError(`${path} route unit price is invalid`);
+        return {
+          usageUnit: String(entry.usageUnit),
+          price: entry.price as unknown as ManagedEconomicAmount,
+        };
+      }),
+      usageLimits: envelope.limits as ManagedEconomicAmount[],
+      auxiliaryCharges: auxiliaryCharges.map((entry) => {
+        if (!isRecord(entry) || !isRecord(entry.amount)) throw new KilnYamlError(`${path} auxiliary charge is invalid`);
+        return {
+          id: String(entry.id),
+          amount: entry.amount as unknown as ManagedEconomicAmount,
+        };
+      }),
+      outputUnit: String(domain.unit),
+      targetScheme: domain.scheme as Exclude<ManagedEconomicAmount["scheme"], { readonly kind: "unit" }>,
+    });
+    if (compareManagedEconomicAmounts(reservation.amount as unknown as ManagedEconomicAmount, minimum) < 0) {
+      throw new KilnYamlError(`${path} worstCaseReservation must cover the derived minimum reservation`);
+    }
+  } catch (error) {
+    if (error instanceof KilnYamlError) throw error;
+    throw new KilnYamlError(`${path} cannot derive an exact minimum reservation: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function validateReservationPriceClass(
+  reservation: unknown,
+  priceKind: unknown,
+  path: string,
+): void {
+  if (!isRecord(reservation)) return;
+  if (priceKind === "metered" || priceKind === "free") {
+    if (reservation.kind !== "exact") {
+      throw new KilnYamlError(`${path} ${priceKind} route requires an exact worst-case reservation`);
+    }
+    return;
+  }
+  const expectedReason = priceKind === "subscription"
+    ? "subscription-basis"
+    : priceKind === "included"
+      ? "included-basis"
+      : priceKind === "estimated"
+        ? "estimated-basis"
+        : priceKind === "unknown"
+          ? "unknown-basis"
+          : undefined;
+  if (expectedReason && (reservation.kind !== "not-comparable" || reservation.reason !== expectedReason)) {
+    throw new KilnYamlError(`${path} ${priceKind} route requires not-comparable reason '${expectedReason}'`);
   }
 }
 
@@ -1043,6 +1443,30 @@ function isWorkGovernanceEvidence(value: unknown): boolean {
     || value === "managed-agent-review"
     || value === "formal-proof"
     || value === "residual-risk";
+}
+
+function rejectUnknownFields(
+  value: Readonly<Record<string, unknown>>,
+  allowed: readonly string[],
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) throw new KilnYamlError(`Unknown ${path} field: ${key}`);
+  }
+}
+
+function validateCanonicalId(value: unknown, path: string): asserts value is string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(value)) {
+    throw new KilnYamlError(`${path} must be a canonical id`);
+  }
+}
+
+function economicSchemesEqual(left: unknown, right: unknown): boolean {
+  if (!isRecord(left) || !isRecord(right) || left.kind !== right.kind) return false;
+  if (left.kind === "unit") return true;
+  if (left.kind === "currency") return left.currency === right.currency;
+  if (left.kind === "credit") return left.creditSchemeId === right.creditSchemeId;
+  return false;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/config/managed-agent-route-catalog.test.ts
+++ b/packages/cli/src/config/managed-agent-route-catalog.test.ts
@@ -12,6 +12,7 @@ import type { ManagedAgentRuntimeAdapter } from "@kilnai/runtime";
 import { createStagedManagedInvocationRouteCatalog } from "./managed-agent-route-catalog.js";
 import type { ManagedAgentProviderModelCatalogDiagnostics } from "./managed-agent-provider-models.js";
 import {
+  closeManagedAccountRuntimeComposition,
   createManagedAccountRuntimeComposition,
   resolveManagedInvocationToolOptions,
 } from "./managed-agent-routes.js";
@@ -261,6 +262,7 @@ function makeIsolatedWorktreeWriteConfig(): ManagedAgentRouteConfigSource {
 describe("managed agent route catalog", () => {
   afterEach(() => {
     for (const root of tempRoots.splice(0)) {
+      closeManagedAccountRuntimeComposition(root);
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/packages/cli/src/config/managed-agent-route-catalog.ts
+++ b/packages/cli/src/config/managed-agent-route-catalog.ts
@@ -39,14 +39,15 @@ export async function createStagedManagedInvocationRouteCatalog(
   const mark = createRouteCatalogStartupMarker();
   mark("route-catalog-entered");
   const currentConfig = () => options.reloadConfig?.() ?? config;
-  let managedAccountComposition = config
+  const executionComposition = context.compositionMode !== "candidate-admission";
+  let managedAccountComposition = executionComposition && config
     ? createManagedAccountRuntimeComposition(config, context.cwd)
     : undefined;
   let invocationService: ManagedInvocationToolOptions["invocationService"] | undefined;
   let invocationServiceKey: ManagedInvocationToolOptions["invocationServiceKey"] | undefined;
   const resolve = (providerModelCatalogDiagnostics: ManagedAgentProviderModelCatalogDiagnostics) => {
     const nextConfig = currentConfig();
-    if (!managedAccountComposition && nextConfig) {
+    if (executionComposition && !managedAccountComposition && nextConfig) {
       managedAccountComposition = createManagedAccountRuntimeComposition(nextConfig, context.cwd);
     }
     if (managedAccountComposition && nextConfig?.modelGateway) {

--- a/packages/cli/src/config/managed-agent-routes.ts
+++ b/packages/cli/src/config/managed-agent-routes.ts
@@ -207,9 +207,20 @@ export async function resolveManagedInvocationToolOptions(
 
   const routes: ManagedInvocationToolRoute[] = [];
   const routeHealth: ManagedAgentRouteHealth[] = [];
-  const agentDefinitions = await loadAgentDefinitions(context.cwd);
-  mark("managed-route-agents-loaded", { count: agentDefinitions.length });
   const userHome = context.userHome ?? homedir();
+  const agentDefinitions = await loadAgentDefinitions(context.cwd, { userHome });
+  mark("managed-route-agents-loaded", { count: agentDefinitions.length });
+  const configuredAgentDefinitions = config.managedAgents?.schemaVersion === 2
+    ? agentDefinitions.filter((agent) => agent.scope !== "builtin")
+    : agentDefinitions;
+  const economicPolicyHealth = validateManagedAgentEconomicPolicyBindings(
+    configuredAgentDefinitions,
+    routeConfigs,
+    config.managedAgents,
+  );
+  if (economicPolicyHealth.length > 0) {
+    return { routeHealth: [], agentHealth: economicPolicyHealth };
+  }
   const skillCatalog = loadManagedInvocationSkillCatalog(context.cwd, userHome, config.skills);
   mark("managed-route-skills-loaded", { count: skillCatalog.length });
 
@@ -224,7 +235,7 @@ export async function resolveManagedInvocationToolOptions(
       routes.push(resolved.route);
     }
   }
-  const agentProjections = agentDefinitions.map((agent) => projectManagedAgentCatalogEntry(agent, routes));
+  const agentProjections = configuredAgentDefinitions.map((agent) => projectManagedAgentCatalogEntry(agent, routes));
   const agentCatalog = agentProjections.flatMap((projection) => projection.entry ? [projection.entry] : []);
   const agentHealth = agentProjections.flatMap((projection) => projection.health ? [projection.health] : []);
 
@@ -279,6 +290,64 @@ export async function resolveManagedInvocationToolOptions(
       },
     } : {}),
   };
+}
+
+function validateManagedAgentEconomicPolicyBindings(
+  agents: readonly KilnAgentDefinition[],
+  routeConfigs: readonly ManagedAgentRouteConfigProjection[],
+  managedAgents: KilnManagedAgentsConfig | undefined,
+): readonly ManagedAgentProfileHealth[] {
+  if (managedAgents?.schemaVersion !== 2 || !managedAgents.economicPolicies) return [];
+  const policies = new Map(managedAgents.economicPolicies.map((policy) => [policy.id, policy]));
+  const configuredRoutes = new Map(routeConfigs.map((route) => [route.routeConfig.id, route.routeConfig]));
+  const failures: ManagedAgentProfileHealth[] = [];
+  for (const agent of agents) {
+    if (agent.mode !== "managed-child" && agent.mode !== "all") continue;
+    if (!agent.economicPolicyId) {
+      failures.push({
+        agentName: agent.name,
+        available: false,
+        reason: "Managed agent schema v2 requires an explicit economicPolicyId.",
+      });
+      continue;
+    }
+    const policy = policies.get(agent.economicPolicyId);
+    if (!policy) {
+      failures.push({
+        agentName: agent.name,
+        available: false,
+        reason: `Agent references unknown economic policy '${agent.economicPolicyId}'.`,
+      });
+      continue;
+    }
+    const candidateRouteIds = new Set(policy.candidates.map((candidate) => candidate.routeId));
+    if (agent.routeId && !candidateRouteIds.has(agent.routeId)) {
+      failures.push({
+        agentName: agent.name,
+        available: false,
+        routeId: agent.routeId,
+        reason: `Agent route '${agent.routeId}' is not admitted by economic policy '${policy.id}'.`,
+      });
+      continue;
+    }
+    if (agent.providerRoute) {
+      const providerRoute = agent.providerRoute;
+      const matchesCandidate = [...candidateRouteIds].some((routeId) => {
+        const route = configuredRoutes.get(routeId);
+        return route !== undefined
+          && route.provider === providerRoute.providerId
+          && (!providerRoute.model || route.model === providerRoute.model);
+      });
+      if (!matchesCandidate) {
+        failures.push({
+          agentName: agent.name,
+          available: false,
+          reason: `Agent provider constraint is not admitted by economic policy '${policy.id}'.`,
+        });
+      }
+    }
+  }
+  return failures;
 }
 
 function createManagedRouteResolutionStartupMarker(): (phase: string, detail?: Record<string, unknown>) => void {
@@ -387,6 +456,9 @@ function resolveAgentRouteHint(
   const explicit = routeFromExplicitAgentHint(agent, routes);
   if (explicit) {
     return routeHint(explicit, agent);
+  }
+  if (agent.economicPolicyId) {
+    return undefined;
   }
   const scored = routes
     .map((route, index) => ({

--- a/packages/cli/src/config/managed-agent-routes.ts
+++ b/packages/cli/src/config/managed-agent-routes.ts
@@ -43,6 +43,7 @@ import {
   type ManagedAgentRuntimeAdapter,
   type ManagedAgentRuntimeAuthorityObserver,
   type ManagedInvocationAgentCatalogEntry,
+  type ManagedCommittedInvocationRequest,
   type ManagedInvocationRouteProfile,
   type ManagedInvocationToolOptions,
   type ManagedInvocationToolRoute,
@@ -119,6 +120,8 @@ export interface ResolveManagedInvocationToolOptionsContext {
   readonly maxParallelChildren?: number;
   readonly orchestrationBudgetAdmission?: RuntimeBudgetAdmissionPort;
   readonly managedAccountComposition?: ManagedAccountRuntimeComposition;
+  /** Candidate admission projects static route evidence without constructing execution owners. */
+  readonly compositionMode?: "execution" | "candidate-admission";
 }
 
 type BuiltinToolOptionsSource = DefaultBuiltinToolRegistryOptions | (() => DefaultBuiltinToolRegistryOptions | undefined);
@@ -151,6 +154,7 @@ export interface ManagedAccountRuntimeComposition {
   readonly routing: ConfiguredManagedAccountRuntime;
   readonly authority: ManagedAccountLeaseAuthority;
   updateConfig(config: ModelGatewayConfig): void;
+  close(): void;
 }
 
 const SUPPORTED_HARNESS_PROVIDERS = new Set<string>(["claude", "codex", "opencode"]);
@@ -225,45 +229,82 @@ export async function resolveManagedInvocationToolOptions(
   mark("managed-route-skills-loaded", { count: skillCatalog.length });
 
   let routeIndex = 0;
+  const economicPolicyIdsByRoute = managedEconomicPolicyIdsByRoute(config.managedAgents);
+  const economicCapabilityByRoute = managedEconomicCapabilitiesByRoute(
+    config,
+    routeConfigs.map((projection) => projection.routeConfig),
+    economicPolicyIdsByRoute,
+  );
   for (const routeConfig of routeConfigs) {
     routeIndex += 1;
     mark("managed-route-resolve-started", { routeIndex, routeId: routeConfig.routeConfig.id });
-    const resolved = await resolveRouteConfig(routeConfig, context, config);
+    const policyIds = economicPolicyIdsByRoute.get(routeConfig.routeConfig.id) ?? [];
+    const resolved = await resolveRouteConfig(
+      routeConfig,
+      context,
+      config,
+      policyIds.length > 0 || context.compositionMode === "candidate-admission",
+    );
     mark("managed-route-resolve-finished", { routeIndex, routeId: routeConfig.routeConfig.id });
     routeHealth.push(resolved.health);
     if (resolved.route) {
-      routes.push(resolved.route);
+      const economics = economicCapabilityByRoute.get(routeConfig.routeConfig.id);
+      routes.push({
+        ...resolved.route,
+        ...(policyIds.length > 0 ? { economicPolicyIds: policyIds } : {}),
+        ...(economics ? { economicCapability: economics } : {}),
+      });
     }
   }
-  const agentProjections = configuredAgentDefinitions.map((agent) => projectManagedAgentCatalogEntry(agent, routes));
+  const agentProjections = configuredAgentDefinitions.map((agent) =>
+    projectManagedAgentCatalogEntry(agent, routes, config.managedAgents)
+  );
   const agentCatalog = agentProjections.flatMap((projection) => projection.entry ? [projection.entry] : []);
   const agentHealth = agentProjections.flatMap((projection) => projection.health ? [projection.health] : []);
 
   const unavailableRoutes = routeHealth
     .filter((route) => !route.available)
-    .map((route) => ({
-      routeId: route.routeId,
-      routeSource: route.routeSource,
-      providerId: route.provider,
-      ...(route.model ? { model: route.model } : {}),
-      profiles: route.profiles,
-      reason: route.reason ?? "Route is unavailable.",
-    }));
+    .map((route) => {
+      const routeConfig = routeConfigs.find(
+        (candidate) => candidate.routeConfig.id === route.routeId,
+      )?.routeConfig;
+      const policyIds = economicPolicyIdsByRoute.get(route.routeId) ?? [];
+      const economics = economicCapabilityByRoute.get(route.routeId);
+      return {
+        routeId: route.routeId,
+        ...(policyIds.length > 0 ? { economicPolicyIds: policyIds } : {}),
+        ...(routeConfig?.credentials?.mode === "runtime-selected"
+          ? { accountPolicyId: routeConfig.credentials.accountPolicyId }
+          : {}),
+        ...(economics ? { economicCapability: economics } : {}),
+        routeSource: route.routeSource,
+        providerId: route.provider,
+        ...(route.model ? { model: route.model } : {}),
+        profiles: route.profiles,
+        reason: route.reason ?? "Route is unavailable.",
+      };
+    });
   const shouldExposeManagedInvocation = routes.length > 0
     || (context.includeUnavailableRoutes === true && unavailableRoutes.length > 0);
-  const managedAccountComposition = context.managedAccountComposition
-    ?? createManagedAccountRuntimeComposition(config, context.cwd);
+  const executionComposition = context.compositionMode !== "candidate-admission";
+  const managedAccountComposition = executionComposition
+    ? context.managedAccountComposition ?? createManagedAccountRuntimeComposition(config, context.cwd)
+    : undefined;
   if (managedAccountComposition && config.modelGateway) {
     managedAccountComposition.updateConfig(config.modelGateway);
   }
-  const invocationService = createManagedInvocationService(
-    config,
-    context.cwd,
-    context.invocationService,
-    context.invocationServiceKey,
-    managedAccountComposition,
-  );
-  const invocationServiceKey = managedInvocationServiceKey(config, context.cwd);
+  const invocationService = executionComposition
+    ? createManagedInvocationService(
+        config,
+        context.cwd,
+        context.invocationService,
+        context.invocationServiceKey,
+        managedAccountComposition,
+      )
+    : undefined;
+  const invocationServiceKey = executionComposition
+    ? managedInvocationServiceKey(config, context.cwd)
+    : undefined;
 
   return {
     routeHealth,
@@ -350,6 +391,58 @@ function validateManagedAgentEconomicPolicyBindings(
   return failures;
 }
 
+function managedEconomicPolicyIdsByRoute(
+  managedAgents: KilnManagedAgentsConfig | undefined,
+): ReadonlyMap<string, readonly string[]> {
+  const idsByRoute = new Map<string, string[]>();
+  for (const policy of managedAgents?.economicPolicies ?? []) {
+    for (const candidate of policy.candidates) {
+      const ids = idsByRoute.get(candidate.routeId) ?? [];
+      ids.push(policy.id);
+      idsByRoute.set(candidate.routeId, ids);
+    }
+  }
+  return idsByRoute;
+}
+
+function managedEconomicCapabilitiesByRoute(
+  config: ManagedAgentRouteConfigSource,
+  routes: readonly KilnManagedAgentRouteConfig[],
+  policyIdsByRoute: ReadonlyMap<string, readonly string[]>,
+): ReadonlyMap<string, NonNullable<ManagedInvocationToolRoute["economicCapability"]>> {
+  const capabilities = new Map<string, NonNullable<ManagedInvocationToolRoute["economicCapability"]>>();
+  for (const route of routes) {
+    if (!policyIdsByRoute.has(route.id)) continue;
+    if (
+      route.kind !== "direct"
+      || !["codex-oauth", "opencode-go", "opencode-zen"].includes(route.provider)
+      || route.credentials?.mode !== "runtime-selected"
+    ) {
+      capabilities.set(route.id, { status: "unverified" });
+      continue;
+    }
+    // Slice 2 makes this an exact, validated route reference: the managed
+    // route's accountPolicyId names the canonical virtual route whose provider,
+    // model, and economics are validated together at the config boundary.
+    const accountPolicyId = route.credentials.accountPolicyId;
+    const canonicalRoute = config.modelGateway?.virtualModels.find(
+      (candidate) =>
+        candidate.id === accountPolicyId
+        && candidate.providerId === route.provider
+        && candidate.providerModelId === route.model,
+    );
+    const economics = canonicalRoute?.economics;
+    capabilities.set(route.id, economics
+      ? {
+          status: "verified",
+          adapterCapabilityId: economics.adapterCapabilityId,
+          adapterCapabilityVersion: economics.adapterCapabilityVersion,
+        }
+      : { status: "unverified" });
+  }
+  return capabilities;
+}
+
 function createManagedRouteResolutionStartupMarker(): (phase: string, detail?: Record<string, unknown>) => void {
   const startedAt = performance.now();
   return (phase, detail) => {
@@ -369,6 +462,7 @@ function createManagedRouteResolutionStartupMarker(): (phase: string, detail?: R
 function projectManagedAgentCatalogEntry(
   agent: KilnAgentDefinition,
   routes: readonly ManagedInvocationToolRoute[],
+  managedAgents: KilnManagedAgentsConfig | undefined,
 ): { readonly entry?: ManagedInvocationAgentCatalogEntry; readonly health?: ManagedAgentProfileHealth } {
   const explicitRouteHealth = validateExplicitAgentRoute(agent, routes);
   if (explicitRouteHealth) {
@@ -386,6 +480,17 @@ function projectManagedAgentCatalogEntry(
       ...(agent.authorityProfile ? { authorityProfile: agent.authorityProfile } : {}),
       ...(agent.skills ? { skills: agent.skills } : {}),
       ...(agent.taskAffinity ? { taskAffinity: agent.taskAffinity } : {}),
+      ...(agent.economicPolicyId
+        ? {
+            economicPolicyId: agent.economicPolicyId,
+            economicPolicyRevision: managedAgents?.economicPolicies?.find(
+              (policy) => policy.id === agent.economicPolicyId,
+            )?.revision,
+            economicPolicyCandidateRouteIds: managedAgents?.economicPolicies?.find(
+              (policy) => policy.id === agent.economicPolicyId,
+            )?.candidates.map((candidate) => candidate.routeId),
+          }
+        : {}),
       ...(routeHint?.routeId ? { routeId: routeHint.routeId } : {}),
       ...(routeHint?.providerRoute ? { providerRoute: routeHint.providerRoute } : {}),
       ...(agent.voiceProfile ? { voiceProfile: agent.voiceProfile } : {}),
@@ -633,6 +738,7 @@ async function resolveRouteConfig(
   projection: ManagedAgentRouteConfigProjection,
   context: ResolveManagedInvocationToolOptionsContext,
   config: ManagedAgentRouteConfigSource,
+  deferAdapterConstruction: boolean,
 ): Promise<{
   readonly health: ManagedAgentRouteHealth;
   readonly route?: ManagedInvocationToolRoute;
@@ -662,11 +768,25 @@ async function resolveRouteConfig(
   }
 
   if (routeConfig.kind === "direct") {
-    return resolveDirectRouteConfig(routeConfig, context, config, baseHealth, writeRequired);
+    return resolveDirectRouteConfig(
+      routeConfig,
+      context,
+      config,
+      baseHealth,
+      writeRequired,
+      deferAdapterConstruction,
+    );
   }
 
   if (routeConfig.remoteHarness !== undefined) {
-    return resolveRemoteHarnessRouteConfig(routeConfig, context, config, baseHealth, writeRequired);
+    return resolveRemoteHarnessRouteConfig(
+      routeConfig,
+      context,
+      config,
+      baseHealth,
+      writeRequired,
+      deferAdapterConstruction,
+    );
   }
 
   if (routeConfig.workingDirectory === "sandbox") {
@@ -712,14 +832,18 @@ async function resolveRouteConfig(
   if (!profileResolution.ok) {
     return unhealthy(baseHealth, profileResolution.reason);
   }
-  const builtinToolsProvider = createManagedRouteBuiltinToolsProvider(context);
-  const adapter = new ManagedCliHarnessAdapter({
-    providerId: routeConfig.provider,
-    model,
-    factory: createHarnessSessionFactory(routeConfig.provider as ProviderId, model, context),
-    ...(writeRequired ? { writeAuthority: LIVE_PROVEN_HARNESS_WRITE_AUTHORITY } : {}),
-    ...(builtinToolsProvider ? { builtinToolsProvider } : {}),
-  });
+  const builtinToolsProvider = deferAdapterConstruction
+    ? undefined
+    : createManagedRouteBuiltinToolsProvider(context);
+  const adapter = deferAdapterConstruction
+    ? undefined
+    : new ManagedCliHarnessAdapter({
+        providerId: routeConfig.provider,
+        model,
+        factory: createHarnessSessionFactory(routeConfig.provider as ProviderId, model, context),
+        ...(writeRequired ? { writeAuthority: LIVE_PROVEN_HARNESS_WRITE_AUTHORITY } : {}),
+        ...(builtinToolsProvider ? { builtinToolsProvider } : {}),
+      });
   const voiceProfile = managedAgentVoiceProfile(routeConfig, config);
   const externalRuntimeAttachment = resolveRouteExternalRuntimeAttachment(routeConfig);
   const route: ManagedInvocationToolRoute = {
@@ -731,7 +855,7 @@ async function resolveRouteConfig(
     providerId: routeConfig.provider,
     model,
     ...(voiceProfile ? { voiceProfile } : {}),
-    adapter,
+    ...(adapter ? { adapter } : {}),
     surface: "cli-harness",
     ...(externalRuntimeAttachment ? { externalRuntimeAttachment } : {}),
     taskSuitability: resolveTaskSuitability(
@@ -759,6 +883,7 @@ async function resolveRemoteHarnessRouteConfig(
   config: ManagedAgentRouteConfigSource,
   baseHealth: Omit<ManagedAgentRouteHealth, "available" | "reason">,
   writeRequired: boolean,
+  deferAdapterConstruction: boolean,
 ): Promise<{
   readonly health: ManagedAgentRouteHealth;
   readonly route?: ManagedInvocationToolRoute;
@@ -778,14 +903,16 @@ async function resolveRemoteHarnessRouteConfig(
   if (!profileResolution.ok) {
     return unhealthy(baseHealth, profileResolution.reason);
   }
-  const adapter = new ManagedRemoteHarnessAdapter({
-    providerId: routeConfig.provider,
-    model,
-    invokeUrl: remoteHarness.invokeUrl,
-    cancelUrl: remoteHarness.cancelUrl,
-    ...(remoteHarness.authTokenEnv ? { authTokenEnv: remoteHarness.authTokenEnv } : {}),
-    ...(remoteHarness.limitations ? { limitations: remoteHarness.limitations } : {}),
-  });
+  const adapter = deferAdapterConstruction
+    ? undefined
+    : new ManagedRemoteHarnessAdapter({
+        providerId: routeConfig.provider,
+        model,
+        invokeUrl: remoteHarness.invokeUrl,
+        cancelUrl: remoteHarness.cancelUrl,
+        ...(remoteHarness.authTokenEnv ? { authTokenEnv: remoteHarness.authTokenEnv } : {}),
+        ...(remoteHarness.limitations ? { limitations: remoteHarness.limitations } : {}),
+      });
   const voiceProfile = managedAgentVoiceProfile(routeConfig, config);
   const externalRuntimeAttachment = resolveRouteExternalRuntimeAttachment(routeConfig);
   const route: ManagedInvocationToolRoute = {
@@ -797,7 +924,7 @@ async function resolveRemoteHarnessRouteConfig(
     providerId: routeConfig.provider,
     model,
     ...(voiceProfile ? { voiceProfile } : {}),
-    adapter,
+    ...(adapter ? { adapter } : {}),
     surface: "remote-harness",
     ...(externalRuntimeAttachment ? { externalRuntimeAttachment } : {}),
     providerModelProof: {
@@ -1113,6 +1240,7 @@ async function resolveDirectRouteConfig(
   config: ManagedAgentRouteConfigSource,
   baseHealth: Omit<ManagedAgentRouteHealth, "available" | "reason">,
   writeRequired: boolean,
+  deferAdapterConstruction: boolean,
 ): Promise<{
   readonly health: ManagedAgentRouteHealth;
   readonly route?: ManagedInvocationToolRoute;
@@ -1132,15 +1260,17 @@ async function resolveDirectRouteConfig(
     return unhealthy(baseHealth, managedEligibilityUnavailableReason(routeConfig.provider, model, undefined));
   }
   let adapter: ManagedAgentRuntimeAdapter | undefined;
-  try {
-    adapter = await context.directAdapterFactory?.(routeConfig);
-  } catch (err) {
-    return unhealthy(baseHealth, err instanceof Error ? err.message : String(err));
+  if (!deferAdapterConstruction) {
+    try {
+      adapter = await context.directAdapterFactory?.(routeConfig);
+    } catch (err) {
+      return unhealthy(baseHealth, err instanceof Error ? err.message : String(err));
+    }
+    if (!adapter) {
+      return unhealthy(baseHealth, "Direct managed invocation routes require the direct provider managed runtime adapter.");
+    }
   }
-  if (!adapter) {
-    return unhealthy(baseHealth, "Direct managed invocation routes require the direct provider managed runtime adapter.");
-  }
-  if (writeRequired) {
+  if (writeRequired && adapter) {
     const writeSupport = validateDirectAdapterWriteSupport(adapter, normalizeProfiles(routeConfig.profiles));
     if (!writeSupport.ok) {
       return unhealthy(baseHealth, writeSupport.reason);
@@ -1165,7 +1295,22 @@ async function resolveDirectRouteConfig(
     providerId: routeConfig.provider,
     model,
     ...(voiceProfile ? { voiceProfile } : {}),
-    adapter,
+    ...(adapter ? { adapter } : {}),
+    ...(deferAdapterConstruction
+      ? {
+          createCommittedAdapter: async (request: ManagedCommittedInvocationRequest) => {
+            const committedRoute = request.commitment.reservation.selectedIdentity.route;
+            if (
+              committedRoute.routeId !== routeConfig.id
+              || committedRoute.providerId !== routeConfig.provider
+              || committedRoute.modelId !== model
+            ) {
+              return undefined;
+            }
+            return await context.directAdapterFactory?.(routeConfig);
+          },
+        }
+      : {}),
     surface: "direct-provider",
     ...(externalRuntimeAttachment ? { externalRuntimeAttachment } : {}),
     taskSuitability: resolveTaskSuitability(
@@ -1523,9 +1668,21 @@ export function createManagedAccountRuntimeComposition(
     updateConfig(next) {
       routing.updateConfig(next);
     },
+    close() {
+      authority.close();
+    },
   };
   MANAGED_ACCOUNT_COMPOSITIONS.set(compositionKey, composition);
   return composition;
+}
+
+/** Releases the process-scoped authority when its owning application lifecycle ends. */
+export function closeManagedAccountRuntimeComposition(cwd: string): void {
+  const compositionKey = resolve(cwd);
+  const composition = MANAGED_ACCOUNT_COMPOSITIONS.get(compositionKey);
+  if (!composition) return;
+  MANAGED_ACCOUNT_COMPOSITIONS.delete(compositionKey);
+  composition.close();
 }
 
 function createCliManagedRuntimeAuthorityObserver(): ManagedAgentRuntimeAuthorityObserver {

--- a/packages/cli/src/config/native-projection-backup.ts
+++ b/packages/cli/src/config/native-projection-backup.ts
@@ -1,11 +1,24 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
 
 export interface NativeProjectionBackupInput {
   readonly kilnDir: string;
   readonly targetId: string;
   readonly filePath: string;
   readonly timestamp?: string;
+  /**
+   * Maximum backups to keep for this target/file pair; older ones are pruned.
+   * Omit to retain every backup, which is the default for config projections
+   * whose history is small and non-secret. Secret-bearing sources (credential
+   * files) must set this so token material does not accumulate indefinitely.
+   */
+  readonly retain?: number;
+  /**
+   * File mode for the written backup. Omit for the default mode. Secret-bearing
+   * sources must pass an owner-only mode so a backup is never more readable
+   * than the credential it copies.
+   */
+  readonly mode?: number;
 }
 
 export function backupNativeProjectionFile(input: NativeProjectionBackupInput): string | undefined {
@@ -14,15 +27,33 @@ export function backupNativeProjectionFile(input: NativeProjectionBackupInput): 
   }
 
   const timestamp = sanitizeTimestamp(input.timestamp ?? new Date().toISOString());
-  const backupPath = join(
-    input.kilnDir,
-    "backups",
-    sanitizeTargetId(input.targetId),
-    `${timestamp}-${basename(input.filePath)}.bak`,
-  );
-  mkdirSync(dirname(backupPath), { recursive: true });
-  writeFileSync(backupPath, readFileSync(input.filePath));
+  const sourceName = basename(input.filePath);
+  const backupDir = join(input.kilnDir, "backups", sanitizeTargetId(input.targetId));
+  const backupPath = join(backupDir, `${timestamp}-${sourceName}.bak`);
+  mkdirSync(backupDir, { recursive: true });
+  writeFileSync(backupPath, readFileSync(input.filePath), input.mode === undefined ? undefined : { mode: input.mode });
+  if (input.retain !== undefined) {
+    pruneBackups(backupDir, sourceName, input.retain);
+  }
   return backupPath;
+}
+
+/**
+ * Keeps the newest `retain` backups for one source file. Names are
+ * `<sanitized-iso-timestamp>-<sourceName>.bak`; the sanitized timestamp keeps
+ * fixed-width zero-padded fields, so a lexicographic sort is chronological.
+ * Pruning is scoped by source name so unrelated files sharing a target
+ * directory never prune each other.
+ */
+function pruneBackups(backupDir: string, sourceName: string, retain: number): void {
+  const suffix = `-${sourceName}.bak`;
+  const existing = readdirSync(backupDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(suffix))
+    .map((entry) => entry.name)
+    .sort();
+  for (const name of existing.slice(0, Math.max(0, existing.length - Math.max(0, retain)))) {
+    rmSync(join(backupDir, name), { force: true });
+  }
 }
 
 function sanitizeTimestamp(timestamp: string): string {

--- a/packages/cli/src/kiln-yaml-types.ts
+++ b/packages/cli/src/kiln-yaml-types.ts
@@ -1,4 +1,12 @@
-import type { KilnWorkGovernanceEvidence, McpServerConfiguration, MemoryLayerKind, MemoryScopeKind } from "@kilnai/core";
+import type {
+  KilnWorkGovernanceEvidence,
+  ManagedEconomicAmount,
+  ManagedEconomicComparableReservation,
+  ManagedEconomicScheme,
+  McpServerConfiguration,
+  MemoryLayerKind,
+  MemoryScopeKind,
+} from "@kilnai/core";
 import type { KilnMemoryAuthorityOperation } from "./wrapper/session.js";
 
 export type { KilnWorkGovernanceEvidence } from "@kilnai/core";
@@ -432,7 +440,39 @@ export interface KilnManagedAgentRouteConfig {
   readonly externalRuntimeAttachment?: KilnManagedAgentExternalRuntimeAttachmentConfig;
 }
 
+export interface KilnManagedEconomicComparisonDomainConfig {
+  readonly id: string;
+  readonly rank: number;
+  readonly unit: string;
+  readonly scheme: ManagedEconomicScheme;
+  readonly rateCardBasis: string;
+  readonly envelopeSemantics: string;
+}
+
+export interface KilnManagedEconomicPolicyCandidateConfig {
+  readonly routeId: string;
+  readonly comparisonDomainId: string;
+  readonly priorityRank: number;
+  readonly worstCaseReservation: ManagedEconomicComparableReservation;
+  readonly ceiling:
+    | { readonly kind: "none" }
+    | { readonly kind: "finite"; readonly amount: ManagedEconomicAmount };
+}
+
+export interface KilnManagedEconomicPolicyConfig {
+  readonly id: string;
+  readonly revision: string;
+  readonly evidenceRequirements: {
+    readonly quota: "optional" | "required-for-account-bound";
+    readonly price: "optional" | "required";
+  };
+  readonly noRouteAction: "deny";
+  readonly comparisonDomains: readonly KilnManagedEconomicComparisonDomainConfig[];
+  readonly candidates: readonly KilnManagedEconomicPolicyCandidateConfig[];
+}
+
 export interface KilnManagedAgentsConfig {
+  readonly schemaVersion?: 2;
   readonly enabled?: boolean;
   readonly defaultProfile?: KilnManagedAgentProfile;
   readonly defaultProvider?: string;
@@ -441,6 +481,7 @@ export interface KilnManagedAgentsConfig {
   readonly worktreeLease?: KilnManagedAgentWorktreeLeaseConfig;
   readonly requireApproval?: boolean;
   readonly routes?: readonly KilnManagedAgentRouteConfig[];
+  readonly economicPolicies?: readonly KilnManagedEconomicPolicyConfig[];
 }
 
 export interface KilnYamlQualityGate {

--- a/packages/cli/src/native-harness/codex-app-mcp-server.ts
+++ b/packages/cli/src/native-harness/codex-app-mcp-server.ts
@@ -240,9 +240,17 @@ export class NativeHarnessMcpServer {
         state: job.state,
         configuredAgentProfileId: job.configuredAgentProfileId,
         admissionProfileId: job.admissionProfileId,
-        routeId: job.routeId,
+        ...(job.version === 5
+          ? {
+              economicPolicyId: job.economicPolicyId,
+              economicPolicyRevision: job.economicPolicyRevision,
+              constraints: job.constraints,
+            }
+          : {
+              routeId: job.routeId,
+              timeoutSource: job.timeoutSource,
+            }),
         governanceSource: job.governanceSource,
-        timeoutSource: job.timeoutSource,
         createdAt: job.createdAt,
         observedAt: job.updatedAt,
         ...(job.diagnostic ? { diagnostic: { code: job.diagnostic, operatorAction: operatorActionFor(job.diagnostic) } } : {}),
@@ -377,7 +385,7 @@ function applicationInputError(): Error & { code: "invalid_request" } { return O
 function applicationCode(error: unknown): string { return isRecord(error) && typeof error.code === "string" && /^[a-z_]{3,80}$/u.test(error.code) ? error.code : "internal_adapter_failure"; }
 function operatorActionFor(code: string): string {
   const actions: Record<string, string> = {
-    invalid_request: "Provide only valid bounded managed-job fields.", project_identity_unavailable: "Restore the trusted project composition boundary.", unknown_job: "Verify the managed-job identifier.", idempotency_conflict: "Use a new idempotency key for different managed work.", governance_unavailable: "Restore authoritative Kiln governance evidence.", governance_not_authoritative: "Refresh authoritative Kiln governance evidence.", admission_denied: "Review the authoritative work-governance policy.", profile_unavailable: "Choose a configured admitted agent.", route_unavailable: "Restore the configured agent route hint and current eligibility evidence.", job_persistence_unavailable: "Restore the managed-job store and retry safely.", job_persistence_corrupt: "Repair the managed-job store before retrying.", provider_rejected: "Review the Runtime managed-agent admission diagnostic.", provider_timeout: "Review the configured managed-agent timeout.", invocation_failed: "Inspect the Runtime managed-agent diagnostic before retrying.", internal_adapter_failure: "Retry safely or inspect Kiln status."
+    invalid_request: "Provide only valid bounded managed-job fields.", project_identity_unavailable: "Restore the trusted project composition boundary.", unknown_job: "Verify the managed-job identifier.", idempotency_conflict: "Use a new idempotency key for different managed work.", governance_unavailable: "Restore authoritative Kiln governance evidence.", governance_not_authoritative: "Refresh authoritative Kiln governance evidence.", admission_denied: "Review the authoritative work-governance policy.", profile_unavailable: "Choose a configured admitted agent.", route_unavailable: "Restore the configured policy candidate set and current eligibility evidence.", job_persistence_unavailable: "Restore the managed-job store and retry safely.", job_persistence_corrupt: "Repair the managed-job store before retrying.", economic_commitment_unavailable: "Wait until the configured economic commitment authority is available.", provider_rejected: "Review the Runtime managed-agent admission diagnostic.", provider_timeout: "Review the configured managed-agent timeout.", invocation_failed: "Inspect the Runtime managed-agent diagnostic before retrying.", internal_adapter_failure: "Retry safely or inspect Kiln status."
   };
   return actions[code] ?? "Retry safely or inspect Kiln status.";
 }

--- a/packages/cli/tests/application/codex-app-managed-jobs.test.ts
+++ b/packages/cli/tests/application/codex-app-managed-jobs.test.ts
@@ -186,6 +186,7 @@ describe("Codex App managed-job production composition", () => {
     const agents = [
       { name: "scout", displayName: "Scout", role: "Read-only scout", routeId: "scout-route" },
       { name: "researcher", role: "Researcher", routeId: "researcher-route" },
+      { name: "economic-worker", role: "Policy-only worker", economicPolicyId: "bounded-policy" },
     ];
 
     expect(summarizeNativeHarnessManagedAgents(agents, undefined)).toMatchObject([{
@@ -215,6 +216,9 @@ describe("Codex App managed-job production composition", () => {
       admissionProfileId: "foundation-readonly-plan",
       diagnostic: "eligibility_unresolved",
     });
+    expect(summarizeNativeHarnessManagedAgents(agents, {
+      routes: [route("scout-route"), route("researcher-route")],
+    } as never).some((agent) => agent.configuredAgentProfileId === "economic-worker")).toBe(false);
   });
 
   it("uses the real application owner and fails a missing configured profile before provider execution", async () => {

--- a/packages/cli/tests/application/codex-app-managed-jobs.test.ts
+++ b/packages/cli/tests/application/codex-app-managed-jobs.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createHash } from "node:crypto";
-import { basename, dirname, resolve } from "node:path";
-import { defineManagedAccountLeaseEvidence } from "@kilnai/core";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
 import {
   FilesystemManagedJobStore,
   ManagedJobApplicationService,
@@ -117,111 +117,96 @@ describe("Codex App managed-job production composition", () => {
     vi.restoreAllMocks();
   });
 
-  it("recovers persisted nonterminal jobs before exposing the application owner", async () => {
-    const accountLease = defineManagedAccountLeaseEvidence({
-      leaseId: "lease-job-recovered",
-      accountPolicyId: "managed-codex",
-      accountRef: "configured:test-account",
-      route: { providerId: "codex-oauth", providerModelId: "gpt-5.6-terra", scope: "virtual:managed-codex" },
-      jobId: "job-recovered",
-      runtimeInvocationId: "job-recovered",
-      credentialRevisionId: "a".repeat(64),
-      selectionReason: "least-pressure",
-      acquiredAt: "2026-07-28T20:00:00.000Z",
-      lifecycleState: "leaked",
-      resourceUris: ["kiln://managed-accounts/leases/lease-job-recovered"],
-      diagnosticUris: ["kiln://managed-accounts/leases/lease-job-recovered/recovery-unmatchable"],
-    });
-    const foreignAccountLease = defineManagedAccountLeaseEvidence({
-      ...accountLease,
-      leaseId: "lease-foreign-job",
-      jobId: "foreign-job",
-      runtimeInvocationId: "foreign-job",
-      resourceUris: ["kiln://managed-accounts/leases/lease-foreign-job"],
-      diagnosticUris: ["kiln://managed-accounts/leases/lease-foreign-job/recovery-unmatchable"],
-    });
-    const cwd = process.cwd();
-    const projectRoot = basename(cwd) === "cli" && basename(dirname(cwd)) === "packages"
-      ? resolve(cwd, "../..")
-      : cwd;
-    const projectId = `project-${createHash("sha256").update(projectRoot).digest("hex").slice(0, 32)}`;
+  it("recovers persisted jobs without constructing an execution owner", async () => {
+    const projectRoot = mkdtempSync(resolve(tmpdir(), "kiln-managed-job-recovery-"));
+    mkdirSync(resolve(projectRoot, ".kiln"), { recursive: true });
+    writeFileSync(resolve(projectRoot, ".kiln", "kiln.yaml"), "version: '1'\n", "utf8");
     const recoverInvocations = vi
       .spyOn(RuntimeManagedAgentInvocationService.prototype, "recoverPersistedInvocations")
-      .mockResolvedValue({
-        recovered: [],
-        accountLeases: [accountLease, foreignAccountLease],
-      });
-    const get = vi.spyOn(FilesystemManagedJobStore.prototype, "get")
-      .mockImplementation(async (id) => ({
-        version: 4,
-        projectId: id === "job-recovered" ? projectId : "foreign-project",
-      } as never));
+      .mockResolvedValue({ recovered: [], accountLeases: [] });
     const recordAccountLease = vi.spyOn(FilesystemManagedJobStore.prototype, "recordAccountLease")
       .mockResolvedValue({ version: 4 } as never);
     const recoverInterrupted = vi
       .spyOn(ManagedJobApplicationService.prototype, "recoverInterrupted")
       .mockResolvedValue([]);
 
-    await createNativeHarnessManagedJobApplicationComposition({ harness: "codex", discoverProviderModels: async () => ({}) });
+    try {
+      await createNativeHarnessManagedJobApplicationComposition({
+        harness: "codex",
+        discoverProviderModels: async () => ({}),
+        projectPath: projectRoot,
+      });
 
-    expect(recoverInvocations).toHaveBeenCalledOnce();
-    expect(get).toHaveBeenCalledWith("job-recovered");
-    expect(get).toHaveBeenCalledWith("foreign-job");
-    expect(recordAccountLease).toHaveBeenCalledWith("job-recovered", accountLease);
-    expect(recordAccountLease).not.toHaveBeenCalledWith("foreign-job", foreignAccountLease);
-    expect(recoverInterrupted).toHaveBeenCalledOnce();
-    expect(recoverInvocations.mock.invocationCallOrder[0]).toBeLessThan(recoverInterrupted.mock.invocationCallOrder[0]!);
-    recoverInvocations.mockRestore();
-    get.mockRestore();
-    recordAccountLease.mockRestore();
-    recoverInterrupted.mockRestore();
+      expect(recoverInvocations).not.toHaveBeenCalled();
+      expect(recordAccountLease).not.toHaveBeenCalled();
+      expect(recoverInterrupted).toHaveBeenCalledOnce();
+    } finally {
+      recoverInvocations.mockRestore();
+      recordAccountLease.mockRestore();
+      recoverInterrupted.mockRestore();
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 
-  it("projects configured agents through their explicit route hints without exposing route internals", () => {
-    const route = (id: string) => ({
+  it("projects policy agents from candidate admission without selecting a route", () => {
+    const route = (id: string, providerId: string) => ({
       routeId: id,
-      providerId: "opencode-go",
+      providerId,
+      economicPolicyIds: ["bounded-policy"],
+      economicCapability: {
+        status: "verified",
+        adapterCapabilityId: `${providerId}-direct`,
+        adapterCapabilityVersion: "1",
+      },
       profiles: { "foundation-readonly-plan": {} },
     });
     const agents = [
-      { name: "scout", displayName: "Scout", role: "Read-only scout", routeId: "scout-route" },
-      { name: "researcher", role: "Researcher", routeId: "researcher-route" },
       { name: "economic-worker", role: "Policy-only worker", economicPolicyId: "bounded-policy" },
     ];
 
     expect(summarizeNativeHarnessManagedAgents(agents, undefined)).toMatchObject([{
-      configuredAgentProfileId: "scout",
+      configuredAgentProfileId: "economic-worker",
       availability: "unavailable",
       admissionProfileId: "foundation-readonly-plan",
       diagnostic: "route_unavailable",
-    }, {
-      configuredAgentProfileId: "researcher",
-      availability: "unavailable",
     }]);
-    expect(summarizeNativeHarnessManagedAgents(agents, { routes: [route("scout-route"), route("researcher-route")] } as never)).toMatchObject([{
-      configuredAgentProfileId: "scout",
+    expect(summarizeNativeHarnessManagedAgents(agents, {
+      routes: [
+        route("codex-route", "codex-oauth"),
+        route("opencode-route", "opencode-go"),
+      ],
+      agentCatalog: [{
+        name: "economic-worker",
+        economicPolicyId: "bounded-policy",
+        economicPolicyRevision: "revision-001",
+        economicPolicyCandidateRouteIds: ["codex-route", "opencode-route"],
+      }],
+    } as never)).toMatchObject([{
+      configuredAgentProfileId: "economic-worker",
       availability: "admitted",
-      providerFamily: "opencode-go",
       admissionProfileId: "foundation-readonly-plan",
-    }, {
-      configuredAgentProfileId: "researcher",
-      availability: "admitted",
     }]);
     expect(summarizeNativeHarnessManagedAgents(agents, {
       routes: [],
-      unavailableRoutes: [{ routeId: "scout-route", providerId: "opencode-go", profiles: ["foundation-readonly-plan"] }],
+      agentCatalog: [{
+        name: "economic-worker",
+        economicPolicyId: "bounded-policy",
+        economicPolicyRevision: "revision-001",
+        economicPolicyCandidateRouteIds: ["codex-route"],
+      }],
+      unavailableRoutes: [{ routeId: "codex-route", providerId: "codex-oauth", profiles: ["foundation-readonly-plan"] }],
     } as never)[0]).toMatchObject({
-      configuredAgentProfileId: "scout",
+      configuredAgentProfileId: "economic-worker",
       availability: "unresolved",
       admissionProfileId: "foundation-readonly-plan",
       diagnostic: "eligibility_unresolved",
     });
-    expect(summarizeNativeHarnessManagedAgents(agents, {
-      routes: [route("scout-route"), route("researcher-route")],
-    } as never).some((agent) => agent.configuredAgentProfileId === "economic-worker")).toBe(false);
   });
 
   it("uses the real application owner and fails a missing configured profile before provider execution", async () => {
+    const recoverInterrupted = vi
+      .spyOn(ManagedJobApplicationService.prototype, "recoverInterrupted")
+      .mockResolvedValue([]);
     const service = await createNativeHarnessManagedJobApplicationService({ harness: "codex", discoverProviderModels: async () => ({}) });
     await expect(service.submit({
       objective: "Bounded production composition proof.",
@@ -229,6 +214,6 @@ describe("Codex App managed-job production composition", () => {
       callerId: "codex-app",
       idempotencyKey: "production-composition-proof",
     })).rejects.toMatchObject({ code: "profile_unavailable" });
-    await expect(service.getStatus({ project: { id: "trusted-project" }, callerId: "codex-app" }, "unknown-managed-job-0001")).rejects.toMatchObject({ code: "unknown_job" });
+    recoverInterrupted.mockRestore();
   });
 });

--- a/packages/cli/tests/commands/auth.test.ts
+++ b/packages/cli/tests/commands/auth.test.ts
@@ -49,9 +49,12 @@ function codexCredential(accountId: string, email?: string) {
 
 describe("auth command", () => {
   let logs: string[];
+  let previousCodexHome: string | undefined;
 
   beforeEach(async () => {
     logs = [];
+    previousCodexHome = process.env.CODEX_HOME;
+    delete process.env.CODEX_HOME;
     vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
       logs.push(String(message ?? ""));
     });
@@ -100,6 +103,8 @@ describe("auth command", () => {
   afterEach(async () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
     await rm(homeDir, { recursive: true, force: true });
   });
 
@@ -219,6 +224,73 @@ describe("auth command", () => {
   it("rejects unrecognized Codex status flags", async () => {
     await runAuth(["codex", "status", "--bogus"]);
     expect(logs.join("\n")).toContain("Usage: kiln auth codex status [--usage] [--emails]");
+  }, 10_000);
+
+  it("activates a pooled Codex credential natively, absorbing and backing up the previously active native account", async () => {
+    await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "work.json"), JSON.stringify(codexCredential("account-a")), "utf8");
+
+    await mkdir(join(homeDir, ".codex"), { recursive: true });
+    await writeFile(join(homeDir, ".codex", "auth.json"), JSON.stringify({
+      auth_mode: "chatgpt",
+      OPENAI_API_KEY: null,
+      tokens: {
+        id_token: "previous-id-token",
+        access_token: codexCredential("account-b").access_token,
+        refresh_token: "previous-refresh",
+        account_id: "account-b",
+      },
+      last_refresh: "2026-07-01T00:00:00.000Z",
+    }), "utf8");
+
+    await runAuth(["codex", "activate", "work"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("Absorbed currently active native Codex account (account-b) into the Kiln pool");
+    expect(output).toContain("Backed up previous native Codex auth to");
+    expect(output).toContain("Activated Codex OAuth credential work");
+
+    const nativeAfter = JSON.parse(await readFile(join(homeDir, ".codex", "auth.json"), "utf8"));
+    expect(nativeAfter.tokens.account_id).toBe("account-a");
+    expect(nativeAfter.tokens.access_token).toBe(codexCredential("account-a").access_token);
+
+    const codexOauthFiles = await readdir(join(homeDir, ".kiln", "auth", "codex-oauth"));
+    expect(codexOauthFiles).toContain("work.json");
+    expect(codexOauthFiles.length).toBe(2);
+
+    const nativeDirFiles = await readdir(join(homeDir, ".codex"));
+    expect(nativeDirFiles.some((name) => name.startsWith("auth.json.bak-"))).toBe(true);
+  }, 10_000);
+
+  it("activates the least-used available pooled account with --auto", async () => {
+    await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "low.json"), JSON.stringify(codexCredential("account-low")), "utf8");
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "high.json"), JSON.stringify(codexCredential("account-high")), "utf8");
+
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: { headers?: Record<string, string> }) => {
+      const accountId = init?.headers?.["chatgpt-account-id"];
+      const usedPercent = accountId === "account-low" ? 10 : 95;
+      return new Response(JSON.stringify({
+        plan_type: "plus",
+        rate_limit: { allowed: true, limit_reached: false, primary_window: { used_percent: usedPercent, reset_at: 4_070_908_800 } },
+      }), { status: 200 });
+    }));
+
+    await runAuth(["codex", "activate", "--auto"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("Activated Codex OAuth credential low");
+    expect(output).not.toContain("Backed up");
+
+    const nativeAfter = JSON.parse(await readFile(join(homeDir, ".codex", "auth.json"), "utf8"));
+    expect(nativeAfter.tokens.account_id).toBe("account-low");
+  }, 10_000);
+
+  it("reports an unknown Codex credential id without touching native auth", async () => {
+    await runAuth(["codex", "activate", "does-not-exist"]);
+
+    expect(logs.join("\n")).toContain("Unknown or unusable Codex OAuth credential: does-not-exist");
+    await expect(readFile(join(homeDir, ".codex", "auth.json"), "utf8")).rejects.toThrow();
   }, 10_000);
 
   it("logs out only the selected Codex credential and its health and usage", async () => {

--- a/packages/cli/tests/commands/auth.test.ts
+++ b/packages/cli/tests/commands/auth.test.ts
@@ -259,9 +259,32 @@ describe("auth command", () => {
     expect(codexOauthFiles).toContain("work.json");
     expect(codexOauthFiles.length).toBe(2);
 
-    const nativeDirFiles = await readdir(join(homeDir, ".codex"));
-    expect(nativeDirFiles.some((name) => name.startsWith("auth.json.bak-"))).toBe(true);
+    // Backups belong in the canonical Kiln backup root, never littered beside the live native file.
+    const backups = await readdir(join(homeDir, ".kiln", "backups", "codex-native-auth"));
+    expect(backups).toHaveLength(1);
+    expect(backups[0]).toMatch(/-auth\.json\.bak$/);
+    expect(JSON.parse(await readFile(join(homeDir, ".kiln", "backups", "codex-native-auth", backups[0]!), "utf8")).tokens.account_id).toBe("account-b");
+    expect(await readdir(join(homeDir, ".codex"))).toEqual(["auth.json"]);
   }, 10_000);
+
+  it("bounds native auth backup history instead of accumulating token material forever", async () => {
+    await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "a.json"), JSON.stringify(codexCredential("account-a")), "utf8");
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "b.json"), JSON.stringify(codexCredential("account-b")), "utf8");
+
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      plan_type: "plus",
+      rate_limit: { allowed: true, limit_reached: false, primary_window: { used_percent: 5, reset_at: 4_070_908_800 } },
+    }), { status: 200 })));
+
+    for (let index = 0; index < 8; index += 1) {
+      await runAuth(["codex", "activate", "--auto"]);
+    }
+
+    const backups = await readdir(join(homeDir, ".kiln", "backups", "codex-native-auth"));
+    expect(backups.length).toBeGreaterThan(0);
+    expect(backups.length).toBeLessThanOrEqual(5);
+  }, 20_000);
 
   it("activates the least-used available pooled account with --auto", async () => {
     await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
@@ -323,14 +346,64 @@ describe("auth command", () => {
 
     await runAuth(["codex", "activate", "work"]);
 
-    expect(logs.join("\n")).toContain("has no id_token even after a refresh attempt");
+    expect(logs.join("\n")).toContain("Native Codex CLI/App requires an id_token, and none could be recovered for: work");
     await expect(readFile(join(homeDir, ".codex", "auth.json"), "utf8")).rejects.toThrow();
   }, 10_000);
 
   it("reports an unknown Codex credential id without touching native auth", async () => {
     await runAuth(["codex", "activate", "does-not-exist"]);
 
-    expect(logs.join("\n")).toContain("Unknown or unusable Codex OAuth credential: does-not-exist");
+    expect(logs.join("\n")).toContain("Unknown Codex OAuth credential: does-not-exist");
+    await expect(readFile(join(homeDir, ".codex", "auth.json"), "utf8")).rejects.toThrow();
+  }, 10_000);
+
+  it.each([[[]], [["--auto", "extra"]], [["--bogus"]], [["work", "second"]]])(
+    "rejects malformed activate arguments %j without touching native auth",
+    async (args: string[]) => {
+      await runAuth(["codex", "activate", ...args]);
+
+      expect(logs.join("\n")).toContain("Usage: kiln auth codex activate <id> | --auto");
+      await expect(readFile(join(homeDir, ".codex", "auth.json"), "utf8")).rejects.toThrow();
+    },
+    10_000,
+  );
+
+  it("distinguishes exhausted quota from an unrecoverable id_token under --auto", async () => {
+    await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "work.json"), JSON.stringify(codexCredential("account-a")), "utf8");
+
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      plan_type: "plus",
+      rate_limit: { allowed: false, limit_reached: true, primary_window: { used_percent: 100, reset_at: 4_070_908_800 } },
+    }), { status: 200 })));
+
+    await runAuth(["codex", "activate", "--auto"]);
+
+    expect(logs.join("\n")).toContain("No Codex OAuth credential currently has available quota");
+    await expect(readFile(join(homeDir, ".codex", "auth.json"), "utf8")).rejects.toThrow();
+  }, 10_000);
+
+  it("reports which accounts blocked activation when --auto finds quota but no usable id_token", async () => {
+    const { id_token: _unused, ...withoutIdToken } = codexCredential("account-a");
+    await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "work.json"), JSON.stringify(withoutIdToken), "utf8");
+
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => (
+      String(url).includes("/oauth/token")
+        ? new Response(JSON.stringify({
+            access_token: withoutIdToken.access_token,
+            refresh_token: "refreshed-refresh-token",
+            expires_in: 3600,
+          }), { status: 200 })
+        : new Response(JSON.stringify({
+            plan_type: "plus",
+            rate_limit: { allowed: true, limit_reached: false, primary_window: { used_percent: 5, reset_at: 4_070_908_800 } },
+          }), { status: 200 })
+    )));
+
+    await runAuth(["codex", "activate", "--auto"]);
+
+    expect(logs.join("\n")).toContain("Native Codex CLI/App requires an id_token, and none could be recovered for: work");
     await expect(readFile(join(homeDir, ".codex", "auth.json"), "utf8")).rejects.toThrow();
   }, 10_000);
 

--- a/packages/cli/tests/commands/auth.test.ts
+++ b/packages/cli/tests/commands/auth.test.ts
@@ -34,9 +34,10 @@ function openCodeCredential(id: string, tier: "go" | "zen", apiKey: string) {
   };
 }
 
-function codexCredential(accountId: string) {
+function codexCredential(accountId: string, email?: string) {
   const payload = Buffer.from(JSON.stringify({
     "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+    ...(email ? { "https://api.openai.com/profile": { email } } : {}),
   })).toString("base64url");
   return {
     access_token: `header.${payload}.signature`,
@@ -196,6 +197,28 @@ describe("auth command", () => {
     expect(output).toContain("Plan: plus");
     expect(output).toContain("Primary: 42%");
     expect(output).not.toContain("operator@example.test");
+  }, 10_000);
+
+  it("keeps Codex account emails out of status by default and only decodes them with --emails", async () => {
+    await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".kiln", "auth", "codex-oauth", "work.json"),
+      JSON.stringify(codexCredential("account-a", "operator@example.test")),
+      "utf8",
+    );
+
+    await runAuth(["codex", "status"]);
+    expect(logs.join("\n")).not.toContain("operator@example.test");
+
+    logs = [];
+    await runAuth(["codex", "status", "--emails"]);
+    const output = logs.join("\n");
+    expect(output).toContain("Email: operator@example.test");
+  }, 10_000);
+
+  it("rejects unrecognized Codex status flags", async () => {
+    await runAuth(["codex", "status", "--bogus"]);
+    expect(logs.join("\n")).toContain("Usage: kiln auth codex status [--usage] [--emails]");
   }, 10_000);
 
   it("logs out only the selected Codex credential and its health and usage", async () => {

--- a/packages/cli/tests/commands/auth.test.ts
+++ b/packages/cli/tests/commands/auth.test.ts
@@ -44,6 +44,7 @@ function codexCredential(accountId: string, email?: string) {
     refresh_token: "synthetic-refresh",
     expires_at: "2099-01-01T00:00:00.000Z",
     client_id: "synthetic-client",
+    id_token: "synthetic-id-token",
   };
 }
 
@@ -284,6 +285,46 @@ describe("auth command", () => {
 
     const nativeAfter = JSON.parse(await readFile(join(homeDir, ".codex", "auth.json"), "utf8"));
     expect(nativeAfter.tokens.account_id).toBe("account-low");
+  }, 10_000);
+
+  it("backfills a missing id_token via refresh before activating natively", async () => {
+    const { id_token: _unused, ...withoutIdToken } = codexCredential("account-a");
+    await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "work.json"), JSON.stringify(withoutIdToken), "utf8");
+
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      access_token: withoutIdToken.access_token,
+      refresh_token: "refreshed-refresh-token",
+      id_token: "backfilled-id-token",
+      expires_in: 3600,
+    }), { status: 200 })));
+
+    await runAuth(["codex", "activate", "work"]);
+
+    expect(logs.join("\n")).toContain("Activated Codex OAuth credential work");
+
+    const nativeAfter = JSON.parse(await readFile(join(homeDir, ".codex", "auth.json"), "utf8"));
+    expect(nativeAfter.tokens.id_token).toBe("backfilled-id-token");
+
+    const persisted = JSON.parse(await readFile(join(homeDir, ".kiln", "auth", "codex-oauth", "work.json"), "utf8"));
+    expect(persisted.id_token).toBe("backfilled-id-token");
+  }, 10_000);
+
+  it("refuses to activate natively when id_token cannot be recovered, and never touches the native file", async () => {
+    const { id_token: _unused, ...withoutIdToken } = codexCredential("account-a");
+    await mkdir(join(homeDir, ".kiln", "auth", "codex-oauth"), { recursive: true });
+    await writeFile(join(homeDir, ".kiln", "auth", "codex-oauth", "work.json"), JSON.stringify(withoutIdToken), "utf8");
+
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      access_token: withoutIdToken.access_token,
+      refresh_token: "refreshed-refresh-token",
+      expires_in: 3600,
+    }), { status: 200 })));
+
+    await runAuth(["codex", "activate", "work"]);
+
+    expect(logs.join("\n")).toContain("has no id_token even after a refresh attempt");
+    await expect(readFile(join(homeDir, ".codex", "auth.json"), "utf8")).rejects.toThrow();
   }, 10_000);
 
   it("reports an unknown Codex credential id without touching native auth", async () => {

--- a/packages/cli/tests/config/codex-native-account-sync.test.ts
+++ b/packages/cli/tests/config/codex-native-account-sync.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  fromNativeCodexAuthFile,
+  parseNativeCodexAuthFile,
+  toNativeCodexAuthFile,
+} from "../../src/config/codex-native-account-sync.js";
+
+function jwtWithClaims(claims: Record<string, unknown>): string {
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+describe("codex-native-account-sync", () => {
+  it("round-trips a pooled credential into native shape and back with account id and expiry preserved", () => {
+    const accessToken = jwtWithClaims({
+      exp: 4_070_908_800,
+      "https://api.openai.com/auth": { chatgpt_account_id: "account-uuid" },
+    });
+    const pooled = {
+      access_token: accessToken,
+      refresh_token: "refresh",
+      expires_at: "2099-01-01T00:00:00.000Z",
+      client_id: "client",
+      id_token: "id-token-value",
+    };
+
+    const native = toNativeCodexAuthFile(pooled, "2026-07-31T00:00:00.000Z");
+    expect(native).toEqual({
+      auth_mode: "chatgpt",
+      OPENAI_API_KEY: null,
+      tokens: {
+        id_token: "id-token-value",
+        access_token: accessToken,
+        refresh_token: "refresh",
+        account_id: "account-uuid",
+      },
+      last_refresh: "2026-07-31T00:00:00.000Z",
+    });
+
+    const parsed = parseNativeCodexAuthFile(native);
+    expect(parsed).not.toBeNull();
+    const absorbed = fromNativeCodexAuthFile(parsed!);
+    expect(absorbed.access_token).toBe(accessToken);
+    expect(absorbed.refresh_token).toBe("refresh");
+    expect(absorbed.id_token).toBe("id-token-value");
+    expect(absorbed.expires_at).toBe(new Date(4_070_908_800 * 1000).toISOString());
+  });
+
+  it("rejects native files missing required token fields", () => {
+    expect(parseNativeCodexAuthFile({ tokens: { access_token: "only-access" } })).toBeNull();
+    expect(parseNativeCodexAuthFile({})).toBeNull();
+    expect(parseNativeCodexAuthFile(null)).toBeNull();
+  });
+
+  it("omits account_id when the access token carries no chatgpt_account_id claim", () => {
+    const pooled = {
+      access_token: jwtWithClaims({ exp: 4_070_908_800 }),
+      refresh_token: "refresh",
+      expires_at: "2099-01-01T00:00:00.000Z",
+      client_id: "client",
+    };
+    const native = toNativeCodexAuthFile(pooled, "2026-07-31T00:00:00.000Z");
+    expect(native.tokens.account_id).toBeNull();
+    expect(native.tokens.id_token).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/config/managed-agent-routes.test.ts
+++ b/packages/cli/tests/config/managed-agent-routes.test.ts
@@ -907,6 +907,79 @@ describe("resolveManagedInvocationToolOptions", () => {
     expect(result.managedInvocation?.invocationServiceKey).toContain("sandboxPolicy");
   });
 
+  it("keeps policy-owned harness routes adapter-free during candidate admission", async () => {
+    const result = await resolveManagedInvocationToolOptions(baseConfig({
+      schemaVersion: 2,
+      economicPolicies: [{
+        id: "bounded-policy",
+        revision: "rev-1",
+        evidenceRequirements: { quota: "optional", price: "optional" },
+        noRouteAction: "deny",
+        comparisonDomains: [{
+          id: "priority-only",
+          rank: 0,
+          unit: "request",
+          scheme: { kind: "unit" },
+          rateCardBasis: "configured",
+          envelopeSemantics: "bounded",
+        }],
+        candidates: ["local-harness", "remote-harness"].map((routeId, priorityRank) => ({
+          routeId,
+          comparisonDomainId: "priority-only",
+          priorityRank,
+          ceiling: { kind: "none" as const },
+          worstCaseReservation: { kind: "not-comparable" as const, reason: "economic-basis-unavailable" as const },
+        })),
+      }],
+      routes: [{
+        id: "local-harness",
+        kind: "harness",
+        provider: "codex",
+        model: "gpt-5.3-codex-spark",
+        profiles: ["foundation-readonly-plan"],
+      }, {
+        id: "remote-harness",
+        kind: "harness",
+        provider: "codex-cloud",
+        model: "gpt-5.5",
+        profiles: ["foundation-readonly-plan"],
+        workingDirectory: "sandbox",
+        remoteHarness: {
+          invokeUrl: "https://remote.example.test/managed-agent/invoke",
+          cancelUrl: "https://remote.example.test/managed-agent/cancel",
+        },
+      }],
+    }), {
+      cwd: "C:/repo",
+      userHome: "C:/repo",
+      registry: createRegistry("codex"),
+      surface: "gui",
+      compositionMode: "candidate-admission",
+      providerModelEligibility: COMMON_OBSERVED_PROVIDER_MODELS,
+    });
+
+    expect(result.managedInvocation?.routes).toHaveLength(2);
+    expect(result.managedInvocation?.routes.map((route) => ({
+      routeId: route.routeId,
+      adapter: route.adapter,
+      createCommittedAdapter: route.createCommittedAdapter,
+      economicCapability: route.economicCapability,
+    }))).toEqual([
+      {
+        routeId: "local-harness",
+        adapter: undefined,
+        createCommittedAdapter: undefined,
+        economicCapability: { status: "unverified" },
+      },
+      {
+        routeId: "remote-harness",
+        adapter: undefined,
+        createCommittedAdapter: undefined,
+        economicCapability: { status: "unverified" },
+      },
+    ]);
+  });
+
   it("exposes canonical agent profiles as managed invocation selection catalog", async () => {
     const root = mkdtempSync(join(tmpdir(), "kiln-managed-agent-catalog-"));
     try {

--- a/packages/cli/tests/config/managed-agent-routes.test.ts
+++ b/packages/cli/tests/config/managed-agent-routes.test.ts
@@ -1042,6 +1042,158 @@ describe("resolveManagedInvocationToolOptions", () => {
     }
   });
 
+  it("rejects missing or widening schema-v2 agent policy bindings before adapter construction", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kiln-economic-agent-policy-"));
+    try {
+      const agentsDir = join(root, ".kiln", "agents");
+      mkdirSync(agentsDir, { recursive: true });
+      const agentPath = join(agentsDir, "economic-worker.md");
+      const writeAgent = (policyLine: string, routeLine = "") => writeFileSync(agentPath, [
+        "---",
+        "name: economic-worker",
+        "role: Economic managed worker",
+        "goal: Execute only policy-admitted work.",
+        "tier: reasoning",
+        "mode: managed-child",
+        policyLine,
+        routeLine,
+        "---",
+        "Remain within the configured economic policy.",
+      ].filter(Boolean).join("\n"));
+      const economicPolicies = [{
+        id: "bounded-policy",
+        revision: "rev-1",
+        evidenceRequirements: { quota: "optional" as const, price: "optional" as const },
+        noRouteAction: "deny" as const,
+        comparisonDomains: [{
+          id: "priority-only",
+          rank: 0,
+          unit: "request",
+          scheme: { kind: "unit" as const },
+          rateCardBasis: "configured",
+          envelopeSemantics: "bounded",
+        }],
+        candidates: [{
+          routeId: "admitted-route",
+          comparisonDomainId: "priority-only",
+          priorityRank: 0,
+          ceiling: { kind: "none" as const },
+          worstCaseReservation: { kind: "not-comparable" as const, reason: "economic-basis-unavailable" as const },
+        }],
+      }];
+      const config = baseConfig({
+        schemaVersion: 2,
+        economicPolicies,
+        routes: [{
+          id: "admitted-route",
+          kind: "direct",
+          provider: "codex-oauth",
+          model: "gpt-5.4-mini",
+          profiles: ["foundation-readonly-plan"],
+        }],
+      });
+      let adapterConstructions = 0;
+      const resolve = () => resolveManagedInvocationToolOptions(config, {
+        cwd: root,
+        userHome: root,
+        registry: createRegistry("codex-oauth"),
+        surface: "gui",
+        providerModelEligibility: COMMON_OBSERVED_PROVIDER_MODELS,
+        directAdapterFactory: (route) => {
+          adapterConstructions += 1;
+          return makeDirectAdapter(route.provider);
+        },
+      });
+
+      writeAgent("");
+      const missing = await resolve();
+      expect(missing.agentHealth).toContainEqual(expect.objectContaining({
+        agentName: "economic-worker",
+        available: false,
+        reason: expect.stringContaining("economicPolicyId"),
+      }));
+      expect(adapterConstructions).toBe(0);
+
+      writeAgent("economicPolicyId: bounded-policy", "routeId: outside-policy");
+      const widening = await resolve();
+      expect(widening.agentHealth).toContainEqual(expect.objectContaining({
+        agentName: "economic-worker",
+        available: false,
+        reason: expect.stringContaining("not admitted"),
+      }));
+      expect(adapterConstructions).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("consumes a valid schema-v2 agent policy binding without selecting a route hint", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kiln-economic-agent-policy-valid-"));
+    try {
+      const agentsDir = join(root, ".kiln", "agents");
+      mkdirSync(agentsDir, { recursive: true });
+      writeFileSync(join(agentsDir, "economic-worker.md"), [
+        "---",
+        "name: economic-worker",
+        "role: Economic managed worker",
+        "goal: Execute only policy-admitted work.",
+        "tier: reasoning",
+        "mode: managed-child",
+        "economicPolicyId: bounded-policy",
+        "---",
+        "Remain within the configured economic policy.",
+      ].join("\n"));
+      const result = await resolveManagedInvocationToolOptions(baseConfig({
+        schemaVersion: 2,
+        economicPolicies: [{
+          id: "bounded-policy",
+          revision: "rev-1",
+          evidenceRequirements: { quota: "optional", price: "optional" },
+          noRouteAction: "deny",
+          comparisonDomains: [{
+            id: "priority-only",
+            rank: 0,
+            unit: "request",
+            scheme: { kind: "unit" },
+            rateCardBasis: "configured",
+            envelopeSemantics: "bounded",
+          }],
+          candidates: [{
+            routeId: "admitted-route",
+            comparisonDomainId: "priority-only",
+            priorityRank: 0,
+            ceiling: { kind: "none" },
+            worstCaseReservation: { kind: "not-comparable", reason: "economic-basis-unavailable" },
+          }],
+        }],
+        routes: [{
+          id: "admitted-route",
+          kind: "direct",
+          provider: "codex-oauth",
+          model: "gpt-5.4-mini",
+          profiles: ["foundation-readonly-plan"],
+        }],
+      }), {
+        cwd: root,
+        userHome: root,
+        registry: createRegistry("codex-oauth"),
+        surface: "gui",
+        providerModelEligibility: COMMON_OBSERVED_PROVIDER_MODELS,
+        directAdapterFactory: (route) => makeDirectAdapter(route.provider),
+      });
+
+      expect(result.managedInvocation?.agentCatalog).toContainEqual(expect.objectContaining({
+        name: "economic-worker",
+      }));
+      const agent = result.managedInvocation?.agentCatalog?.find((candidate) => candidate.name === "economic-worker");
+      expect(agent).not.toHaveProperty("routeId");
+      expect(agent).not.toHaveProperty("providerRoute");
+      expect(result.managedInvocation?.agentCatalog?.map((candidate) => candidate.name)).toEqual(["economic-worker"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("projects agent route hints from configured task suitability without model-name heuristics", async () => {
     const root = mkdtempSync(join(tmpdir(), "kiln-route-suitability-"));
     try {

--- a/packages/cli/tests/config/managed-economic-policy-config.test.ts
+++ b/packages/cli/tests/config/managed-economic-policy-config.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import { validateGlobalConfig, type KilnGlobalConfig } from "../../src/config/global-config.js";
+
+function economicConfig(): KilnGlobalConfig {
+  return {
+    version: "1",
+    managedAgents: {
+      schemaVersion: 2,
+      routes: [{
+        id: "codex-standard",
+        kind: "direct",
+        provider: "codex-oauth",
+        model: "gpt-5.6-codex",
+        credentials: {
+          mode: "runtime-selected",
+          routeId: "codex-standard",
+          accountPolicyId: "codex-standard-policy",
+        },
+      }],
+      economicPolicies: [{
+        id: "default-economic-policy",
+        revision: "rev-2026-07",
+        evidenceRequirements: {
+          quota: "required-for-account-bound",
+          price: "required",
+        },
+        noRouteAction: "deny",
+        comparisonDomains: [{
+          id: "usd-worst-case",
+          rank: 0,
+          unit: "request",
+          scheme: { kind: "currency", currency: "USD" },
+          rateCardBasis: "public-rate-card",
+          envelopeSemantics: "configured-upper-bound",
+        }],
+        candidates: [{
+          routeId: "codex-standard",
+          comparisonDomainId: "usd-worst-case",
+          priorityRank: 0,
+          ceiling: {
+            kind: "finite",
+            amount: {
+              atoms: "25",
+              scale: 0,
+              unit: "request",
+              scheme: { kind: "currency", currency: "USD" },
+            },
+          },
+          worstCaseReservation: {
+            kind: "exact",
+            amount: {
+              atoms: "25",
+              scale: 0,
+              unit: "request",
+              scheme: { kind: "currency", currency: "USD" },
+            },
+          },
+        }],
+      }],
+    },
+    modelGateway: {
+      port: 4819,
+      accounts: [{
+        id: "codex-account",
+        providerId: "codex-oauth",
+        credentialId: "codex-credential",
+        maxConcurrency: 1,
+        reservedAffinitySlots: 0,
+        economics: {
+          capacityIdentity: "codex-capacity",
+          subscriptionClass: "metered",
+          quotaClassId: "codex-standard",
+          creditPosture: "disabled",
+          overagePosture: "disabled",
+        },
+      }],
+      replay: { ttlMs: 60_000, maxEntries: 10, hmacKeyEnv: "REPLAY_SECRET" },
+      surfaces: { openAIResponses: { maxBodyBytes: 1024, maxConcurrentRequests: 1 } },
+      principals: [{
+        tokenEnv: "KILN_RESPONSES_TOKEN",
+        ingress: "openai-responses",
+        tenantId: "tenant",
+        applicationId: "managed-agent",
+        callerId: "caller",
+        capabilityId: "model-invoke",
+        scopes: ["model.invoke"],
+        budgetEvidenceId: "budget",
+        virtualModelIds: ["codex-standard-policy"],
+      }],
+      virtualModels: [{
+        id: "codex-standard-policy",
+        providerId: "codex-oauth",
+        providerModelId: "gpt-5.6-codex",
+        accountIds: ["codex-account"],
+        capabilities: ["text"],
+        affinity: { continuity: "none" },
+        economics: {
+          adapterCapabilityId: "codex-direct",
+          adapterCapabilityVersion: "v1",
+          authBillingChannel: "oauth-subscription",
+          executionMode: "responses-api",
+          serviceTier: "standard",
+          rateCardBasis: "public-rate-card",
+          envelopeSemantics: "configured-upper-bound",
+          fallbackPosture: "disabled",
+          overagePosture: "disabled",
+          contextClass: "standard-context",
+          cacheClass: "provider-cache",
+          priceEvidence: {
+            kind: "metered",
+            rateCardId: "codex-public",
+            rateCardRevision: "rev-2026-07",
+            unitPrices: [{
+              usageUnit: "input-token",
+              price: {
+                atoms: "125",
+                scale: 6,
+                unit: "input-token",
+                scheme: { kind: "currency", currency: "USD" },
+              },
+            }],
+            evidence: {
+              sourceIdentity: "openai-pricing",
+              sourceRevision: "rev-2026-07",
+              sourceDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              observedAt: "2026-07-29T00:00:00.000Z",
+              validUntil: "2026-08-29T00:00:00.000Z",
+              confidence: "high",
+              authority: "provider-reported",
+            },
+          },
+          auxiliaryCharges: [],
+          executionEnvelope: {
+            limits: [{
+              atoms: "200000",
+              scale: 0,
+              unit: "input-token",
+              scheme: { kind: "unit" },
+            }],
+          },
+        },
+      }],
+    },
+  };
+}
+
+describe("managed economic policy config", () => {
+  it("admits one explicit versioned policy with complete direct-route economics", () => {
+    expect(() => validateGlobalConfig(economicConfig())).not.toThrow();
+  });
+
+  it("requires the one-way schema version and rejects unknown policy fields", () => {
+    const missingVersion = structuredClone(economicConfig()) as Record<string, any>;
+    delete missingVersion.managedAgents.schemaVersion;
+    expect(() => validateGlobalConfig(missingVersion)).toThrow(/schemaVersion must be 2/);
+
+    const unknown = structuredClone(economicConfig()) as Record<string, any>;
+    unknown.managedAgents.economicPolicies[0].estimatedCost = 0.25;
+    expect(() => validateGlobalConfig(unknown)).toThrow(/estimatedCost/);
+
+    const unknownReservation = structuredClone(economicConfig()) as Record<string, any>;
+    unknownReservation.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation.rounding = "float";
+    expect(() => validateGlobalConfig(unknownReservation)).toThrow(/rounding/);
+
+    const emptyPolicies = structuredClone(economicConfig()) as Record<string, any>;
+    emptyPolicies.managedAgents.economicPolicies = [];
+    expect(() => validateGlobalConfig(emptyPolicies)).toThrow(/schemaVersion 2 requires non-empty economicPolicies/);
+
+    const missingPolicies = structuredClone(economicConfig()) as Record<string, any>;
+    delete missingPolicies.managedAgents.economicPolicies;
+    expect(() => validateGlobalConfig(missingPolicies)).toThrow(/schemaVersion 2 requires non-empty economicPolicies/);
+  });
+
+  it("rejects broken candidate, route, virtual-model, and account cross-links", () => {
+    const unknownRoute = structuredClone(economicConfig()) as Record<string, any>;
+    unknownRoute.managedAgents.economicPolicies[0].candidates[0].routeId = "missing";
+    expect(() => validateGlobalConfig(unknownRoute)).toThrow(/routeId must reference managedAgents.routes/);
+
+    const missingRouteEconomics = structuredClone(economicConfig()) as Record<string, any>;
+    delete missingRouteEconomics.modelGateway.virtualModels[0].economics;
+    expect(() => validateGlobalConfig(missingRouteEconomics)).toThrow(/virtual model with economics/);
+
+    const missingAccountEconomics = structuredClone(economicConfig()) as Record<string, any>;
+    delete missingAccountEconomics.modelGateway.accounts[0].economics;
+    expect(() => validateGlobalConfig(missingAccountEconomics)).toThrow(/economics for every account candidate/);
+  });
+
+  it("rejects unsupported providers, implicit fallback, and incompatible ceilings", () => {
+    const unsupported = structuredClone(economicConfig()) as Record<string, any>;
+    unsupported.managedAgents.routes[0].provider = "anthropic";
+    unsupported.modelGateway.accounts[0].providerId = "anthropic";
+    unsupported.modelGateway.virtualModels[0].providerId = "anthropic";
+    expect(() => validateGlobalConfig(unsupported)).toThrow(/supported direct economic route/);
+
+    const fallback = structuredClone(economicConfig()) as Record<string, any>;
+    fallback.modelGateway.virtualModels[0].economics.fallbackPosture = "committed";
+    expect(() => validateGlobalConfig(fallback)).toThrow(/uncommitted fallback or overage/);
+
+    const ceiling = structuredClone(economicConfig()) as Record<string, any>;
+    ceiling.managedAgents.economicPolicies[0].candidates[0].ceiling.amount.scheme.currency = "EUR";
+    expect(() => validateGlobalConfig(ceiling)).toThrow(/comparison domain unit and scheme/);
+
+    const committedAccount = structuredClone(economicConfig()) as Record<string, any>;
+    committedAccount.modelGateway.accounts[0].economics.creditPosture = "committed";
+    expect(() => validateGlobalConfig(committedAccount)).toThrow(/account credit or overage subcommitments/);
+  });
+
+  it("rejects duplicate domains, candidates, and non-canonical decimal ceilings", () => {
+    const duplicateDomain = structuredClone(economicConfig()) as Record<string, any>;
+    duplicateDomain.managedAgents.economicPolicies[0].comparisonDomains.push(
+      structuredClone(duplicateDomain.managedAgents.economicPolicies[0].comparisonDomains[0]),
+    );
+    expect(() => validateGlobalConfig(duplicateDomain)).toThrow(/id must be unique/);
+
+    const duplicateCandidate = structuredClone(economicConfig()) as Record<string, any>;
+    duplicateCandidate.managedAgents.economicPolicies[0].candidates.push(
+      structuredClone(duplicateCandidate.managedAgents.economicPolicies[0].candidates[0]),
+    );
+    expect(() => validateGlobalConfig(duplicateCandidate)).toThrow(/routeId must be unique/);
+
+    const malformedAmount = structuredClone(economicConfig()) as Record<string, any>;
+    malformedAmount.managedAgents.economicPolicies[0].candidates[0].ceiling.amount.atoms = "01";
+    expect(() => validateGlobalConfig(malformedAmount)).toThrow(/canonical non-negative base-10/);
+  });
+
+  it("binds candidate reservations and policy domains to exact route economics", () => {
+    const aboveCeiling = structuredClone(economicConfig()) as Record<string, any>;
+    aboveCeiling.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation.amount.atoms = "26";
+    expect(() => validateGlobalConfig(aboveCeiling)).toThrow(/must not exceed its finite ceiling/);
+
+    const underReserved = structuredClone(economicConfig()) as Record<string, any>;
+    underReserved.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation.amount.atoms = "24";
+    expect(() => validateGlobalConfig(underReserved)).toThrow(/must cover the derived minimum reservation/);
+
+    const mismatchedBasis = structuredClone(economicConfig()) as Record<string, any>;
+    mismatchedBasis.managedAgents.economicPolicies[0].comparisonDomains[0].rateCardBasis = "different-rate-card";
+    expect(() => validateGlobalConfig(mismatchedBasis)).toThrow(/rateCardBasis must match route economics/);
+
+    const mismatchedEnvelope = structuredClone(economicConfig()) as Record<string, any>;
+    mismatchedEnvelope.managedAgents.economicPolicies[0].comparisonDomains[0].envelopeSemantics = "different-envelope";
+    expect(() => validateGlobalConfig(mismatchedEnvelope)).toThrow(/envelopeSemantics must match route economics/);
+
+    const missingReservation = structuredClone(economicConfig()) as Record<string, any>;
+    delete missingReservation.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation;
+    expect(() => validateGlobalConfig(missingReservation)).toThrow(/worstCaseReservation/);
+
+    const notComparableMetered = structuredClone(economicConfig()) as Record<string, any>;
+    notComparableMetered.managedAgents.economicPolicies[0].candidates[0].ceiling = { kind: "none" };
+    notComparableMetered.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation = {
+      kind: "not-comparable",
+      reason: "subscription-basis",
+    };
+    expect(() => validateGlobalConfig(notComparableMetered)).toThrow(/metered route requires an exact worst-case reservation/);
+
+    const subscription = structuredClone(economicConfig()) as Record<string, any>;
+    subscription.modelGateway.virtualModels[0].economics.priceEvidence.kind = "subscription";
+    delete subscription.modelGateway.virtualModels[0].economics.priceEvidence.unitPrices;
+    subscription.managedAgents.economicPolicies[0].candidates[0].ceiling = { kind: "none" };
+    subscription.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation = {
+      kind: "not-comparable",
+      reason: "subscription-basis",
+    };
+    expect(() => validateGlobalConfig(subscription)).not.toThrow();
+    subscription.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation.reason = "included-basis";
+    expect(() => validateGlobalConfig(subscription)).toThrow(/subscription-basis/);
+
+    const priceScheme = structuredClone(economicConfig()) as Record<string, any>;
+    priceScheme.modelGateway.virtualModels[0].economics.priceEvidence.unitPrices[0].price.scheme.currency = "EUR";
+    expect(() => validateGlobalConfig(priceScheme)).toThrow(/route price scheme must match its comparison domain/);
+
+    const auxiliaryScheme = structuredClone(economicConfig()) as Record<string, any>;
+    auxiliaryScheme.modelGateway.virtualModels[0].economics.auxiliaryCharges = [{
+      id: "tool-call",
+      amount: { atoms: "1", scale: 2, unit: "request", scheme: { kind: "currency", currency: "EUR" } },
+    }];
+    expect(() => validateGlobalConfig(auxiliaryScheme)).toThrow(/auxiliary charge unit and scheme must match its comparison domain/);
+  });
+
+  it("requires proven free routes to reserve exact zero without auxiliary charges", () => {
+    const free = structuredClone(economicConfig()) as Record<string, any>;
+    free.modelGateway.virtualModels[0].economics.priceEvidence.kind = "free";
+    delete free.modelGateway.virtualModels[0].economics.priceEvidence.unitPrices;
+    free.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation.amount.atoms = "0";
+    expect(() => validateGlobalConfig(free)).not.toThrow();
+
+    const nonzero = structuredClone(free);
+    nonzero.managedAgents.economicPolicies[0].candidates[0].worstCaseReservation.amount.atoms = "1";
+    expect(() => validateGlobalConfig(nonzero)).toThrow(/exact zero worst-case reservation/);
+
+    const chargedAuxiliary = structuredClone(free);
+    chargedAuxiliary.modelGateway.virtualModels[0].economics.auxiliaryCharges = [{
+      id: "tool-call",
+      amount: { atoms: "1", scale: 2, unit: "request", scheme: { kind: "currency", currency: "USD" } },
+    }];
+    expect(() => validateGlobalConfig(chargedAuxiliary)).toThrow(/cannot declare separately charged auxiliary calls/);
+  });
+});

--- a/packages/cli/tests/config/model-gateway-native-projection.test.ts
+++ b/packages/cli/tests/config/model-gateway-native-projection.test.ts
@@ -13,7 +13,20 @@ function config(principals: ModelGatewayConfig["principals"]): ModelGatewayConfi
   const hasMessages = principals.some((candidate) => candidate.ingress === "anthropic-messages");
   return {
     port: 4910,
-    accounts: [{ id: "account", providerId: "codex-oauth", credentialId: "credential", maxConcurrency: 1, reservedAffinitySlots: 0 }],
+    accounts: [{
+      id: "account",
+      providerId: "codex-oauth",
+      credentialId: "credential",
+      maxConcurrency: 1,
+      reservedAffinitySlots: 0,
+      economics: {
+        capacityIdentity: "private-capacity-identity",
+        subscriptionClass: "subscription",
+        quotaClassId: "private-quota-class",
+        creditPosture: "disabled",
+        overagePosture: "disabled",
+      },
+    }],
     replay: { ttlMs: 1000, maxEntries: 10, hmacKeyEnv: "REPLAY_KEY" },
     surfaces: {
       ...(hasResponses ? { openAIResponses: { maxBodyBytes: 1024, maxConcurrentRequests: 1 } } : {}),
@@ -21,7 +34,49 @@ function config(principals: ModelGatewayConfig["principals"]): ModelGatewayConfi
     },
     principals,
     virtualModels: [
-        { id: "model-a", displayName: "Model A", contextTokens: 200000, outputTokens: 8192, baseInstructions: "Governed model A instructions.", providerId: "codex-oauth", providerModelId: "upstream-a", accountIds: ["account"], capabilities: ["text", "parallel-tool-calls", "input-image-url"], affinity: { continuity: "none" } },
+        {
+          id: "model-a",
+          displayName: "Model A",
+          contextTokens: 200000,
+          outputTokens: 8192,
+          baseInstructions: "Governed model A instructions.",
+          providerId: "codex-oauth",
+          providerModelId: "upstream-a",
+          accountIds: ["account"],
+          capabilities: ["text", "parallel-tool-calls", "input-image-url"],
+          affinity: { continuity: "none" },
+          economics: {
+            adapterCapabilityId: "codex-direct",
+            adapterCapabilityVersion: "v1",
+            authBillingChannel: "private-billing-channel",
+            executionMode: "responses-api",
+            serviceTier: "standard",
+            rateCardBasis: "private-rate-card-basis",
+            envelopeSemantics: "configured-upper-bound",
+            fallbackPosture: "disabled",
+            overagePosture: "disabled",
+            contextClass: "standard-context",
+            cacheClass: "provider-cache",
+            priceEvidence: {
+              kind: "subscription",
+              rateCardId: "private-rate-card",
+              rateCardRevision: "rev-1",
+              evidence: {
+                sourceIdentity: "configured-pricing",
+                sourceRevision: "rev-1",
+                sourceDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                observedAt: "2026-07-29T00:00:00.000Z",
+                validUntil: "2026-08-29T00:00:00.000Z",
+                confidence: "high",
+                authority: "configured",
+              },
+            },
+            auxiliaryCharges: [],
+            executionEnvelope: {
+              limits: [{ atoms: "1", scale: 0, unit: "request", scheme: { kind: "unit" } }],
+            },
+          },
+        },
         { id: "model-b", displayName: "Model B", contextTokens: 100000, outputTokens: 4096, baseInstructions: "Governed model B instructions.", providerId: "codex-oauth", providerModelId: "upstream-b", accountIds: ["account"], capabilities: ["text"], affinity: { continuity: "none" } },
     ],
   };
@@ -60,6 +115,9 @@ describe("model gateway native projections", () => {
     expect(projected?.managedFields).toEqual(["model_providers.kiln"]);
     expect(projected).not.toHaveProperty("catalog");
     expect(JSON.stringify(projected)).not.toContain("Bearer");
+    expect(JSON.stringify(projected)).not.toContain("private-capacity-identity");
+    expect(JSON.stringify(projected)).not.toContain("private-rate-card");
+    expect(JSON.stringify(projected)).not.toContain("private-billing-channel");
   });
 
   it("projects an OpenCode-backed virtual model into Codex without exposing upstream credentials", () => {

--- a/packages/cli/tests/config/native-projection-backup.test.ts
+++ b/packages/cli/tests/config/native-projection-backup.test.ts
@@ -51,6 +51,81 @@ describe("backupNativeProjectionFile", () => {
     }
   });
 
+  it("retains every backup by default so config projection history is never silently dropped", () => {
+    const root = mkdtempSync(join(tmpdir(), "kiln-native-projection-backup-retain-default-"));
+    const kilnDir = join(root, "project", ".kiln");
+    const nativePath = join(root, "home", ".codex", "config.toml");
+
+    try {
+      writeFileSyncRecursive(nativePath, "model = 'a'\n", "utf-8");
+      for (let index = 0; index < 4; index += 1) {
+        backupNativeProjectionFile({
+          kilnDir,
+          targetId: "codex-config",
+          filePath: nativePath,
+          timestamp: `2026-05-0${index + 1}T12:00:00.000Z`,
+        });
+      }
+
+      expect(readdirSync(join(kilnDir, "backups", "codex-config"))).toHaveLength(4);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prunes oldest backups beyond the retention limit, keeping the newest", () => {
+    const root = mkdtempSync(join(tmpdir(), "kiln-native-projection-backup-retain-"));
+    const kilnDir = join(root, "project", ".kiln");
+    const nativePath = join(root, "home", ".codex", "auth.json");
+
+    try {
+      writeFileSyncRecursive(nativePath, "{}\n", "utf-8");
+      for (const day of ["01", "02", "03", "04", "05"]) {
+        backupNativeProjectionFile({
+          kilnDir,
+          targetId: "codex-native-auth",
+          filePath: nativePath,
+          timestamp: `2026-05-${day}T12:00:00.000Z`,
+          retain: 2,
+        });
+      }
+
+      expect(readdirSync(join(kilnDir, "backups", "codex-native-auth")).sort()).toEqual([
+        "2026-05-04T12-00-00-000Z-auth.json.bak",
+        "2026-05-05T12-00-00-000Z-auth.json.bak",
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scopes pruning per source file so unrelated backups in one target never prune each other", () => {
+    const root = mkdtempSync(join(tmpdir(), "kiln-native-projection-backup-scope-"));
+    const kilnDir = join(root, "project", ".kiln");
+    const authPath = join(root, "home", ".codex", "auth.json");
+    const configPath = join(root, "home", ".codex", "config.toml");
+
+    try {
+      writeFileSyncRecursive(authPath, "{}\n", "utf-8");
+      writeFileSyncRecursive(configPath, "model = 'a'\n", "utf-8");
+      for (const day of ["01", "02", "03"]) {
+        backupNativeProjectionFile({
+          kilnDir, targetId: "shared", filePath: authPath, timestamp: `2026-05-${day}T12:00:00.000Z`, retain: 1,
+        });
+        backupNativeProjectionFile({
+          kilnDir, targetId: "shared", filePath: configPath, timestamp: `2026-05-${day}T12:00:00.000Z`, retain: 1,
+        });
+      }
+
+      expect(readdirSync(join(kilnDir, "backups", "shared")).sort()).toEqual([
+        "2026-05-03T12-00-00-000Z-auth.json.bak",
+        "2026-05-03T12-00-00-000Z-config.toml.bak",
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("preserves binary projection content", () => {
     const root = mkdtempSync(join(tmpdir(), "kiln-native-projection-backup-binary-"));
     const kilnDir = join(root, "project", ".kiln");

--- a/packages/cli/tests/config/native-projection-backup.test.ts
+++ b/packages/cli/tests/config/native-projection-backup.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
@@ -121,6 +121,30 @@ describe("backupNativeProjectionFile", () => {
         "2026-05-03T12-00-00-000Z-auth.json.bak",
         "2026-05-03T12-00-00-000Z-config.toml.bak",
       ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // POSIX-only: Windows ignores mode bits and protects these paths through the
+  // user-profile ACL instead. CI runs Linux, so the invariant is enforced there.
+  it.skipIf(process.platform === "win32")("writes secret-bearing backups owner-only", () => {
+    const root = mkdtempSync(join(tmpdir(), "kiln-native-projection-backup-mode-"));
+    const kilnDir = join(root, "project", ".kiln");
+    const nativePath = join(root, "home", ".codex", "auth.json");
+
+    try {
+      writeFileSyncRecursive(nativePath, "{}\n", "utf-8");
+
+      const backupPath = backupNativeProjectionFile({
+        kilnDir,
+        targetId: "codex-native-auth",
+        filePath: nativePath,
+        timestamp: "2026-05-06T12:00:00.000Z",
+        mode: 0o600,
+      });
+
+      expect(statSync(backupPath!).mode & 0o777).toBe(0o600);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/cli/tests/native-harness/codex-app-mcp-server.test.ts
+++ b/packages/cli/tests/native-harness/codex-app-mcp-server.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -108,6 +108,49 @@ function managedJob(overrides: Partial<ManagedJobRecord> = {}): ManagedJobRecord
   };
 }
 
+function managedEconomicJob(): ManagedJobRecord {
+  return {
+    version: 5,
+    id: "managed-job-economic-0001",
+    state: "failed",
+    projectId: "trusted-project",
+    callerId: "trusted-codex-user",
+    configuredAgentProfileId: "scout",
+    admissionProfileId: "foundation-readonly-plan",
+    economicPolicyId: "economy-policy",
+    economicPolicyRevision: "revision-001",
+    constraints: {},
+    candidateSet: {
+      economicPolicyId: "economy-policy",
+      economicPolicyRevision: "revision-001",
+      admissionProfileId: "foundation-readonly-plan",
+      constraints: {},
+      candidates: [{
+        routeId: "codex-primary",
+        routeSource: "explicit-managed-route",
+        providerId: "codex-oauth",
+        surface: "direct-provider",
+        adapterCapabilityId: "codex-oauth-direct",
+        adapterCapabilityVersion: "1",
+      }],
+      rejections: [],
+    },
+    governanceSource: "kiln-governance",
+    admissionId: "admission-001",
+    requestFingerprint: "a".repeat(64),
+    idempotencyKeyHash: "b".repeat(64),
+    createdAt: OBSERVED_AT,
+    updatedAt: OBSERVED_AT,
+    diagnostic: "economic_commitment_unavailable",
+    lifecycle: [{
+      sequence: 1,
+      state: "failed",
+      observedAt: OBSERVED_AT,
+      diagnostic: "economic_commitment_unavailable",
+    }],
+  };
+}
+
 describe("CodexAppMcpServer", () => {
   it.each(["codex", "claude", "opencode"] as const)("uses trusted %s identity in managed-job evidence", async (harness) => {
     const server = new NativeHarnessMcpServer({
@@ -199,6 +242,58 @@ describe("CodexAppMcpServer", () => {
     expect(submitted).toEqual([{ objective: "inspect bounded work", configuredAgentProfileId: "scout", idempotencyKey: "retry-1", callerId: "trusted-codex-user" }]);
     expect(result.structuredContent).toMatchObject({ job: { id: "managed-job-0001", routeId: "route-go" }, evidence: { callerId: "trusted-codex-user", requestId: "trusted-request" } });
     expect(JSON.stringify(result)).not.toContain("objective");
+  });
+
+  it("projects an uncommitted V5 job without fabricating route or provider identity", async () => {
+    const server = new CodexAppMcpServer({
+      managedJobs: {
+        submit: async () => managedEconomicJob(),
+        getStatus: async () => managedEconomicJob(),
+        getResult: async () => ({
+          jobId: "managed-job-economic-0001",
+          availability: "failed",
+          lifecycleState: "failed",
+          configuredAgentProfileId: "scout",
+          admissionProfileId: "foundation-readonly-plan",
+          diagnostic: "economic_commitment_unavailable",
+        }),
+        cancel: async () => managedEconomicJob(),
+        getReplay: async () => ({
+          jobId: "managed-job-economic-0001",
+          availability: "unavailable",
+          lifecycleState: "failed",
+          configuredAgentProfileId: "scout",
+          admissionProfileId: "foundation-readonly-plan",
+          lifecycle: [],
+          resultAvailability: "failed",
+          diagnostic: "replay_unavailable",
+          accountLeaseHistory: [],
+        }),
+      },
+      requestIdentity: () => ({
+        callerId: "trusted-codex-user",
+        requestId: "trusted-request",
+      }),
+    });
+
+    const result = await server.callTool("kiln_managed_agent_invoke", {
+      objective: "Inspect bounded work.",
+      configuredAgentProfileId: "scout",
+      idempotencyKey: "retry-economic",
+    });
+
+    expect(result.structuredContent).toMatchObject({
+      job: {
+        economicPolicyId: "economy-policy",
+        economicPolicyRevision: "revision-001",
+        diagnostic: {
+          code: "economic_commitment_unavailable",
+          operatorAction: "Wait until the configured economic commitment authority is available.",
+        },
+      },
+    });
+    expect(JSON.stringify(result.structuredContent)).not.toContain("routeId");
+    expect(JSON.stringify(result.structuredContent)).not.toContain("providerId");
   });
 
   it("projects trusted cancellation and canonical lifecycle replay without accepting caller authority or prose", async () => {

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -155,6 +155,11 @@ export { ElevenLabsTtsAdapter } from "./infrastructure/elevenlabs-tts.js";
 export type { ElevenLabsTtsConfig } from "./infrastructure/elevenlabs-tts.js";
 export { CodexOAuthAuth } from "./infrastructure/codex-oauth-auth.js";
 export { CODEX_DEVICE_VERIFICATION_URI, CODEX_OAUTH_CLIENT_ID } from "./infrastructure/codex-oauth-auth.js";
+export {
+  CREDENTIAL_FILE_MODE,
+  applyCredentialFileMode,
+  isOverPermissiveCredentialMode,
+} from "./infrastructure/credential-file-mode.js";
 export { CodexOAuthAdapter } from "./infrastructure/codex-oauth.js";
 export type {
   BrowserAuthorizationResult,

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -154,7 +154,7 @@ export type { OpenAITtsConfig } from "./infrastructure/openai-tts.js";
 export { ElevenLabsTtsAdapter } from "./infrastructure/elevenlabs-tts.js";
 export type { ElevenLabsTtsConfig } from "./infrastructure/elevenlabs-tts.js";
 export { CodexOAuthAuth } from "./infrastructure/codex-oauth-auth.js";
-export { CODEX_DEVICE_VERIFICATION_URI } from "./infrastructure/codex-oauth-auth.js";
+export { CODEX_DEVICE_VERIFICATION_URI, CODEX_OAUTH_CLIENT_ID } from "./infrastructure/codex-oauth-auth.js";
 export { CodexOAuthAdapter } from "./infrastructure/codex-oauth.js";
 export type {
   BrowserAuthorizationResult,

--- a/packages/core/src/agents/infrastructure/codex-oauth-auth.ts
+++ b/packages/core/src/agents/infrastructure/codex-oauth-auth.ts
@@ -367,7 +367,9 @@ export class CodexOAuthAuth {
       hasRefreshToken: this.isNonEmptyTokenString(tokenFile.refresh_token),
     });
     await mkdir(dirname(this.tokenPath), { recursive: true });
-    await writeFile(this.tokenPath, JSON.stringify(tokenFile, null, 2), "utf8");
+    // Owner-only on creation; POSIX applies this, Windows relies on the profile ACL.
+    // An already-existing file keeps its current mode, so this hardens new logins.
+    await writeFile(this.tokenPath, JSON.stringify(tokenFile, null, 2), { encoding: "utf8", mode: 0o600 });
     providerAuthDebug("token file saved", {
       tokenPath: this.tokenPath,
     });

--- a/packages/core/src/agents/infrastructure/codex-oauth-auth.ts
+++ b/packages/core/src/agents/infrastructure/codex-oauth-auth.ts
@@ -4,6 +4,7 @@ import { createServer, type Server, type ServerResponse } from "node:http";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { KilnError } from "../../engine/errors.js";
+import { CREDENTIAL_FILE_MODE, applyCredentialFileMode } from "./credential-file-mode.js";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTH_BASE = "https://auth.openai.com";
@@ -367,9 +368,13 @@ export class CodexOAuthAuth {
       hasRefreshToken: this.isNonEmptyTokenString(tokenFile.refresh_token),
     });
     await mkdir(dirname(this.tokenPath), { recursive: true });
-    // Owner-only on creation; POSIX applies this, Windows relies on the profile ACL.
-    // An already-existing file keeps its current mode, so this hardens new logins.
-    await writeFile(this.tokenPath, JSON.stringify(tokenFile, null, 2), { encoding: "utf8", mode: 0o600 });
+    await writeFile(this.tokenPath, JSON.stringify(tokenFile, null, 2), {
+      encoding: "utf8",
+      mode: CREDENTIAL_FILE_MODE,
+    });
+    // Creation mode does not cover a file that already existed, so a credential
+    // written before this invariant repairs itself on its next refresh.
+    await applyCredentialFileMode(this.tokenPath);
     providerAuthDebug("token file saved", {
       tokenPath: this.tokenPath,
     });

--- a/packages/core/src/agents/infrastructure/codex-oauth-auth.ts
+++ b/packages/core/src/agents/infrastructure/codex-oauth-auth.ts
@@ -51,6 +51,8 @@ export interface CodexOAuthTokenFile {
   readonly refresh_token: string;
   readonly expires_at: string;
   readonly client_id: string;
+  /** Carried only for native-harness projection (e.g. `~/.codex/auth.json`); never required for Kiln's own API calls. */
+  readonly id_token?: string;
 }
 
 export interface DeviceAuthorizationResult {
@@ -330,7 +332,7 @@ export class CodexOAuthAuth {
       });
     }
 
-    return this.toTokenFile(data);
+    return this.toTokenFile(data, tokenFile.id_token);
   }
 
   async getValidAccessToken(): Promise<string> {
@@ -445,7 +447,7 @@ export class CodexOAuthAuth {
     return this.toTokenFile(data);
   }
 
-  private toTokenFile(token: OAuthTokenResponse): CodexOAuthTokenFile {
+  private toTokenFile(token: OAuthTokenResponse, previousIdToken?: string): CodexOAuthTokenFile {
     const expiresAt = this.resolveExpiresAt(token);
     providerAuthDebug("resolved token expiry", {
       expiresAt,
@@ -453,11 +455,14 @@ export class CodexOAuthAuth {
       hasAccessTokenJwtExpiry: Boolean(this.readJwtExpiry(token.access_token)),
       hasIdTokenJwtExpiry: Boolean(this.readJwtExpiry(token.id_token)),
     });
+    // Refresh responses sometimes omit id_token and expect the prior one to remain valid.
+    const idToken = token.id_token ?? previousIdToken;
     return {
       access_token: token.access_token!,
       refresh_token: token.refresh_token!,
       expires_at: expiresAt,
       client_id: CLIENT_ID,
+      ...(idToken ? { id_token: idToken } : {}),
     };
   }
 
@@ -601,3 +606,4 @@ export class CodexOAuthAuth {
 }
 
 export const CODEX_DEVICE_VERIFICATION_URI = DEVICE_VERIFICATION_URI;
+export const CODEX_OAUTH_CLIENT_ID = CLIENT_ID;

--- a/packages/core/src/agents/infrastructure/credential-file-mode.ts
+++ b/packages/core/src/agents/infrastructure/credential-file-mode.ts
@@ -1,0 +1,36 @@
+import { chmod } from "node:fs/promises";
+
+/** Owner-only. Credential files must never be readable by other local accounts. */
+export const CREDENTIAL_FILE_MODE = 0o600;
+
+/**
+ * Enforces owner-only mode on a credential file that already exists.
+ *
+ * Creation-time mode does not cover files written before this invariant existed,
+ * and POSIX `write` does not change the mode of an existing file. Applying it on
+ * every persist lets credentials repair themselves on their next refresh instead
+ * of requiring a one-shot migration command that would become dead code.
+ *
+ * Best-effort by design: the write itself already succeeded, so a filesystem
+ * that cannot represent POSIX modes must not fail an otherwise valid login.
+ * Residual exposure stays visible through credential permission diagnostics
+ * rather than being silently accepted.
+ */
+export async function applyCredentialFileMode(
+  path: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  // Windows does not implement POSIX mode bits; these paths are protected by the
+  // user-profile ACL instead, so a chmod here would be misleading rather than safe.
+  if (platform === "win32") return;
+  try {
+    await chmod(path, CREDENTIAL_FILE_MODE);
+  } catch {
+    return;
+  }
+}
+
+/** True when a stat mode grants any group or other permission. */
+export function isOverPermissiveCredentialMode(mode: number): boolean {
+  return (mode & 0o077) !== 0;
+}

--- a/packages/core/src/cost/index.ts
+++ b/packages/core/src/cost/index.ts
@@ -98,3 +98,4 @@ export type {
   BudgetRouteBudget,
   BudgetUsageSnapshot,
 } from "./budget-admission.js";
+export * from "./managed-route-economics.js";

--- a/packages/core/src/cost/managed-route-economics.ts
+++ b/packages/core/src/cost/managed-route-economics.ts
@@ -425,6 +425,125 @@ export function validateManagedEconomicAmount(amount: ManagedEconomicAmount): vo
   validateScheme(amount.scheme);
 }
 
+export interface ManagedEconomicReservationUnitRate {
+  readonly usageUnit: string;
+  readonly price: ManagedEconomicAmount;
+}
+
+export interface ManagedEconomicReservationAuxiliaryCharge {
+  readonly id: string;
+  readonly amount: ManagedEconomicAmount;
+}
+
+export interface ManagedEconomicMinimumReservationInput {
+  readonly unitRates: readonly ManagedEconomicReservationUnitRate[];
+  readonly usageLimits: readonly ManagedEconomicAmount[];
+  readonly auxiliaryCharges: readonly ManagedEconomicReservationAuxiliaryCharge[];
+  readonly outputUnit: string;
+  readonly targetScheme: Exclude<ManagedEconomicScheme, { readonly kind: "unit" }>;
+}
+
+/**
+ * Derives the minimum comparable reservation implied by a rate schedule and
+ * bounded usage. The caller may configure a larger conservative reservation.
+ */
+export function deriveManagedEconomicMinimumReservation(
+  input: ManagedEconomicMinimumReservationInput,
+): ManagedEconomicAmount {
+  requireIdentity(input.outputUnit, "reservation output unit");
+  const targetScheme = input.targetScheme as ManagedEconomicScheme;
+  validateScheme(targetScheme);
+  if (targetScheme.kind === "unit") {
+    throw new ManagedEconomicValidationError("reservation target scheme must be currency or credit");
+  }
+  if (!Array.isArray(input.unitRates) || !Array.isArray(input.usageLimits) || !Array.isArray(input.auxiliaryCharges)) {
+    throw new ManagedEconomicValidationError("reservation rates, limits, and auxiliary charges must be arrays");
+  }
+
+  const rates = new Map<string, ManagedEconomicReservationUnitRate>();
+  for (const rate of input.unitRates) {
+    requireIdentity(rate.usageUnit, "reservation rate usage unit");
+    validateManagedEconomicAmount(rate.price);
+    if (rate.price.unit !== rate.usageUnit) {
+      throw new ManagedEconomicValidationError("reservation rate usageUnit must equal price.unit");
+    }
+    if (!sameScheme(rate.price.scheme, targetScheme)) {
+      throw new ManagedEconomicValidationError("reservation rate scheme must match target scheme");
+    }
+    if (rates.has(rate.usageUnit)) {
+      throw new ManagedEconomicValidationError("reservation rates must not duplicate a usage unit");
+    }
+    rates.set(rate.usageUnit, rate);
+  }
+
+  const limits = new Map<string, ManagedEconomicAmount>();
+  for (const limit of input.usageLimits) {
+    validateManagedEconomicAmount(limit);
+    if (limit.scheme.kind !== "unit") {
+      throw new ManagedEconomicValidationError("reservation usage limits must use the unit scheme");
+    }
+    if (limits.has(limit.unit)) {
+      throw new ManagedEconomicValidationError("reservation limits must not duplicate a usage unit");
+    }
+    limits.set(limit.unit, limit);
+  }
+  if ([...rates.keys()].some((unit) => !limits.has(unit))) {
+    throw new ManagedEconomicValidationError("every reservation rate must have exactly one matching usage limit");
+  }
+
+  const terms: Array<{ atoms: bigint; scale: number }> = [];
+  for (const [usageUnit, rate] of rates) {
+    const limit = limits.get(usageUnit)!;
+    terms.push(normalizeReservationTerm(
+      BigInt(rate.price.atoms) * BigInt(limit.atoms),
+      rate.price.scale + limit.scale,
+    ));
+  }
+
+  const auxiliaryIds = new Set<string>();
+  for (const charge of input.auxiliaryCharges) {
+    requireIdentity(charge.id, "reservation auxiliary charge id");
+    if (auxiliaryIds.has(charge.id)) {
+      throw new ManagedEconomicValidationError("reservation auxiliary charge ids must be unique");
+    }
+    auxiliaryIds.add(charge.id);
+    validateManagedEconomicAmount(charge.amount);
+    if (charge.amount.unit !== input.outputUnit) {
+      throw new ManagedEconomicValidationError("reservation auxiliary charge unit must equal output unit");
+    }
+    if (!sameScheme(charge.amount.scheme, targetScheme)) {
+      throw new ManagedEconomicValidationError("reservation auxiliary charge scheme must match target scheme");
+    }
+    terms.push(normalizeReservationTerm(BigInt(charge.amount.atoms), charge.amount.scale));
+  }
+
+  const scale = terms.reduce((maximum, term) => Math.max(maximum, term.scale), 0);
+  const atoms = terms.reduce(
+    (total, term) => total + term.atoms * powerOfTen(scale - term.scale),
+    0n,
+  );
+  const normalized = normalizeReservationTerm(atoms, scale);
+  return {
+    atoms: normalized.atoms.toString(),
+    scale: normalized.scale,
+    unit: input.outputUnit,
+    scheme: input.targetScheme,
+  };
+}
+
+function normalizeReservationTerm(atoms: bigint, scale: number): { atoms: bigint; scale: number } {
+  while (scale > 0 && atoms % 10n === 0n) {
+    atoms /= 10n;
+    scale -= 1;
+  }
+  if (scale > MAX_MANAGED_ECONOMIC_DECIMAL_SCALE) {
+    throw new ManagedEconomicValidationError(
+      `derived reservation scale exceeds ${MAX_MANAGED_ECONOMIC_DECIMAL_SCALE}`,
+    );
+  }
+  return { atoms, scale };
+}
+
 export function compareManagedEconomicAmounts(
   left: ManagedEconomicAmount,
   right: ManagedEconomicAmount,

--- a/packages/core/src/cost/managed-route-economics.ts
+++ b/packages/core/src/cost/managed-route-economics.ts
@@ -1,0 +1,1168 @@
+export type ManagedEconomicConfidence = "high" | "medium" | "low";
+
+export type ManagedEconomicEvidenceAuthority =
+  | "provider-reported"
+  | "configured"
+  | "calculated-estimate";
+
+export interface ManagedEconomicEvidenceIdentity {
+  readonly sourceIdentity: string;
+  readonly sourceRevision: string;
+  readonly sourceDigest: string;
+  readonly observedAt: string;
+  readonly validUntil: string;
+  readonly confidence: ManagedEconomicConfidence;
+  readonly authority: ManagedEconomicEvidenceAuthority;
+}
+
+export type ManagedEconomicScheme =
+  | {
+      readonly kind: "currency";
+      readonly currency: string;
+    }
+  | {
+      readonly kind: "credit";
+      readonly creditSchemeId: string;
+    }
+  | {
+      readonly kind: "unit";
+    };
+
+/**
+ * Exact non-negative decimal. `atoms` is canonical base-10 and `scale` records
+ * the decimal position; persisted arithmetic never passes through Number.
+ */
+export interface ManagedEconomicAmount {
+  readonly atoms: string;
+  readonly scale: number;
+  readonly unit: string;
+  readonly scheme: ManagedEconomicScheme;
+}
+
+export type ManagedEconomicClass =
+  | "subscription"
+  | "included"
+  | "free"
+  | "metered"
+  | "unknown"
+  | "estimated";
+
+export interface ManagedEconomicPriceIdentity {
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly authBillingChannel: string;
+  readonly executionMode: string;
+  readonly serviceTier: string;
+  readonly rateCardId: string;
+  readonly rateCardRevision: string;
+  readonly unit: string;
+  readonly scheme: ManagedEconomicScheme;
+  readonly unitScheduleDigest: string;
+  readonly contextClass: string;
+  readonly cacheClass: string;
+  readonly auxiliaryScheduleDigest: string;
+  readonly evidence: ManagedEconomicEvidenceIdentity;
+}
+
+export type ManagedEconomicPriceEvidence =
+  | {
+      readonly kind: "subscription";
+      readonly identity: ManagedEconomicPriceIdentity;
+    }
+  | {
+      readonly kind: "included";
+      readonly identity: ManagedEconomicPriceIdentity;
+      readonly allowanceId: string;
+    }
+  | {
+      readonly kind: "free";
+      readonly identity: ManagedEconomicPriceIdentity;
+    }
+  | {
+      readonly kind: "metered";
+      readonly identity: ManagedEconomicPriceIdentity;
+    }
+  | {
+      readonly kind: "unknown";
+      readonly identity: ManagedEconomicPriceIdentity;
+      readonly reason: string;
+    }
+  | {
+      readonly kind: "estimated";
+      readonly identity: ManagedEconomicPriceIdentity;
+      readonly estimationMethod: string;
+    };
+
+export interface ManagedEconomicQuotaBucket {
+  readonly bucketId: string;
+  readonly dimension: string;
+  readonly remaining: ManagedEconomicAmount | null;
+  readonly resetsAt: string | null;
+}
+
+export type ManagedEconomicQuotaEvidence =
+  | {
+      readonly kind: "known";
+      readonly capacityIdentity: string;
+      readonly subscriptionClass: Exclude<ManagedEconomicClass, "estimated">;
+      readonly quotaClassId: string;
+      readonly buckets: readonly ManagedEconomicQuotaBucket[];
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "unlimited";
+      readonly capacityIdentity: string;
+      readonly subscriptionClass: Exclude<ManagedEconomicClass, "estimated">;
+      readonly quotaClassId: string;
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "unknown";
+      readonly capacityIdentity: string;
+      readonly subscriptionClass: "unknown";
+      readonly reason: string;
+      readonly evidence: ManagedEconomicEvidenceIdentity | null;
+    };
+
+export interface ManagedEconomicRouteIdentity {
+  readonly routeId: string;
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly adapterCapabilityId: string;
+  readonly adapterCapabilityVersion: string;
+  readonly authBillingChannel: string;
+  readonly executionMode: string;
+  readonly serviceTier: string;
+  readonly accountPolicyId: string | null;
+  readonly fallbackPosture: "disabled" | "committed";
+  readonly overagePosture: "disabled" | "committed";
+  readonly rateCardId: string;
+  readonly rateCardRevision: string;
+  readonly priceEvidenceDigest: string;
+  readonly unit: string;
+  readonly scheme: ManagedEconomicScheme;
+  readonly contextClass: string;
+  readonly cacheClass: string;
+  readonly auxiliaryScheduleDigest: string;
+  readonly envelopeDigest: string;
+}
+
+export type ManagedEconomicAccountIdentity =
+  | {
+      readonly kind: "account-bound";
+      readonly capacityIdentity: string;
+      readonly accountRef: string;
+      readonly credentialRevision: string;
+      readonly creditPosture: "disabled" | "committed";
+      readonly overagePosture: "disabled" | "committed";
+      readonly quotaEvidence?: ManagedEconomicQuotaEvidence | null;
+    }
+  | {
+      readonly kind: "accountless";
+    };
+
+export interface ManagedEconomicExecutionIdentity {
+  readonly route: ManagedEconomicRouteIdentity;
+  readonly account: ManagedEconomicAccountIdentity;
+}
+
+export interface ManagedEconomicComparisonDomain {
+  readonly id: string;
+  readonly rank: number;
+  readonly basis: {
+    readonly unit: string;
+    readonly scheme: ManagedEconomicScheme;
+    readonly rateCardBasis: string;
+    readonly envelopeSemantics: string;
+  };
+}
+
+export type ManagedEconomicExecutionEnvelope =
+  | {
+      readonly kind: "bounded";
+      readonly digest: string;
+      readonly limits: readonly ManagedEconomicAmount[];
+    }
+  | {
+      readonly kind: "unbounded";
+      readonly missingDimensions: readonly string[];
+    };
+
+export type ManagedEconomicComparableReservation =
+  | {
+      readonly kind: "exact";
+      readonly amount: ManagedEconomicAmount;
+    }
+  | {
+      readonly kind: "not-comparable";
+      readonly reason:
+        | "subscription-basis"
+        | "included-basis"
+        | "estimated-basis"
+        | "unknown-basis"
+        | "economic-basis-unavailable";
+    };
+
+export type ManagedEconomicCeiling =
+  | {
+      readonly kind: "none";
+    }
+  | {
+      readonly kind: "finite";
+      readonly amount: ManagedEconomicAmount;
+    };
+
+export interface ManagedEconomicExecutionAlternative {
+  readonly identity: ManagedEconomicExecutionIdentity;
+  readonly comparisonDomain: ManagedEconomicComparisonDomain;
+  readonly priorityRank: number;
+  readonly priceEvidence?: ManagedEconomicPriceEvidence | null;
+  readonly executionEnvelope: ManagedEconomicExecutionEnvelope;
+  readonly worstCaseReservation: ManagedEconomicComparableReservation;
+  readonly ceiling: ManagedEconomicCeiling;
+  readonly accountSelectionReason: "existing-affinity" | "least-pressure" | "affinity-rebind" | "accountless";
+  readonly observedAffinityRevision: string | null;
+}
+
+export type ManagedEconomicCoreRejectionReason =
+  | "quota-evidence-missing"
+  | "quota-evidence-stale"
+  | "price-evidence-missing"
+  | "price-evidence-stale"
+  | "comparison-domain-incompatible"
+  | "execution-envelope-unbounded"
+  | "ceiling-exceeded";
+
+export interface ManagedEconomicCoreRejection {
+  readonly stage: "economic-selection";
+  readonly reason: ManagedEconomicCoreRejectionReason;
+  readonly alternativeIdentity: ManagedEconomicExecutionIdentity;
+}
+
+export type ManagedEconomicOrderingReason =
+  | "higher-comparison-domain-rank"
+  | "higher-priority-rank"
+  | "higher-worst-case-reservation"
+  | "stable-route-id-order"
+  | "stable-capacity-identity-order";
+
+export interface ManagedEconomicNotSelected {
+  readonly alternativeIdentity: ManagedEconomicExecutionIdentity;
+  readonly reason: ManagedEconomicOrderingReason;
+}
+
+export interface ManagedEconomicSelectionRequest {
+  /** Injected decision time makes freshness evaluation replay-stable. */
+  readonly decisionAt: string;
+  readonly evidenceRequirements: {
+    readonly quota: "optional" | "required-for-account-bound";
+    readonly price: "optional" | "required";
+  };
+  readonly alternatives: readonly ManagedEconomicExecutionAlternative[];
+}
+
+export interface ManagedEconomicPolicyIdentity {
+  readonly policyId: string;
+  readonly schemaVersion: number;
+  readonly policyRevision: string;
+  readonly policyDigest: string;
+  readonly comparisonDomains: readonly ManagedEconomicComparisonDomain[];
+  readonly noRouteAction: "deny";
+  readonly evidenceRequirements: ManagedEconomicSelectionRequest["evidenceRequirements"];
+}
+
+export type ManagedEconomicSelectionExplanation =
+  | {
+      readonly kind: "only-eligible-alternative";
+      readonly cheapestRouteClaim: false;
+    }
+  | {
+      readonly kind: "configured-domain-order";
+      readonly cheapestRouteClaim: false;
+    }
+  | {
+      readonly kind: "configured-priority-order";
+      readonly cheapestRouteClaim: false;
+    }
+  | {
+      readonly kind: "lower-comparable-reservation";
+      readonly cheapestRouteClaim: true;
+    }
+  | {
+      readonly kind: "stable-identity-order";
+      readonly cheapestRouteClaim: false;
+    };
+
+export type ManagedEconomicSelectionDecision =
+  | {
+      readonly kind: "selected";
+      readonly selected: ManagedEconomicExecutionAlternative;
+      readonly rejected: readonly ManagedEconomicCoreRejection[];
+      readonly notSelected: readonly ManagedEconomicNotSelected[];
+      readonly explanation: ManagedEconomicSelectionExplanation;
+    }
+  | {
+      readonly kind: "denied";
+      readonly rejected: readonly ManagedEconomicCoreRejection[];
+    };
+
+export interface ManagedEconomicCallerConstraint {
+  readonly routeIds?: readonly string[];
+  readonly providerIds?: readonly string[];
+  readonly modelIds?: readonly string[];
+}
+
+export interface ManagedEconomicReservation {
+  readonly reservationId: string;
+  readonly jobId: string;
+  readonly attemptId: string;
+  readonly policy: ManagedEconomicPolicyIdentity;
+  readonly selectedIdentity: ManagedEconomicExecutionIdentity;
+  readonly priceIdentity: ManagedEconomicPriceIdentity | null;
+  readonly envelope: Extract<ManagedEconomicExecutionEnvelope, { readonly kind: "bounded" }>;
+  readonly amounts: readonly ManagedEconomicAmount[];
+  readonly authorityRevision: string;
+}
+
+export interface ManagedEconomicCommitment {
+  readonly commitmentId: string;
+  readonly reservation: ManagedEconomicReservation;
+  readonly rejected: readonly ManagedEconomicCoreRejection[];
+  readonly notSelected: readonly ManagedEconomicNotSelected[];
+}
+
+export type ManagedEconomicSettlement =
+  | {
+      readonly kind: "charged";
+      readonly reservationId: string;
+      readonly dispatchFenceId: string;
+      readonly actualIdentity: ManagedEconomicExecutionIdentity;
+      readonly units: readonly ManagedEconomicAmount[];
+      readonly charge: ManagedEconomicAmount;
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "estimated";
+      readonly reservationId: string;
+      readonly dispatchFenceId: string;
+      readonly actualIdentity: ManagedEconomicExecutionIdentity;
+      readonly units: readonly ManagedEconomicAmount[];
+      readonly estimate: ManagedEconomicAmount;
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "subscription";
+      readonly reservationId: string;
+      readonly dispatchFenceId: string;
+      readonly actualIdentity: ManagedEconomicExecutionIdentity;
+      readonly units: readonly ManagedEconomicAmount[];
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "included";
+      readonly reservationId: string;
+      readonly dispatchFenceId: string;
+      readonly actualIdentity: ManagedEconomicExecutionIdentity;
+      readonly units: readonly ManagedEconomicAmount[];
+      readonly allowanceId: string;
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "free";
+      readonly reservationId: string;
+      readonly dispatchFenceId: string;
+      readonly actualIdentity: ManagedEconomicExecutionIdentity;
+      readonly units: readonly ManagedEconomicAmount[];
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "unknown";
+      readonly reservationId: string;
+      readonly dispatchFenceId: string;
+      readonly actualIdentity: ManagedEconomicExecutionIdentity | null;
+      readonly reason: string;
+      readonly evidence: ManagedEconomicEvidenceIdentity | null;
+    }
+  | {
+      readonly kind: "pending";
+      readonly reservationId: string;
+      readonly dispatchFenceId: string;
+    }
+  | {
+      readonly kind: "leaked";
+      readonly reservationId: string;
+      readonly dispatchFenceId: string;
+      readonly reason: string;
+    };
+
+const CANONICAL_ATOMS = /^(?:0|[1-9][0-9]*)$/;
+const UTC_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const SHA_256_DIGEST = /^sha256:[0-9a-f]{64}$/;
+/** Bounds canonical exact arithmetic while retaining sub-atto unit precision. */
+export const MAX_MANAGED_ECONOMIC_DECIMAL_SCALE = 18;
+
+export class ManagedEconomicValidationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "ManagedEconomicValidationError";
+  }
+}
+
+export function validateManagedEconomicAmount(amount: ManagedEconomicAmount): void {
+  if (!CANONICAL_ATOMS.test(amount.atoms)) {
+    throw new ManagedEconomicValidationError("amount atoms must be canonical non-negative base-10");
+  }
+  if (
+    !Number.isSafeInteger(amount.scale)
+    || amount.scale < 0
+    || amount.scale > MAX_MANAGED_ECONOMIC_DECIMAL_SCALE
+  ) {
+    throw new ManagedEconomicValidationError(
+      `amount scale must be an integer from 0 to ${MAX_MANAGED_ECONOMIC_DECIMAL_SCALE}`,
+    );
+  }
+  requireIdentity(amount.unit, "amount unit");
+  validateScheme(amount.scheme);
+}
+
+export function compareManagedEconomicAmounts(
+  left: ManagedEconomicAmount,
+  right: ManagedEconomicAmount,
+): number {
+  validateManagedEconomicAmount(left);
+  validateManagedEconomicAmount(right);
+  if (left.unit !== right.unit || !sameScheme(left.scheme, right.scheme)) {
+    throw new ManagedEconomicValidationError("amounts use incompatible units or schemes");
+  }
+
+  const scale = Math.max(left.scale, right.scale);
+  const leftAtoms = BigInt(left.atoms) * powerOfTen(scale - left.scale);
+  const rightAtoms = BigInt(right.atoms) * powerOfTen(scale - right.scale);
+  return leftAtoms < rightAtoms ? -1 : leftAtoms > rightAtoms ? 1 : 0;
+}
+
+export function narrowManagedEconomicExecutionAlternatives(
+  alternatives: readonly ManagedEconomicExecutionAlternative[],
+  constraint: ManagedEconomicCallerConstraint,
+): readonly ManagedEconomicExecutionAlternative[] {
+  const routeIds = constraint.routeIds === undefined ? null : new Set(constraint.routeIds);
+  const providerIds = constraint.providerIds === undefined ? null : new Set(constraint.providerIds);
+  const modelIds = constraint.modelIds === undefined ? null : new Set(constraint.modelIds);
+  return alternatives.filter(({ identity }) =>
+    (routeIds === null || routeIds.has(identity.route.routeId))
+    && (providerIds === null || providerIds.has(identity.route.providerId))
+    && (modelIds === null || modelIds.has(identity.route.modelId)));
+}
+
+export function orderManagedEconomicExecutionAlternatives(
+  alternatives: readonly ManagedEconomicExecutionAlternative[],
+): readonly ManagedEconomicExecutionAlternative[] {
+  const exactGroups = new Set<string>();
+  const nonExactGroups = new Set<string>();
+  for (const alternative of alternatives) {
+    const key = comparisonGroupKey(alternative);
+    (alternative.worstCaseReservation.kind === "exact" ? exactGroups : nonExactGroups).add(key);
+  }
+  const amountComparableGroups = new Set(
+    [...exactGroups].filter((key) => !nonExactGroups.has(key)),
+  );
+  return [...alternatives].sort((left, right) =>
+    compareAlternatives(left, right, amountComparableGroups));
+}
+
+function compareAlternatives(
+  left: ManagedEconomicExecutionAlternative,
+  right: ManagedEconomicExecutionAlternative,
+  amountComparableGroups: ReadonlySet<string>,
+): number {
+  const domain = compareIntegerRank(left.comparisonDomain.rank, right.comparisonDomain.rank);
+  if (domain !== 0) {
+    return domain;
+  }
+  const priority = compareIntegerRank(left.priorityRank, right.priorityRank);
+  if (priority !== 0) {
+    return priority;
+  }
+
+  const groupKey = comparisonGroupKey(left);
+  if (
+    amountComparableGroups.has(groupKey)
+    && left.worstCaseReservation.kind === "exact"
+    && right.worstCaseReservation.kind === "exact"
+  ) {
+    const amountComparison = compareManagedEconomicAmounts(
+      left.worstCaseReservation.amount,
+      right.worstCaseReservation.amount,
+    );
+    if (amountComparison !== 0) {
+      return amountComparison;
+    }
+  }
+
+  const route = compareStableStrings(left.identity.route.routeId, right.identity.route.routeId);
+  if (route !== 0) {
+    return route;
+  }
+  return compareStableStrings(stableCapacityIdentity(left), stableCapacityIdentity(right));
+}
+
+function comparisonGroupKey(alternative: ManagedEconomicExecutionAlternative): string {
+  return `${alternative.comparisonDomain.rank}\u0000${alternative.priorityRank}`;
+}
+
+export function selectManagedEconomicExecutionAlternative(
+  request: ManagedEconomicSelectionRequest,
+): ManagedEconomicSelectionDecision {
+  requireTimestamp(request.decisionAt, "decisionAt");
+  const rejected: ManagedEconomicCoreRejection[] = [];
+  const eligible: ManagedEconomicExecutionAlternative[] = [];
+  const incompatibleAlternatives = findSetLevelIncompatibilities(request.alternatives);
+
+  for (const alternative of request.alternatives) {
+    const reason = rejectionReason(
+      alternative,
+      request,
+      incompatibleAlternatives.has(alternative),
+    );
+    if (reason === null) {
+      eligible.push(alternative);
+    } else {
+      rejected.push({
+        stage: "economic-selection",
+        reason,
+        alternativeIdentity: alternative.identity,
+      });
+    }
+  }
+
+  if (eligible.length === 0) {
+    return { kind: "denied", rejected: rejected.sort(compareRejections) };
+  }
+
+  const ordered = orderManagedEconomicExecutionAlternatives(eligible);
+  const selected = ordered[0]!;
+  const selectedGroupUsesAmount = eligible
+    .filter((candidate) =>
+      candidate.comparisonDomain.rank === selected.comparisonDomain.rank
+      && candidate.priorityRank === selected.priorityRank)
+    .every((candidate) => candidate.worstCaseReservation.kind === "exact");
+  const notSelected = ordered.slice(1).map((alternative) => ({
+    alternativeIdentity: alternative.identity,
+    reason: orderingReason(selected, alternative, selectedGroupUsesAmount),
+  }));
+  return {
+    kind: "selected",
+    selected,
+    rejected: rejected.sort(compareRejections),
+    notSelected,
+    explanation: selectionExplanation(selected, ordered.slice(1)),
+  };
+}
+
+function rejectionReason(
+  alternative: ManagedEconomicExecutionAlternative,
+  request: ManagedEconomicSelectionRequest,
+  setLevelIncompatible: boolean,
+): ManagedEconomicCoreRejectionReason | null {
+  try {
+    validateAlternativeIdentity(alternative);
+  } catch (error) {
+    if (error instanceof ManagedEconomicValidationError) {
+      return "comparison-domain-incompatible";
+    }
+    throw error;
+  }
+
+  if (
+    alternative.identity.account.kind === "account-bound"
+    && request.evidenceRequirements.quota === "required-for-account-bound"
+  ) {
+    const quota = alternative.identity.account.quotaEvidence;
+    if (quota === undefined || quota === null) {
+      return "quota-evidence-missing";
+    }
+    if (quota.kind === "unknown") {
+      return "quota-evidence-missing";
+    }
+    if (!isEvidenceCurrent(quota.evidence, request.decisionAt)) {
+      return "quota-evidence-stale";
+    }
+  }
+
+  const price = alternative.priceEvidence;
+  if (price === undefined || price === null) {
+    if (request.evidenceRequirements.price === "required") {
+      return "price-evidence-missing";
+    }
+  } else if (!isEvidenceCurrent(price.identity.evidence, request.decisionAt)) {
+    return "price-evidence-stale";
+  } else if (price.kind === "unknown" && request.evidenceRequirements.price === "required") {
+    return "price-evidence-missing";
+  }
+
+  if (alternative.executionEnvelope.kind === "unbounded") {
+    return "execution-envelope-unbounded";
+  }
+  if (setLevelIncompatible) {
+    return "comparison-domain-incompatible";
+  }
+
+  try {
+    validateAlternativeRanks(alternative);
+    validateDomainCompatibility(alternative);
+  } catch (error) {
+    if (error instanceof ManagedEconomicValidationError) {
+      return "comparison-domain-incompatible";
+    }
+    throw error;
+  }
+
+  if (alternative.ceiling.kind === "finite") {
+    if (alternative.worstCaseReservation.kind !== "exact") {
+      return "execution-envelope-unbounded";
+    }
+    try {
+      if (
+        compareManagedEconomicAmounts(
+          alternative.worstCaseReservation.amount,
+          alternative.ceiling.amount,
+        ) > 0
+      ) {
+        return "ceiling-exceeded";
+      }
+    } catch (error) {
+      if (error instanceof ManagedEconomicValidationError) {
+        return "comparison-domain-incompatible";
+      }
+      throw error;
+    }
+  }
+  return null;
+}
+
+function validateAlternativeIdentity(alternative: ManagedEconomicExecutionAlternative): void {
+  const { route, account } = alternative.identity;
+  requireAllowed(account.kind, ["account-bound", "accountless"], "account identity kind");
+  requireAllowed(
+    alternative.accountSelectionReason,
+    ["existing-affinity", "least-pressure", "affinity-rebind", "accountless"],
+    "account selection reason",
+  );
+  requireAllowed(
+    alternative.executionEnvelope.kind,
+    ["bounded", "unbounded"],
+    "execution envelope kind",
+  );
+  requireAllowed(
+    alternative.worstCaseReservation.kind,
+    ["exact", "not-comparable"],
+    "reservation comparability kind",
+  );
+  requireAllowed(alternative.ceiling.kind, ["none", "finite"], "ceiling kind");
+  for (const [value, label] of [
+    [route.routeId, "route id"],
+    [route.providerId, "provider id"],
+    [route.modelId, "model id"],
+    [route.adapterCapabilityId, "adapter capability id"],
+    [route.adapterCapabilityVersion, "adapter capability version"],
+    [route.authBillingChannel, "auth billing channel"],
+    [route.executionMode, "execution mode"],
+    [route.serviceTier, "service tier"],
+    [route.rateCardId, "rate card id"],
+    [route.rateCardRevision, "rate card revision"],
+    [route.unit, "route unit"],
+    [route.contextClass, "context class"],
+    [route.cacheClass, "cache class"],
+  ] as const) {
+    requireIdentity(value, label);
+  }
+  validateScheme(route.scheme);
+  requireDigest(route.priceEvidenceDigest, "route price evidence digest");
+  requireDigest(route.auxiliaryScheduleDigest, "route auxiliary schedule digest");
+  requireDigest(route.envelopeDigest, "route envelope digest");
+  requireAllowed(route.fallbackPosture, ["disabled", "committed"], "fallback posture");
+  requireAllowed(route.overagePosture, ["disabled", "committed"], "overage posture");
+
+  if (account.kind === "account-bound") {
+    requireIdentity(account.capacityIdentity, "account capacity identity");
+    requireIdentity(account.accountRef, "account reference");
+    requireIdentity(account.credentialRevision, "credential revision");
+    requireAllowed(account.creditPosture, ["disabled", "committed"], "credit posture");
+    requireAllowed(account.overagePosture, ["disabled", "committed"], "account overage posture");
+    if (route.accountPolicyId === null) {
+      throw new ManagedEconomicValidationError("account-bound route requires an account policy");
+    }
+    requireIdentity(route.accountPolicyId, "account policy id");
+    if (account.quotaEvidence !== undefined && account.quotaEvidence !== null) {
+      validateQuotaEvidence(account.quotaEvidence, account.capacityIdentity);
+    }
+    if (alternative.accountSelectionReason === "accountless") {
+      throw new ManagedEconomicValidationError("account-bound alternative cannot be accountless");
+    }
+    if (alternative.observedAffinityRevision !== null) {
+      requireIdentity(alternative.observedAffinityRevision, "observed affinity revision");
+    }
+  } else {
+    if (route.accountPolicyId !== null) {
+      throw new ManagedEconomicValidationError("accountless route cannot reference an account policy");
+    }
+    if (
+      alternative.accountSelectionReason !== "accountless"
+      || alternative.observedAffinityRevision !== null
+    ) {
+      throw new ManagedEconomicValidationError("accountless alternative has account-bound evidence");
+    }
+  }
+
+  if (alternative.executionEnvelope.kind === "bounded") {
+    requireDigest(alternative.executionEnvelope.digest, "execution envelope digest");
+    if (alternative.executionEnvelope.digest !== route.envelopeDigest) {
+      throw new ManagedEconomicValidationError("execution envelope digest does not match route identity");
+    }
+  }
+  if (alternative.priceEvidence !== undefined && alternative.priceEvidence !== null) {
+    validatePriceEvidence(alternative.priceEvidence);
+  }
+}
+
+function validateQuotaEvidence(
+  quota: ManagedEconomicQuotaEvidence,
+  capacityIdentity: string,
+): void {
+  requireAllowed(quota.kind, ["known", "unlimited", "unknown"], "quota evidence kind");
+  requireIdentity(quota.capacityIdentity, "quota capacity identity");
+  if (quota.capacityIdentity !== capacityIdentity) {
+    throw new ManagedEconomicValidationError("quota evidence belongs to another capacity identity");
+  }
+  if (quota.kind === "unknown") {
+    if (quota.subscriptionClass !== "unknown") {
+      throw new ManagedEconomicValidationError("unknown quota requires unknown subscription class");
+    }
+    requireIdentity(quota.reason, "unknown quota reason");
+    if (quota.evidence !== null) {
+      requireEvidenceIdentity(quota.evidence);
+    }
+    return;
+  }
+
+  requireAllowed(
+    quota.subscriptionClass,
+    ["subscription", "included", "free", "metered", "unknown"],
+    "subscription class",
+  );
+  requireIdentity(quota.quotaClassId, "quota class id");
+  requireEvidenceIdentity(quota.evidence);
+  if (quota.kind === "known") {
+    if (quota.buckets.length === 0) {
+      throw new ManagedEconomicValidationError("known quota requires at least one bucket");
+    }
+    const bucketIds = new Set<string>();
+    for (const bucket of quota.buckets) {
+      requireIdentity(bucket.bucketId, "quota bucket id");
+      requireIdentity(bucket.dimension, "quota bucket dimension");
+      if (bucketIds.has(bucket.bucketId)) {
+        throw new ManagedEconomicValidationError("quota bucket ids must be unique");
+      }
+      bucketIds.add(bucket.bucketId);
+      if (bucket.remaining !== null) {
+        validateManagedEconomicAmount(bucket.remaining);
+      }
+      if (bucket.resetsAt !== null) {
+        requireTimestamp(bucket.resetsAt, "quota reset time");
+      }
+    }
+  }
+}
+
+function validatePriceEvidence(price: ManagedEconomicPriceEvidence): void {
+  requireAllowed(
+    price.kind,
+    ["subscription", "included", "free", "metered", "unknown", "estimated"],
+    "price evidence kind",
+  );
+  const identity = price.identity;
+  for (const [value, label] of [
+    [identity.providerId, "price provider id"],
+    [identity.modelId, "price model id"],
+    [identity.authBillingChannel, "price auth billing channel"],
+    [identity.executionMode, "price execution mode"],
+    [identity.serviceTier, "price service tier"],
+    [identity.rateCardId, "price rate card id"],
+    [identity.rateCardRevision, "price rate card revision"],
+    [identity.unit, "price unit"],
+    [identity.contextClass, "price context class"],
+    [identity.cacheClass, "price cache class"],
+  ] as const) {
+    requireIdentity(value, label);
+  }
+  validateScheme(identity.scheme);
+  requireDigest(identity.unitScheduleDigest, "price unit schedule digest");
+  requireDigest(identity.auxiliaryScheduleDigest, "price auxiliary schedule digest");
+  requireEvidenceIdentity(identity.evidence);
+  if (price.kind === "included") {
+    requireIdentity(price.allowanceId, "included allowance id");
+  } else if (price.kind === "unknown") {
+    requireIdentity(price.reason, "unknown price reason");
+  } else if (price.kind === "estimated") {
+    requireIdentity(price.estimationMethod, "price estimation method");
+  }
+}
+
+function validateAlternativeRanks(alternative: ManagedEconomicExecutionAlternative): void {
+  if (
+    !Number.isSafeInteger(alternative.comparisonDomain.rank)
+    || alternative.comparisonDomain.rank < 0
+    || !Number.isSafeInteger(alternative.priorityRank)
+    || alternative.priorityRank < 0
+  ) {
+    throw new ManagedEconomicValidationError("comparison and priority ranks must be non-negative integers");
+  }
+}
+
+function validateDomainCompatibility(alternative: ManagedEconomicExecutionAlternative): void {
+  const { basis } = alternative.comparisonDomain;
+  requireIdentity(alternative.comparisonDomain.id, "comparison domain id");
+  requireIdentity(basis.rateCardBasis, "comparison domain rate-card basis");
+  requireIdentity(basis.envelopeSemantics, "comparison domain envelope semantics");
+  if (
+    basis.unit !== alternative.identity.route.unit
+    || !sameScheme(basis.scheme, alternative.identity.route.scheme)
+  ) {
+    throw new ManagedEconomicValidationError("route and comparison domain use incompatible bases");
+  }
+
+  for (const limit of alternative.executionEnvelope.kind === "bounded"
+    ? alternative.executionEnvelope.limits
+    : []) {
+    validateManagedEconomicAmount(limit);
+  }
+
+  const reservation = alternative.worstCaseReservation;
+  if (reservation.kind === "exact") {
+    validateManagedEconomicAmount(reservation.amount);
+    if (
+      reservation.amount.unit !== basis.unit
+      || !sameScheme(reservation.amount.scheme, basis.scheme)
+    ) {
+      throw new ManagedEconomicValidationError("reservation and comparison domain are incompatible");
+    }
+  }
+  if (alternative.ceiling.kind === "finite") {
+    validateManagedEconomicAmount(alternative.ceiling.amount);
+  }
+
+  const priceKind = alternative.priceEvidence?.kind;
+  if (
+    alternative.priceEvidence !== undefined
+    && alternative.priceEvidence !== null
+    && (
+      alternative.priceEvidence.identity.providerId !== alternative.identity.route.providerId
+      || alternative.priceEvidence.identity.modelId !== alternative.identity.route.modelId
+      || alternative.priceEvidence.identity.authBillingChannel
+        !== alternative.identity.route.authBillingChannel
+      || alternative.priceEvidence.identity.executionMode !== alternative.identity.route.executionMode
+      || alternative.priceEvidence.identity.serviceTier !== alternative.identity.route.serviceTier
+      || alternative.priceEvidence.identity.rateCardId !== alternative.identity.route.rateCardId
+      || alternative.priceEvidence.identity.rateCardRevision
+        !== alternative.identity.route.rateCardRevision
+      || alternative.priceEvidence.identity.contextClass !== alternative.identity.route.contextClass
+      || alternative.priceEvidence.identity.cacheClass !== alternative.identity.route.cacheClass
+      || alternative.priceEvidence.identity.auxiliaryScheduleDigest
+        !== alternative.identity.route.auxiliaryScheduleDigest
+      || alternative.priceEvidence.identity.evidence.sourceDigest
+        !== alternative.identity.route.priceEvidenceDigest
+      || alternative.priceEvidence.identity.unit !== basis.unit
+      || !sameScheme(alternative.priceEvidence.identity.scheme, basis.scheme)
+    )
+  ) {
+    throw new ManagedEconomicValidationError("price evidence and comparison domain are incompatible");
+  }
+  if (
+    reservation.kind === "exact"
+    && priceKind !== "free"
+    && priceKind !== "metered"
+  ) {
+    throw new ManagedEconomicValidationError("non-comparable price evidence cannot carry an exact reservation");
+  }
+  if (priceKind === "free" && reservation.kind === "exact" && BigInt(reservation.amount.atoms) !== 0n) {
+    throw new ManagedEconomicValidationError("proven free evidence must reserve exact zero");
+  }
+}
+
+function selectionExplanation(
+  selected: ManagedEconomicExecutionAlternative,
+  remaining: readonly ManagedEconomicExecutionAlternative[],
+): ManagedEconomicSelectionExplanation {
+  if (remaining.length === 0) {
+    return { kind: "only-eligible-alternative", cheapestRouteClaim: false };
+  }
+  if (remaining.some((candidate) => candidate.comparisonDomain.rank !== selected.comparisonDomain.rank)) {
+    return { kind: "configured-domain-order", cheapestRouteClaim: false };
+  }
+  if (remaining.some((candidate) => candidate.priorityRank !== selected.priorityRank)) {
+    return { kind: "configured-priority-order", cheapestRouteClaim: false };
+  }
+  if (
+    selected.worstCaseReservation.kind === "exact"
+    && remaining.every((candidate) => candidate.worstCaseReservation.kind === "exact")
+    && remaining.some((candidate) =>
+      candidate.worstCaseReservation.kind === "exact"
+      && compareManagedEconomicAmounts(
+        selected.worstCaseReservation.kind === "exact"
+          ? selected.worstCaseReservation.amount
+          : candidate.worstCaseReservation.amount,
+        candidate.worstCaseReservation.amount,
+      ) !== 0)
+  ) {
+    return { kind: "lower-comparable-reservation", cheapestRouteClaim: true };
+  }
+  return { kind: "stable-identity-order", cheapestRouteClaim: false };
+}
+
+function orderingReason(
+  selected: ManagedEconomicExecutionAlternative,
+  alternative: ManagedEconomicExecutionAlternative,
+  amountComparisonEnabled: boolean,
+): ManagedEconomicOrderingReason {
+  if (selected.comparisonDomain.rank !== alternative.comparisonDomain.rank) {
+    return "higher-comparison-domain-rank";
+  }
+  if (selected.priorityRank !== alternative.priorityRank) {
+    return "higher-priority-rank";
+  }
+  if (
+    amountComparisonEnabled
+    && selected.worstCaseReservation.kind === "exact"
+    && alternative.worstCaseReservation.kind === "exact"
+    && compareManagedEconomicAmounts(
+      selected.worstCaseReservation.amount,
+      alternative.worstCaseReservation.amount,
+    ) !== 0
+  ) {
+    return "higher-worst-case-reservation";
+  }
+  if (selected.identity.route.routeId !== alternative.identity.route.routeId) {
+    return "stable-route-id-order";
+  }
+  return "stable-capacity-identity-order";
+}
+
+function compareIntegerRank(left: number, right: number): number {
+  if (!Number.isSafeInteger(left) || left < 0 || !Number.isSafeInteger(right) || right < 0) {
+    throw new ManagedEconomicValidationError("ordering ranks must be non-negative safe integers");
+  }
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function stableCapacityIdentity(alternative: ManagedEconomicExecutionAlternative): string {
+  return stableCapacityIdentityFromIdentity(alternative.identity);
+}
+
+function stableCapacityIdentityFromIdentity(identity: ManagedEconomicExecutionIdentity): string {
+  return identity.account.kind === "accountless"
+    ? "\uffffaccountless"
+    : identity.account.capacityIdentity;
+}
+
+function isEvidenceCurrent(evidence: ManagedEconomicEvidenceIdentity, decisionAt: string): boolean {
+  try {
+    requireEvidenceIdentity(evidence);
+    requireTimestamp(decisionAt, "decisionAt");
+  } catch (error) {
+    if (error instanceof ManagedEconomicValidationError) {
+      return false;
+    }
+    throw error;
+  }
+  const observedAt = Date.parse(evidence.observedAt);
+  const validUntil = Date.parse(evidence.validUntil);
+  const decisionTime = Date.parse(decisionAt);
+  return observedAt <= decisionTime && decisionTime < validUntil;
+}
+
+function findSetLevelIncompatibilities(
+  alternatives: readonly ManagedEconomicExecutionAlternative[],
+): ReadonlySet<ManagedEconomicExecutionAlternative> {
+  const byExecutionIdentity = new Map<string, ManagedEconomicExecutionAlternative[]>();
+  for (const alternative of alternatives) {
+    const key = [
+      alternative.identity.route.routeId,
+      stableCapacityIdentity(alternative),
+    ].join("\u0000");
+    const duplicates = byExecutionIdentity.get(key) ?? [];
+    duplicates.push(alternative);
+    byExecutionIdentity.set(key, duplicates);
+  }
+
+  const byRank = new Map<number, ManagedEconomicExecutionAlternative[]>();
+  for (const alternative of alternatives) {
+    const group = byRank.get(alternative.comparisonDomain.rank) ?? [];
+    group.push(alternative);
+    byRank.set(alternative.comparisonDomain.rank, group);
+  }
+
+  const incompatible = new Set<ManagedEconomicExecutionAlternative>();
+  for (const duplicates of byExecutionIdentity.values()) {
+    if (duplicates.length > 1) {
+      duplicates.forEach((alternative) => incompatible.add(alternative));
+    }
+  }
+  for (const rankGroup of byRank.values()) {
+    const domainFingerprints = new Set(rankGroup.map(domainFingerprint));
+    if (domainFingerprints.size > 1) {
+      rankGroup.forEach((alternative) => incompatible.add(alternative));
+      continue;
+    }
+
+  }
+  return incompatible;
+}
+
+function compareRejections(
+  left: ManagedEconomicCoreRejection,
+  right: ManagedEconomicCoreRejection,
+): number {
+  const route = compareStableStrings(
+    left.alternativeIdentity.route.routeId,
+    right.alternativeIdentity.route.routeId,
+  );
+  if (route !== 0) {
+    return route;
+  }
+  const account = compareStableStrings(
+    stableCapacityIdentityFromIdentity(left.alternativeIdentity),
+    stableCapacityIdentityFromIdentity(right.alternativeIdentity),
+  );
+  if (account !== 0) {
+    return account;
+  }
+  const reason = compareStableStrings(left.reason, right.reason);
+  return reason !== 0
+    ? reason
+    : compareStableStrings(
+      canonicalJson(left.alternativeIdentity),
+      canonicalJson(right.alternativeIdentity),
+    );
+}
+
+function compareStableStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "undefined";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  const record = value as Readonly<Record<string, unknown>>;
+  return `{${Object.keys(record)
+    .sort(compareStableStrings)
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+function domainFingerprint(alternative: ManagedEconomicExecutionAlternative): string {
+  const { comparisonDomain } = alternative;
+  return [
+    comparisonDomain.id,
+    comparisonDomain.basis.unit,
+    schemeFingerprint(comparisonDomain.basis.scheme),
+    comparisonDomain.basis.rateCardBasis,
+    comparisonDomain.basis.envelopeSemantics,
+  ].join("\u0000");
+}
+
+function schemeFingerprint(scheme: ManagedEconomicScheme): string {
+  switch (scheme.kind) {
+    case "currency":
+      return `currency:${scheme.currency}`;
+    case "credit":
+      return `credit:${scheme.creditSchemeId}`;
+    case "unit":
+      return "unit";
+  }
+}
+
+function requireEvidenceIdentity(evidence: ManagedEconomicEvidenceIdentity): void {
+  requireIdentity(evidence.sourceIdentity, "evidence source identity");
+  requireIdentity(evidence.sourceRevision, "evidence source revision");
+  requireDigest(evidence.sourceDigest, "evidence source digest");
+  requireTimestamp(evidence.observedAt, "evidence observedAt");
+  requireTimestamp(evidence.validUntil, "evidence validUntil");
+  if (Date.parse(evidence.observedAt) >= Date.parse(evidence.validUntil)) {
+    throw new ManagedEconomicValidationError("evidence observedAt must precede validUntil");
+  }
+  requireAllowed(evidence.confidence, ["high", "medium", "low"], "evidence confidence");
+  requireAllowed(
+    evidence.authority,
+    ["provider-reported", "configured", "calculated-estimate"],
+    "evidence authority",
+  );
+}
+
+function requireTimestamp(value: string, label: string): void {
+  const parsed = Date.parse(value);
+  if (
+    !UTC_TIMESTAMP.test(value)
+    || !Number.isFinite(parsed)
+    || new Date(parsed).toISOString() !== value
+  ) {
+    throw new ManagedEconomicValidationError(`${label} must be a canonical UTC timestamp`);
+  }
+}
+
+function requireIdentity(value: string, label: string): void {
+  if (value.trim().length === 0) {
+    throw new ManagedEconomicValidationError(`${label} must not be empty`);
+  }
+}
+
+function requireDigest(value: string, label: string): void {
+  if (!SHA_256_DIGEST.test(value)) {
+    throw new ManagedEconomicValidationError(`${label} must be a canonical SHA-256 digest`);
+  }
+}
+
+function requireAllowed<T extends string>(
+  value: string,
+  allowed: readonly T[],
+  label: string,
+): asserts value is T {
+  if (!(allowed as readonly string[]).includes(value)) {
+    throw new ManagedEconomicValidationError(`${label} is invalid`);
+  }
+}
+
+function validateScheme(scheme: ManagedEconomicScheme): void {
+  requireAllowed(scheme.kind, ["currency", "credit", "unit"], "economic scheme kind");
+  switch (scheme.kind) {
+    case "currency":
+      requireIdentity(scheme.currency, "currency");
+      return;
+    case "credit":
+      requireIdentity(scheme.creditSchemeId, "credit scheme");
+      return;
+    case "unit":
+      return;
+  }
+}
+
+function sameScheme(left: ManagedEconomicScheme, right: ManagedEconomicScheme): boolean {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+  switch (left.kind) {
+    case "currency":
+      return right.kind === "currency" && left.currency === right.currency;
+    case "credit":
+      return right.kind === "credit" && left.creditSchemeId === right.creditSchemeId;
+    case "unit":
+      return right.kind === "unit";
+  }
+}
+
+function powerOfTen(exponent: number): bigint {
+  return 10n ** BigInt(exponent);
+}

--- a/packages/core/src/engine/gateway/gateway-config.ts
+++ b/packages/core/src/engine/gateway/gateway-config.ts
@@ -6,6 +6,11 @@ import type { GatewayAuthConfig } from "./auth-config.js";
 import type { GatewayMcpConfig } from "./mcp-config.js";
 import { isDirectProviderId, type DirectProviderId } from "../../agents/provider-execution-profiles.js";
 import { ModelCapabilityRegistry } from "../../agents/model-capability-registry.js";
+import {
+  validateManagedEconomicAmount,
+  type ManagedEconomicAmount,
+  type ManagedEconomicEvidenceIdentity,
+} from "../../cost/managed-route-economics.js";
 
 /** Channel binding for a specific platform adapter */
 export interface GatewayChannelBinding {
@@ -64,6 +69,7 @@ export interface ModelGatewayVirtualModelConfig {
     readonly scope?: "session" | "turn";
     readonly allowRebind?: boolean;
   };
+  readonly economics?: ModelGatewayRouteEconomicsConfig;
 }
 
 export interface ModelGatewayAccountConfig {
@@ -72,6 +78,85 @@ export interface ModelGatewayAccountConfig {
   readonly credentialId: string;
   readonly maxConcurrency: number;
   readonly reservedAffinitySlots: number;
+  readonly economics?: ModelGatewayAccountEconomicsConfig;
+}
+
+export interface ModelGatewayAccountEconomicsConfig {
+  readonly capacityIdentity: string;
+  readonly subscriptionClass: "subscription" | "included" | "free" | "metered" | "unknown";
+  readonly quotaClassId: string;
+  readonly creditPosture: "disabled" | "committed";
+  readonly overagePosture: "disabled" | "committed";
+}
+
+export interface ModelGatewayUnitPriceConfig {
+  readonly usageUnit: string;
+  readonly price: ManagedEconomicAmount;
+}
+
+export type ModelGatewayPriceEvidenceConfig =
+  | {
+      readonly kind: "subscription";
+      readonly rateCardId: string;
+      readonly rateCardRevision: string;
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "included";
+      readonly allowanceId: string;
+      readonly rateCardId: string;
+      readonly rateCardRevision: string;
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "free";
+      readonly rateCardId: string;
+      readonly rateCardRevision: string;
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "metered";
+      readonly rateCardId: string;
+      readonly rateCardRevision: string;
+      readonly unitPrices: readonly ModelGatewayUnitPriceConfig[];
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "unknown";
+      readonly reason: string;
+      readonly rateCardId: string;
+      readonly rateCardRevision: string;
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    }
+  | {
+      readonly kind: "estimated";
+      readonly estimationMethod: string;
+      readonly rateCardId: string;
+      readonly rateCardRevision: string;
+      readonly unitPrices: readonly ModelGatewayUnitPriceConfig[];
+      readonly evidence: ManagedEconomicEvidenceIdentity;
+    };
+
+export interface ModelGatewayRouteEconomicsConfig {
+  readonly adapterCapabilityId: string;
+  readonly adapterCapabilityVersion: string;
+  readonly authBillingChannel: string;
+  readonly executionMode: string;
+  readonly serviceTier: string;
+  readonly rateCardBasis: string;
+  readonly envelopeSemantics: string;
+  readonly fallbackPosture: "disabled" | "committed";
+  readonly overagePosture: "disabled" | "committed";
+  readonly contextClass: string;
+  readonly cacheClass: string;
+  readonly priceEvidence: ModelGatewayPriceEvidenceConfig;
+  readonly auxiliaryCharges: readonly {
+    readonly id: string;
+    readonly amount: ManagedEconomicAmount;
+  }[];
+  readonly executionEnvelope: {
+    readonly limits: readonly ManagedEconomicAmount[];
+  };
 }
 
 export interface ModelGatewayConfig {
@@ -194,6 +279,7 @@ function validateModelGateway(value: ModelGatewayConfig, gatewayPort: number, er
   const accountIds = new Set<string>();
   const accountProviders = new Map<string, DirectProviderId>();
   const bindings = new Set<string>();
+  const capacityIdentities = new Set<string>();
   for (const [index, account] of (value.accounts ?? []).entries()) {
     const path = `modelGateway.accounts[${index}]`;
     if (!ID.test(account.id ?? "") || accountIds.has(account.id)) errors.push({ field: `${path}.id`, message: "must be a unique canonical id" });
@@ -207,6 +293,13 @@ function validateModelGateway(value: ModelGatewayConfig, gatewayPort: number, er
     if (bindings.has(binding)) errors.push({ field: `${path}.credentialId`, message: "provider credential binding must be unique" }); else bindings.add(binding);
     if (!Number.isSafeInteger(account.maxConcurrency) || account.maxConcurrency < 1 || account.maxConcurrency > 1024) errors.push({ field: `${path}.maxConcurrency`, message: "must be an integer between 1 and 1024" });
     if (!Number.isSafeInteger(account.reservedAffinitySlots) || account.reservedAffinitySlots < 0 || account.reservedAffinitySlots > account.maxConcurrency) errors.push({ field: `${path}.reservedAffinitySlots`, message: "must be between 0 and maxConcurrency" });
+    if (account.economics !== undefined) {
+      validateAccountEconomics(account.economics, path, errors);
+      if (capacityIdentities.has(account.economics.capacityIdentity)) {
+        errors.push({ field: `${path}.economics.capacityIdentity`, message: "must be unique" });
+      }
+      capacityIdentities.add(account.economics.capacityIdentity);
+    }
   }
   if (!Array.isArray(value.accounts) || value.accounts.length === 0) errors.push({ field: "modelGateway.accounts", message: "must be non-empty" });
   const surfaces = value.surfaces;
@@ -288,9 +381,159 @@ function validateModelGateway(value: ModelGatewayConfig, gatewayPort: number, er
     else if (affinity.continuity === "none" && (affinity.scope !== undefined || affinity.allowRebind !== undefined)) errors.push({ field: `${path}.affinity`, message: "scope and allowRebind require continuity" });
     else if (affinity.continuity !== "none" && !["session", "turn"].includes(affinity.scope ?? "")) errors.push({ field: `${path}.affinity.scope`, message: "must be session or turn" });
     if (affinity?.allowRebind === true && affinity.continuity !== "prefer" && affinity.continuity !== "require") errors.push({ field: `${path}.affinity.allowRebind`, message: "is not meaningful" });
+    if (model.economics !== undefined) validateRouteEconomics(model.economics, path, errors);
   }
   if (!Array.isArray(value.virtualModels) || value.virtualModels.length === 0) errors.push({ field: "modelGateway.virtualModels", message: "must be non-empty" });
   for (const [index, principal] of (value.principals ?? []).entries()) for (const id of principal.virtualModelIds ?? []) if (!models.has(id)) errors.push({ field: `modelGateway.principals[${index}].virtualModelIds`, message: `references unknown virtual model '${id}'` });
+}
+
+const ECONOMIC_CLASS = new Set(["subscription", "included", "free", "metered", "unknown"]);
+const POSTURE = new Set(["disabled", "committed"]);
+const SHA_256 = /^sha256:[0-9a-f]{64}$/;
+const UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function validateAccountEconomics(
+  economics: ModelGatewayAccountEconomicsConfig,
+  path: string,
+  errors: GatewayValidationError[],
+): void {
+  if (!ID.test(economics.capacityIdentity ?? "")) errors.push({ field: `${path}.economics.capacityIdentity`, message: "must be a canonical id" });
+  if (!ECONOMIC_CLASS.has(economics.subscriptionClass)) errors.push({ field: `${path}.economics.subscriptionClass`, message: "is invalid" });
+  if (!ID.test(economics.quotaClassId ?? "")) errors.push({ field: `${path}.economics.quotaClassId`, message: "must be a canonical id" });
+  if (!POSTURE.has(economics.creditPosture)) errors.push({ field: `${path}.economics.creditPosture`, message: "is invalid" });
+  if (!POSTURE.has(economics.overagePosture)) errors.push({ field: `${path}.economics.overagePosture`, message: "is invalid" });
+}
+
+function validateRouteEconomics(
+  economics: ModelGatewayRouteEconomicsConfig,
+  path: string,
+  errors: GatewayValidationError[],
+): void {
+  const economicPath = `${path}.economics`;
+  for (const [field, value] of Object.entries({
+    adapterCapabilityId: economics.adapterCapabilityId,
+    adapterCapabilityVersion: economics.adapterCapabilityVersion,
+    authBillingChannel: economics.authBillingChannel,
+    executionMode: economics.executionMode,
+    serviceTier: economics.serviceTier,
+    rateCardBasis: economics.rateCardBasis,
+    envelopeSemantics: economics.envelopeSemantics,
+    contextClass: economics.contextClass,
+    cacheClass: economics.cacheClass,
+  })) {
+    if (!ID.test(value ?? "")) errors.push({ field: `${economicPath}.${field}`, message: "must be a canonical id" });
+  }
+  if (!POSTURE.has(economics.fallbackPosture)) errors.push({ field: `${economicPath}.fallbackPosture`, message: "is invalid" });
+  if (!POSTURE.has(economics.overagePosture)) errors.push({ field: `${economicPath}.overagePosture`, message: "is invalid" });
+  validatePriceEvidence(economics.priceEvidence, economicPath, errors);
+  validateUniqueAmounts(
+    economics.executionEnvelope?.limits,
+    `${economicPath}.executionEnvelope.limits`,
+    errors,
+    true,
+  );
+  const envelopeUsageUnits = new Set<string>();
+  for (const [index, limit] of (economics.executionEnvelope?.limits ?? []).entries()) {
+    if (limit.scheme?.kind !== "unit") {
+      errors.push({ field: `${economicPath}.executionEnvelope.limits[${index}].scheme`, message: "must use the unit scheme" });
+    } else {
+      envelopeUsageUnits.add(limit.unit);
+    }
+  }
+  if (economics.priceEvidence?.kind === "metered" || economics.priceEvidence?.kind === "estimated") {
+    for (const [index, unitPrice] of economics.priceEvidence.unitPrices.entries()) {
+      if (unitPrice.usageUnit !== unitPrice.price.unit) {
+        errors.push({ field: `${economicPath}.priceEvidence.unitPrices[${index}].usageUnit`, message: "must equal price.unit" });
+      }
+      if (!envelopeUsageUnits.has(unitPrice.usageUnit)) {
+        errors.push({ field: `${economicPath}.priceEvidence.unitPrices[${index}].usageUnit`, message: "must be covered by a unit-scheme execution envelope limit" });
+      }
+    }
+  }
+  const auxiliaryIds = new Set<string>();
+  for (const [index, charge] of (economics.auxiliaryCharges ?? []).entries()) {
+    if (!ID.test(charge.id ?? "") || auxiliaryIds.has(charge.id)) {
+      errors.push({ field: `${economicPath}.auxiliaryCharges[${index}].id`, message: "must be a unique canonical id" });
+    }
+    auxiliaryIds.add(charge.id);
+    validateAmount(charge.amount, `${economicPath}.auxiliaryCharges[${index}].amount`, errors);
+  }
+}
+
+function validatePriceEvidence(
+  price: ModelGatewayPriceEvidenceConfig,
+  path: string,
+  errors: GatewayValidationError[],
+): void {
+  const pricePath = `${path}.priceEvidence`;
+  if (!price || !["subscription", "included", "free", "metered", "unknown", "estimated"].includes(price.kind)) {
+    errors.push({ field: `${pricePath}.kind`, message: "is invalid" });
+    return;
+  }
+  if (!ID.test(price.rateCardId ?? "")) errors.push({ field: `${pricePath}.rateCardId`, message: "must be a canonical id" });
+  if (!ID.test(price.rateCardRevision ?? "")) errors.push({ field: `${pricePath}.rateCardRevision`, message: "must be a canonical id" });
+  validateEconomicEvidence(price.evidence, `${pricePath}.evidence`, errors);
+  if (price.kind === "included" && !ID.test(price.allowanceId ?? "")) errors.push({ field: `${pricePath}.allowanceId`, message: "must be a canonical id" });
+  if (price.kind === "unknown" && (typeof price.reason !== "string" || price.reason.trim().length === 0)) errors.push({ field: `${pricePath}.reason`, message: "must be non-empty" });
+  if (price.kind === "estimated" && !ID.test(price.estimationMethod ?? "")) errors.push({ field: `${pricePath}.estimationMethod`, message: "must be a canonical id" });
+  if (price.kind === "metered" || price.kind === "estimated") {
+    const usageUnits = new Set<string>();
+    if (!Array.isArray(price.unitPrices) || price.unitPrices.length === 0) errors.push({ field: `${pricePath}.unitPrices`, message: "must be non-empty" });
+    for (const [index, unitPrice] of (price.unitPrices ?? []).entries()) {
+      if (!ID.test(unitPrice.usageUnit ?? "") || usageUnits.has(unitPrice.usageUnit)) errors.push({ field: `${pricePath}.unitPrices[${index}].usageUnit`, message: "must be a unique canonical id" });
+      usageUnits.add(unitPrice.usageUnit);
+      validateAmount(unitPrice.price, `${pricePath}.unitPrices[${index}].price`, errors);
+    }
+  }
+}
+
+function validateEconomicEvidence(
+  evidence: ManagedEconomicEvidenceIdentity,
+  path: string,
+  errors: GatewayValidationError[],
+): void {
+  if (!evidence || !ID.test(evidence.sourceIdentity ?? "")) errors.push({ field: `${path}.sourceIdentity`, message: "must be a canonical id" });
+  if (!evidence || !ID.test(evidence.sourceRevision ?? "")) errors.push({ field: `${path}.sourceRevision`, message: "must be a canonical id" });
+  if (!evidence || !SHA_256.test(evidence.sourceDigest ?? "")) errors.push({ field: `${path}.sourceDigest`, message: "must be a canonical SHA-256 digest" });
+  if (!evidence || !isCanonicalTimestamp(evidence.observedAt)) errors.push({ field: `${path}.observedAt`, message: "must be a canonical UTC timestamp" });
+  if (!evidence || !isCanonicalTimestamp(evidence.validUntil)) errors.push({ field: `${path}.validUntil`, message: "must be a canonical UTC timestamp" });
+  if (evidence && isCanonicalTimestamp(evidence.observedAt) && isCanonicalTimestamp(evidence.validUntil)
+    && Date.parse(evidence.observedAt) >= Date.parse(evidence.validUntil)) errors.push({ field: `${path}.validUntil`, message: "must be after observedAt" });
+  if (!evidence || !["high", "medium", "low"].includes(evidence.confidence)) errors.push({ field: `${path}.confidence`, message: "is invalid" });
+  if (!evidence || !["provider-reported", "configured", "calculated-estimate"].includes(evidence.authority)) errors.push({ field: `${path}.authority`, message: "is invalid" });
+}
+
+function validateUniqueAmounts(
+  amounts: readonly ManagedEconomicAmount[] | undefined,
+  path: string,
+  errors: GatewayValidationError[],
+  required: boolean,
+): void {
+  if (!Array.isArray(amounts) || (required && amounts.length === 0)) {
+    errors.push({ field: path, message: "must be non-empty" });
+    return;
+  }
+  const units = new Set<string>();
+  for (const [index, amount] of amounts.entries()) {
+    validateAmount(amount, `${path}[${index}]`, errors);
+    const key = `${amount.unit}\0${JSON.stringify(amount.scheme)}`;
+    if (units.has(key)) errors.push({ field: `${path}[${index}]`, message: "duplicates an economic unit and scheme" });
+    units.add(key);
+  }
+}
+
+function validateAmount(amount: ManagedEconomicAmount, path: string, errors: GatewayValidationError[]): void {
+  try {
+    validateManagedEconomicAmount(amount);
+  } catch (error) {
+    errors.push({ field: path, message: error instanceof Error ? error.message : "is invalid" });
+  }
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string" || !UTC.test(value)) return false;
+  const time = Date.parse(value);
+  return Number.isFinite(time) && new Date(time).toISOString() === value;
 }
 
 function bounded(value: number | undefined, min: number, max: number, field: string, errors: GatewayValidationError[], required = false): void {

--- a/packages/core/src/engine/gateway/gateway-loader.ts
+++ b/packages/core/src/engine/gateway/gateway-loader.ts
@@ -3,7 +3,16 @@
 
 import { parse } from "yaml";
 import { KilnError } from "../errors.js";
-import type { GatewayConfig, GatewayAppBinding, GatewayChannelBinding, GatewayValidationError, ModelGatewayConfig } from "./gateway-config.js";
+import type {
+  GatewayConfig,
+  GatewayAppBinding,
+  GatewayChannelBinding,
+  GatewayValidationError,
+  ModelGatewayConfig,
+  ModelGatewayAccountEconomicsConfig,
+  ModelGatewayPriceEvidenceConfig,
+  ModelGatewayRouteEconomicsConfig,
+} from "./gateway-config.js";
 import { validateGatewayConfig } from "./gateway-config.js";
 import type { ObservabilityConfig } from "./observability-config.js";
 import { validateObservabilityConfig } from "./observability-config.js";
@@ -12,6 +21,7 @@ import { validateGatewayAuthConfig } from "./auth-config.js";
 import type { GatewayMcpConfig } from "./mcp-config.js";
 import { validateGatewayMcpConfig } from "./mcp-config.js";
 import type { DirectProviderId } from "../../agents/provider-execution-profiles.js";
+import type { ManagedEconomicAmount, ManagedEconomicEvidenceIdentity, ManagedEconomicScheme } from "../../cost/managed-route-economics.js";
 
 /** Error class for gateway YAML loader failures, aggregating all validation errors */
 export class GatewayLoaderError extends KilnError {
@@ -154,19 +164,188 @@ function mapModelGateway(rawValue: unknown, errors: GatewayValidationError[]): M
   }) : [];
   const virtualModels = Array.isArray(rawValue.virtualModels) ? rawValue.virtualModels.map((entry, index) => {
     const raw = isRecord(entry) ? entry : {};
-    rejectUnknown(raw, ["id", "displayName", "contextTokens", "outputTokens", "baseInstructions", "providerId", "providerModelId", "accountIds", "capabilities", "affinity"], `modelGateway.virtualModels[${index}]`, errors);
+    rejectUnknown(raw, ["id", "displayName", "contextTokens", "outputTokens", "baseInstructions", "providerId", "providerModelId", "accountIds", "capabilities", "affinity", "economics"], `modelGateway.virtualModels[${index}]`, errors);
     const affinity = isRecord(raw.affinity) ? raw.affinity : {};
     rejectUnknown(affinity, ["continuity", "scope", "allowRebind"], `modelGateway.virtualModels[${index}].affinity`, errors);
     if (affinity.scope !== undefined && typeof affinity.scope !== "string") errors.push({ field: `modelGateway.virtualModels[${index}].affinity.scope`, message: "must be a string" });
     if (affinity.allowRebind !== undefined && typeof affinity.allowRebind !== "boolean") errors.push({ field: `modelGateway.virtualModels[${index}].affinity.allowRebind`, message: "must be a boolean" });
-    return { id: str(raw.id), ...(raw.displayName === undefined ? {} : { displayName: str(raw.displayName) }), ...(raw.contextTokens === undefined ? {} : { contextTokens: num(raw.contextTokens) }), ...(raw.outputTokens === undefined ? {} : { outputTokens: num(raw.outputTokens) }), ...(raw.baseInstructions === undefined ? {} : { baseInstructions: str(raw.baseInstructions) }), providerId: str(raw.providerId) as DirectProviderId, providerModelId: str(raw.providerModelId), accountIds: strings(raw.accountIds), capabilities: strings(raw.capabilities) as ModelGatewayConfig["virtualModels"][number]["capabilities"], affinity: { continuity: str(affinity.continuity) as "none", ...(typeof affinity.scope === "string" ? { scope: affinity.scope as "session" } : {}), ...(typeof affinity.allowRebind === "boolean" ? { allowRebind: affinity.allowRebind } : {}) } };
+    return { id: str(raw.id), ...(raw.displayName === undefined ? {} : { displayName: str(raw.displayName) }), ...(raw.contextTokens === undefined ? {} : { contextTokens: num(raw.contextTokens) }), ...(raw.outputTokens === undefined ? {} : { outputTokens: num(raw.outputTokens) }), ...(raw.baseInstructions === undefined ? {} : { baseInstructions: str(raw.baseInstructions) }), providerId: str(raw.providerId) as DirectProviderId, providerModelId: str(raw.providerModelId), accountIds: strings(raw.accountIds), capabilities: strings(raw.capabilities) as ModelGatewayConfig["virtualModels"][number]["capabilities"], affinity: { continuity: str(affinity.continuity) as "none", ...(typeof affinity.scope === "string" ? { scope: affinity.scope as "session" } : {}), ...(typeof affinity.allowRebind === "boolean" ? { allowRebind: affinity.allowRebind } : {}) }, ...(raw.economics === undefined ? {} : { economics: mapRouteEconomics(raw.economics, `modelGateway.virtualModels[${index}].economics`, errors) }) };
   }) : [];
   const accounts = Array.isArray(rawValue.accounts) ? rawValue.accounts.map((entry, index) => {
     const raw = isRecord(entry) ? entry : {};
-    rejectUnknown(raw, ["id", "providerId", "credentialId", "maxConcurrency", "reservedAffinitySlots"], `modelGateway.accounts[${index}]`, errors);
-    return { id: str(raw.id), providerId: str(raw.providerId) as DirectProviderId, credentialId: str(raw.credentialId), maxConcurrency: num(raw.maxConcurrency), reservedAffinitySlots: num(raw.reservedAffinitySlots) };
+    rejectUnknown(raw, ["id", "providerId", "credentialId", "maxConcurrency", "reservedAffinitySlots", "economics"], `modelGateway.accounts[${index}]`, errors);
+    return { id: str(raw.id), providerId: str(raw.providerId) as DirectProviderId, credentialId: str(raw.credentialId), maxConcurrency: num(raw.maxConcurrency), reservedAffinitySlots: num(raw.reservedAffinitySlots), ...(raw.economics === undefined ? {} : { economics: mapAccountEconomics(raw.economics, `modelGateway.accounts[${index}].economics`, errors) }) };
   }) : [];
   return { port: num(rawValue.port), accounts, replay: { ttlMs: num(replay.ttlMs), maxEntries: num(replay.maxEntries), hmacKeyEnv: str(replay.hmacKeyEnv) }, principals, virtualModels, surfaces: { ...(openAIResponses ? { openAIResponses } : {}), ...(anthropicMessages ? { anthropicMessages } : {}) } };
+}
+
+function mapAccountEconomics(
+  value: unknown,
+  path: string,
+  errors: GatewayValidationError[],
+): ModelGatewayAccountEconomicsConfig {
+  const raw = isRecord(value) ? value : {};
+  if (!isRecord(value)) errors.push({ field: path, message: "must be an object" });
+  rejectUnknown(raw, ["capacityIdentity", "subscriptionClass", "quotaClassId", "creditPosture", "overagePosture"], path, errors);
+  return {
+    capacityIdentity: str(raw.capacityIdentity),
+    subscriptionClass: str(raw.subscriptionClass) as ModelGatewayAccountEconomicsConfig["subscriptionClass"],
+    quotaClassId: str(raw.quotaClassId),
+    creditPosture: str(raw.creditPosture) as ModelGatewayAccountEconomicsConfig["creditPosture"],
+    overagePosture: str(raw.overagePosture) as ModelGatewayAccountEconomicsConfig["overagePosture"],
+  };
+}
+
+function mapRouteEconomics(
+  value: unknown,
+  path: string,
+  errors: GatewayValidationError[],
+): ModelGatewayRouteEconomicsConfig {
+  const raw = isRecord(value) ? value : {};
+  if (!isRecord(value)) errors.push({ field: path, message: "must be an object" });
+  rejectUnknown(raw, [
+    "adapterCapabilityId",
+    "adapterCapabilityVersion",
+    "authBillingChannel",
+    "executionMode",
+    "serviceTier",
+    "rateCardBasis",
+    "envelopeSemantics",
+    "fallbackPosture",
+    "overagePosture",
+    "contextClass",
+    "cacheClass",
+    "priceEvidence",
+    "auxiliaryCharges",
+    "executionEnvelope",
+  ], path, errors);
+  const envelope = isRecord(raw.executionEnvelope) ? raw.executionEnvelope : {};
+  if (!isRecord(raw.executionEnvelope)) errors.push({ field: `${path}.executionEnvelope`, message: "must be an object" });
+  rejectUnknown(envelope, ["limits"], `${path}.executionEnvelope`, errors);
+  const auxiliaryCharges = Array.isArray(raw.auxiliaryCharges)
+    ? raw.auxiliaryCharges.map((entry, index) => {
+        const chargePath = `${path}.auxiliaryCharges[${index}]`;
+        const charge = isRecord(entry) ? entry : {};
+        if (!isRecord(entry)) errors.push({ field: chargePath, message: "must be an object" });
+        rejectUnknown(charge, ["id", "amount"], chargePath, errors);
+        return { id: str(charge.id), amount: mapEconomicAmount(charge.amount, `${chargePath}.amount`, errors) };
+      })
+    : [];
+  if (!Array.isArray(raw.auxiliaryCharges)) errors.push({ field: `${path}.auxiliaryCharges`, message: "must be an array" });
+  return {
+    adapterCapabilityId: str(raw.adapterCapabilityId),
+    adapterCapabilityVersion: str(raw.adapterCapabilityVersion),
+    authBillingChannel: str(raw.authBillingChannel),
+    executionMode: str(raw.executionMode),
+    serviceTier: str(raw.serviceTier),
+    rateCardBasis: str(raw.rateCardBasis),
+    envelopeSemantics: str(raw.envelopeSemantics),
+    fallbackPosture: str(raw.fallbackPosture) as ModelGatewayRouteEconomicsConfig["fallbackPosture"],
+    overagePosture: str(raw.overagePosture) as ModelGatewayRouteEconomicsConfig["overagePosture"],
+    contextClass: str(raw.contextClass),
+    cacheClass: str(raw.cacheClass),
+    priceEvidence: mapPriceEvidence(raw.priceEvidence, `${path}.priceEvidence`, errors),
+    auxiliaryCharges,
+    executionEnvelope: {
+      limits: Array.isArray(envelope.limits)
+        ? envelope.limits.map((entry, index) => mapEconomicAmount(entry, `${path}.executionEnvelope.limits[${index}]`, errors))
+        : [],
+    },
+  };
+}
+
+function mapPriceEvidence(
+  value: unknown,
+  path: string,
+  errors: GatewayValidationError[],
+): ModelGatewayPriceEvidenceConfig {
+  const raw = isRecord(value) ? value : {};
+  if (!isRecord(value)) errors.push({ field: path, message: "must be an object" });
+  const kind = str(raw.kind);
+  const common = ["kind", "rateCardId", "rateCardRevision", "evidence"];
+  const allowed = kind === "included"
+    ? [...common, "allowanceId"]
+    : kind === "metered"
+      ? [...common, "unitPrices"]
+      : kind === "unknown"
+        ? [...common, "reason"]
+        : kind === "estimated"
+          ? [...common, "estimationMethod", "unitPrices"]
+          : common;
+  rejectUnknown(raw, allowed, path, errors);
+  const base = {
+    rateCardId: str(raw.rateCardId),
+    rateCardRevision: str(raw.rateCardRevision),
+    evidence: mapEconomicEvidence(raw.evidence, `${path}.evidence`, errors),
+  };
+  if (kind === "included") return { kind, ...base, allowanceId: str(raw.allowanceId) };
+  if (kind === "metered") return { kind, ...base, unitPrices: mapUnitPrices(raw.unitPrices, path, errors) };
+  if (kind === "unknown") return { kind, ...base, reason: str(raw.reason) };
+  if (kind === "estimated") return { kind, ...base, estimationMethod: str(raw.estimationMethod), unitPrices: mapUnitPrices(raw.unitPrices, path, errors) };
+  return { kind: kind as "subscription", ...base };
+}
+
+function mapUnitPrices(value: unknown, path: string, errors: GatewayValidationError[]) {
+  if (!Array.isArray(value)) {
+    errors.push({ field: `${path}.unitPrices`, message: "must be an array" });
+    return [];
+  }
+  return value.map((entry, index) => {
+    const unitPath = `${path}.unitPrices[${index}]`;
+    const raw = isRecord(entry) ? entry : {};
+    if (!isRecord(entry)) errors.push({ field: unitPath, message: "must be an object" });
+    rejectUnknown(raw, ["usageUnit", "price"], unitPath, errors);
+    return { usageUnit: str(raw.usageUnit), price: mapEconomicAmount(raw.price, `${unitPath}.price`, errors) };
+  });
+}
+
+function mapEconomicEvidence(
+  value: unknown,
+  path: string,
+  errors: GatewayValidationError[],
+): ManagedEconomicEvidenceIdentity {
+  const raw = isRecord(value) ? value : {};
+  if (!isRecord(value)) errors.push({ field: path, message: "must be an object" });
+  rejectUnknown(raw, ["sourceIdentity", "sourceRevision", "sourceDigest", "observedAt", "validUntil", "confidence", "authority"], path, errors);
+  return {
+    sourceIdentity: str(raw.sourceIdentity),
+    sourceRevision: str(raw.sourceRevision),
+    sourceDigest: str(raw.sourceDigest),
+    observedAt: str(raw.observedAt),
+    validUntil: str(raw.validUntil),
+    confidence: str(raw.confidence) as ManagedEconomicEvidenceIdentity["confidence"],
+    authority: str(raw.authority) as ManagedEconomicEvidenceIdentity["authority"],
+  };
+}
+
+function mapEconomicAmount(
+  value: unknown,
+  path: string,
+  errors: GatewayValidationError[],
+): ManagedEconomicAmount {
+  const raw = isRecord(value) ? value : {};
+  if (!isRecord(value)) errors.push({ field: path, message: "must be an object" });
+  rejectUnknown(raw, ["atoms", "scale", "unit", "scheme"], path, errors);
+  return {
+    atoms: str(raw.atoms),
+    scale: num(raw.scale),
+    unit: str(raw.unit),
+    scheme: mapEconomicScheme(raw.scheme, `${path}.scheme`, errors),
+  };
+}
+
+function mapEconomicScheme(
+  value: unknown,
+  path: string,
+  errors: GatewayValidationError[],
+): ManagedEconomicScheme {
+  const raw = isRecord(value) ? value : {};
+  if (!isRecord(value)) errors.push({ field: path, message: "must be an object" });
+  const kind = str(raw.kind);
+  rejectUnknown(raw, kind === "currency" ? ["kind", "currency"] : kind === "credit" ? ["kind", "creditSchemeId"] : ["kind"], path, errors);
+  if (kind === "currency") return { kind, currency: str(raw.currency) };
+  if (kind === "credit") return { kind, creditSchemeId: str(raw.creditSchemeId) };
+  return { kind: kind as "unit" };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -200,8 +200,12 @@ export type {
   GatewayValidationError,
   ModelGatewayCapabilityId,
   ModelGatewayAccountConfig,
+  ModelGatewayAccountEconomicsConfig,
   ModelGatewayConfig,
+  ModelGatewayPriceEvidenceConfig,
   ModelGatewayPrincipalConfig,
+  ModelGatewayRouteEconomicsConfig,
+  ModelGatewayUnitPriceConfig,
   ModelGatewayVirtualModelConfig,
 } from "./gateway/gateway-config.js";
 export { validateGatewayConfig } from "./gateway/gateway-config.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -219,8 +219,12 @@ export type {
   GatewayValidationError,
   ModelGatewayCapabilityId,
   ModelGatewayAccountConfig,
+  ModelGatewayAccountEconomicsConfig,
   ModelGatewayConfig,
+  ModelGatewayPriceEvidenceConfig,
   ModelGatewayPrincipalConfig,
+  ModelGatewayRouteEconomicsConfig,
+  ModelGatewayUnitPriceConfig,
   ModelGatewayVirtualModelConfig,
 } from "./engine/gateway/gateway-config.js";
 export { validateGatewayConfig } from "./engine/gateway/gateway-config.js";

--- a/packages/core/tests/cost/managed-route-economics-properties.test.ts
+++ b/packages/core/tests/cost/managed-route-economics-properties.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from "vitest";
+import {
+  orderManagedEconomicExecutionAlternatives,
+  selectManagedEconomicExecutionAlternative,
+  type ManagedEconomicExecutionAlternative,
+  type ManagedEconomicPriceEvidence,
+  type ManagedEconomicSelectionRequest,
+} from "../../src/cost/managed-route-economics.js";
+
+const evidence = {
+  sourceIdentity: "synthetic",
+  sourceRevision: "1",
+  sourceDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  observedAt: "2026-07-29T11:00:00.000Z",
+  validUntil: "2026-07-29T13:00:00.000Z",
+  confidence: "high" as const,
+  authority: "configured" as const,
+};
+
+function makeAlternative(
+  routeId: string,
+  options: {
+    readonly domainRank?: number;
+    readonly priorityRank?: number;
+    readonly reservationAtoms?: string;
+    readonly accountIdentity?: string;
+    readonly accountless?: boolean;
+    readonly priceKind?: ManagedEconomicPriceEvidence["kind"];
+    readonly comparable?: boolean;
+  } = {},
+): ManagedEconomicExecutionAlternative {
+  const priceKind = options.priceKind ?? "metered";
+  const exactAmount = {
+    atoms: options.reservationAtoms ?? "100",
+    scale: 2,
+    unit: "currency",
+    scheme: { kind: "currency" as const, currency: "USD" },
+  };
+  const priceIdentity = {
+    providerId: "provider",
+    modelId: "model",
+    authBillingChannel: "channel",
+    executionMode: "standard",
+    serviceTier: "default",
+    rateCardId: "rate",
+    rateCardRevision: "1",
+    unit: "currency",
+    scheme: exactAmount.scheme,
+    unitScheduleDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    contextClass: "standard",
+    cacheClass: "default",
+    auxiliaryScheduleDigest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    evidence,
+  };
+  const priceEvidence: ManagedEconomicPriceEvidence =
+    priceKind === "included"
+      ? { kind: priceKind, identity: priceIdentity, allowanceId: "allowance" }
+      : priceKind === "unknown"
+        ? { kind: priceKind, identity: priceIdentity, reason: "unavailable" }
+        : priceKind === "estimated"
+          ? { kind: priceKind, identity: priceIdentity, estimationMethod: "configured-rate-card" }
+          : { kind: priceKind, identity: priceIdentity };
+
+  return {
+    identity: {
+      route: {
+        routeId,
+        providerId: "provider",
+        modelId: "model",
+        adapterCapabilityId: "direct",
+        adapterCapabilityVersion: "1",
+        authBillingChannel: "channel",
+        executionMode: "standard",
+        serviceTier: "default",
+        accountPolicyId: options.accountless ? null : "policy",
+        fallbackPosture: "disabled",
+        overagePosture: "disabled",
+        rateCardId: "rate",
+        rateCardRevision: "1",
+        priceEvidenceDigest: evidence.sourceDigest,
+        unit: "currency",
+        scheme: exactAmount.scheme,
+        contextClass: "standard",
+        cacheClass: "default",
+        auxiliaryScheduleDigest: priceIdentity.auxiliaryScheduleDigest,
+        envelopeDigest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      },
+      account: options.accountless
+        ? { kind: "accountless" }
+        : {
+            kind: "account-bound",
+            capacityIdentity: options.accountIdentity ?? "account-a",
+            accountRef: "account-ref",
+            credentialRevision: "1",
+            creditPosture: "disabled",
+            overagePosture: "disabled",
+            quotaEvidence: {
+              kind: "known",
+              capacityIdentity: options.accountIdentity ?? "account-a",
+              subscriptionClass: priceKind === "estimated" ? "unknown" : priceKind,
+              quotaClassId: "quota",
+              buckets: [{
+                bucketId: "primary",
+                dimension: "currency",
+                remaining: exactAmount,
+                resetsAt: "2026-07-30T12:00:00.000Z",
+              }],
+              evidence,
+            },
+          },
+    },
+    comparisonDomain: {
+      id: `domain-${options.domainRank ?? 0}`,
+      rank: options.domainRank ?? 0,
+      basis: {
+        unit: "currency",
+        scheme: exactAmount.scheme,
+        rateCardBasis: "rate:1",
+        envelopeSemantics: "worst-case-v1",
+      },
+    },
+    priorityRank: options.priorityRank ?? 0,
+    priceEvidence,
+    executionEnvelope: {
+      kind: "bounded",
+      digest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      limits: [exactAmount],
+    },
+    worstCaseReservation: options.comparable === false
+      ? { kind: "not-comparable", reason: "economic-basis-unavailable" }
+      : { kind: "exact", amount: exactAmount },
+    ceiling: { kind: "none" },
+    accountSelectionReason: options.accountless ? "accountless" : "least-pressure",
+    observedAffinityRevision: options.accountless ? null : "1",
+  };
+}
+
+function makeSelectionRequest(
+  alternatives: readonly ManagedEconomicExecutionAlternative[],
+): ManagedEconomicSelectionRequest {
+  return {
+    decisionAt: "2026-07-29T12:00:00.000Z",
+    evidenceRequirements: {
+      quota: "required-for-account-bound",
+      price: "required",
+    },
+    alternatives,
+  };
+}
+
+function permutations<T>(values: readonly T[]): readonly (readonly T[])[] {
+  if (values.length <= 1) {
+    return [values];
+  }
+  return values.flatMap((value, index) =>
+    permutations(values.filter((_, candidateIndex) => candidateIndex !== index))
+      .map((remaining) => [value, ...remaining]),
+  );
+}
+
+describe("managed route economic ordering properties", () => {
+  it("explains a single eligible alternative without a cost claim", () => {
+    const decision = selectManagedEconomicExecutionAlternative(makeSelectionRequest([
+      makeAlternative("only"),
+    ]));
+    expect(decision).toMatchObject({
+      kind: "selected",
+      explanation: { kind: "only-eligible-alternative", cheapestRouteClaim: false },
+    });
+  });
+
+  it("selects lower exact reservation only within equal domain and priority", () => {
+    const selected = selectManagedEconomicExecutionAlternative(makeSelectionRequest([
+      makeAlternative("expensive", { reservationAtoms: "200" }),
+      makeAlternative("cheap", { reservationAtoms: "100" }),
+    ]));
+    expect(selected.kind === "selected" && selected.selected.identity.route.routeId).toBe("cheap");
+  });
+
+  it("configured priority outranks a cheaper amount", () => {
+    const selected = selectManagedEconomicExecutionAlternative(makeSelectionRequest([
+      makeAlternative("priority", { priorityRank: 0, reservationAtoms: "900" }),
+      makeAlternative("cheap", { priorityRank: 1, reservationAtoms: "1" }),
+    ]));
+    expect(selected.kind === "selected" && selected.selected.identity.route.routeId).toBe("priority");
+    expect(selected.kind === "selected" && selected.explanation).toEqual({
+      kind: "configured-priority-order",
+      cheapestRouteClaim: false,
+    });
+    expect(selected.kind === "selected" && selected.notSelected[0]?.reason)
+      .toBe("higher-priority-rank");
+  });
+
+  it("domain rank outranks amount without making a cheapest-route claim", () => {
+    const selected = selectManagedEconomicExecutionAlternative(makeSelectionRequest([
+      makeAlternative("preferred-domain", { domainRank: 0, reservationAtoms: "900" }),
+      makeAlternative("cheap", { domainRank: 1, reservationAtoms: "1" }),
+    ]));
+    expect(selected).toMatchObject({
+      kind: "selected",
+      selected: { identity: { route: { routeId: "preferred-domain" } } },
+      explanation: { kind: "configured-domain-order", cheapestRouteClaim: false },
+    });
+    expect(selected.kind === "selected" && selected.notSelected[0]?.reason)
+      .toBe("higher-comparison-domain-rank");
+  });
+
+  it("is input-order independent across every permutation", () => {
+    const values = [
+      makeAlternative("route-c", { reservationAtoms: "300" }),
+      makeAlternative("route-a", { reservationAtoms: "100" }),
+      makeAlternative("route-b", { reservationAtoms: "200" }),
+    ];
+    const selected = permutations(values).map((candidateOrder) => {
+      const decision = selectManagedEconomicExecutionAlternative(makeSelectionRequest(candidateOrder));
+      return decision.kind === "selected" ? decision.selected.identity.route.routeId : "denied";
+    });
+    expect(new Set(selected)).toEqual(new Set(["route-a"]));
+  });
+
+  it("is total for route/account ties", () => {
+    const values = [
+      makeAlternative("route-b", { accountIdentity: "account-b" }),
+      makeAlternative("route-a", { accountIdentity: "account-z" }),
+      makeAlternative("route-a", { accountIdentity: "account-a" }),
+      makeAlternative("route-a", { accountless: true }),
+    ];
+    expect(orderManagedEconomicExecutionAlternatives(values).map(stableIdentity)).toEqual([
+      "route-a/account-a",
+      "route-a/account-z",
+      "route-a/accountless",
+      "route-b/account-b",
+    ]);
+  });
+
+  it("is transitive", () => {
+    const values = [
+      makeAlternative("route-d", { domainRank: 1 }),
+      makeAlternative("route-c", { priorityRank: 1 }),
+      makeAlternative("route-b", { reservationAtoms: "200" }),
+      makeAlternative("route-a", { reservationAtoms: "100" }),
+    ];
+    const expected = orderManagedEconomicExecutionAlternatives(values).map(stableIdentity);
+    for (const candidateOrder of permutations(values)) {
+      expect(orderManagedEconomicExecutionAlternatives(candidateOrder).map(stableIdentity))
+        .toEqual(expected);
+    }
+  });
+
+  it("uses priority deterministically for mixed comparable and non-comparable evidence", () => {
+    const nonComparable = makeAlternative("subscription", {
+      priorityRank: 0,
+      priceKind: "subscription",
+      comparable: false,
+    });
+    const metered = makeAlternative("metered", {
+      priorityRank: 1,
+      priceKind: "metered",
+      reservationAtoms: "1",
+    });
+    for (const order of [[nonComparable, metered], [metered, nonComparable]]) {
+      const decision = selectManagedEconomicExecutionAlternative(makeSelectionRequest(order));
+      expect(decision.kind === "selected" && decision.selected.identity.route.routeId).toBe("subscription");
+      expect(decision.kind === "selected" && decision.explanation.cheapestRouteClaim).toBe(false);
+    }
+  });
+
+  it("uses stable identity rather than an implicit comparability rank for mixed evidence", () => {
+    const subscription = makeAlternative("a-subscription", {
+      priceKind: "subscription",
+      comparable: false,
+    });
+    const metered = makeAlternative("z-metered", { reservationAtoms: "1" });
+    const decision = selectManagedEconomicExecutionAlternative(
+      makeSelectionRequest([subscription, metered]),
+    );
+    expect(decision).toMatchObject({
+      kind: "selected",
+      selected: { identity: { route: { routeId: "a-subscription" } } },
+      notSelected: [{ reason: "stable-route-id-order" }],
+      explanation: { kind: "stable-identity-order", cheapestRouteClaim: false },
+    });
+  });
+
+  it("explains comparable amount, route, and capacity tie-breaks separately", () => {
+    const amountDecision = selectManagedEconomicExecutionAlternative(makeSelectionRequest([
+      makeAlternative("expensive", { reservationAtoms: "200" }),
+      makeAlternative("cheap", { reservationAtoms: "100" }),
+    ]));
+    expect(amountDecision).toMatchObject({
+      kind: "selected",
+      explanation: { kind: "lower-comparable-reservation", cheapestRouteClaim: true },
+      notSelected: [{ reason: "higher-worst-case-reservation" }],
+    });
+
+    const routeDecision = selectManagedEconomicExecutionAlternative(makeSelectionRequest([
+      makeAlternative("route-b"),
+      makeAlternative("route-a"),
+    ]));
+    expect(routeDecision).toMatchObject({
+      kind: "selected",
+      explanation: { kind: "stable-identity-order", cheapestRouteClaim: false },
+      notSelected: [{ reason: "stable-route-id-order" }],
+    });
+
+    const capacityDecision = selectManagedEconomicExecutionAlternative(makeSelectionRequest([
+      makeAlternative("route", { accountIdentity: "capacity-b" }),
+      makeAlternative("route", { accountIdentity: "capacity-a" }),
+    ]));
+    expect(capacityDecision).toMatchObject({
+      kind: "selected",
+      notSelected: [{ reason: "stable-capacity-identity-order" }],
+    });
+  });
+
+  it("canonicalizes rejection order independently of input order", () => {
+    const missingPriceA = {
+      ...makeAlternative("route-a"),
+      priceEvidence: null,
+    };
+    const missingPriceB = {
+      ...makeAlternative("route-b"),
+      priceEvidence: null,
+    };
+    const decisions = [
+      [missingPriceB, missingPriceA],
+      [missingPriceA, missingPriceB],
+    ].map((alternatives) =>
+      selectManagedEconomicExecutionAlternative(makeSelectionRequest(alternatives)));
+    expect(decisions[0]).toEqual(decisions[1]);
+  });
+
+  it("fails closed deterministically on duplicate route and capacity identities", () => {
+    const first = makeAlternative("duplicate", {
+      accountIdentity: "same-capacity",
+      reservationAtoms: "100",
+    });
+    const second = makeAlternative("duplicate", {
+      accountIdentity: "same-capacity",
+      reservationAtoms: "200",
+    });
+    const decisions = [
+      [first, second],
+      [second, first],
+    ].map((alternatives) =>
+      selectManagedEconomicExecutionAlternative(makeSelectionRequest(alternatives)));
+    expect(decisions[0]).toEqual(decisions[1]);
+    expect(decisions[0]).toMatchObject({
+      kind: "denied",
+      rejected: [
+        { reason: "comparison-domain-incompatible" },
+        { reason: "comparison-domain-incompatible" },
+      ],
+    });
+  });
+});
+
+function stableIdentity(alternative: ManagedEconomicExecutionAlternative): string {
+  const account = alternative.identity.account.kind === "accountless"
+    ? "accountless"
+    : alternative.identity.account.capacityIdentity;
+  return `${alternative.identity.route.routeId}/${account}`;
+}

--- a/packages/core/tests/cost/managed-route-economics.test.ts
+++ b/packages/core/tests/cost/managed-route-economics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   compareManagedEconomicAmounts,
+  deriveManagedEconomicMinimumReservation,
   narrowManagedEconomicExecutionAlternatives,
   selectManagedEconomicExecutionAlternative,
   validateManagedEconomicAmount,
@@ -705,5 +706,109 @@ describe("managed route economics", () => {
       expect(settlement).not.toHaveProperty("charge");
       expect(settlement).not.toHaveProperty("estimate");
     }
+  });
+});
+
+describe("minimum comparable reservation derivation", () => {
+  const usd = { kind: "currency" as const, currency: "USD" };
+  const usage = (atoms: string, scale = 0, unit = "input-token") => ({
+    atoms,
+    scale,
+    unit,
+    scheme: { kind: "unit" as const },
+  });
+  const rate = (atoms: string, scale = 6, usageUnit = "input-token") => ({
+    usageUnit,
+    price: { atoms, scale, unit: usageUnit, scheme: usd },
+  });
+
+  it("derives an exact minimum from unit rates, usage bounds, and fixed charges", () => {
+    expect(deriveManagedEconomicMinimumReservation({
+      unitRates: [rate("125")],
+      usageLimits: [usage("200000")],
+      auxiliaryCharges: [{
+        id: "tool-call",
+        amount: { atoms: "150", scale: 2, unit: "request", scheme: usd },
+      }],
+      outputUnit: "request",
+      targetScheme: usd,
+    })).toEqual({
+      atoms: "265",
+      scale: 1,
+      unit: "request",
+      scheme: usd,
+    });
+  });
+
+  it("normalizes scales exactly without binary floating point", () => {
+    expect(deriveManagedEconomicMinimumReservation({
+      unitRates: [rate("1", 2)],
+      usageLimits: [usage("25", 1)],
+      auxiliaryCharges: [],
+      outputUnit: "request",
+      targetScheme: usd,
+    })).toMatchObject({ atoms: "25", scale: 3 });
+  });
+
+  it("allows additional bounded usage dimensions without a separate rate", () => {
+    expect(deriveManagedEconomicMinimumReservation({
+      unitRates: [rate("125")],
+      usageLimits: [usage("200000"), usage("1", 0, "request")],
+      auxiliaryCharges: [],
+      outputUnit: "request",
+      targetScheme: usd,
+    })).toMatchObject({ atoms: "25", scale: 0 });
+  });
+
+  it.each([
+    {
+      name: "duplicate rate",
+      input: { unitRates: [rate("1"), rate("2")], usageLimits: [usage("1")] },
+    },
+    {
+      name: "duplicate limit",
+      input: { unitRates: [rate("1")], usageLimits: [usage("1"), usage("2")] },
+    },
+    {
+      name: "missing limit",
+      input: { unitRates: [rate("1")], usageLimits: [] },
+    },
+    {
+      name: "wrong limit scheme",
+      input: {
+        unitRates: [rate("1")],
+        usageLimits: [{ atoms: "1", scale: 0, unit: "input-token", scheme: usd }],
+      },
+    },
+    {
+      name: "wrong rate unit",
+      input: {
+        unitRates: [{ usageUnit: "input-token", price: { atoms: "1", scale: 0, unit: "output-token", scheme: usd } }],
+        usageLimits: [usage("1")],
+      },
+    },
+    {
+      name: "wrong auxiliary unit",
+      input: {
+        unitRates: [rate("1")],
+        usageLimits: [usage("1")],
+        auxiliaryCharges: [{ id: "tool", amount: { atoms: "1", scale: 0, unit: "tool", scheme: usd } }],
+      },
+    },
+    {
+      name: "noncanonical atoms",
+      input: { unitRates: [rate("01")], usageLimits: [usage("1")] },
+    },
+    {
+      name: "unsupported resulting scale",
+      input: { unitRates: [rate("1", 18)], usageLimits: [usage("1", 1)] },
+    },
+  ])("rejects $name", ({ input }) => {
+    expect(() => deriveManagedEconomicMinimumReservation({
+      auxiliaryCharges: [],
+      outputUnit: "request",
+      targetScheme: usd,
+      ...input,
+    })).toThrow();
   });
 });

--- a/packages/core/tests/cost/managed-route-economics.test.ts
+++ b/packages/core/tests/cost/managed-route-economics.test.ts
@@ -1,0 +1,709 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareManagedEconomicAmounts,
+  narrowManagedEconomicExecutionAlternatives,
+  selectManagedEconomicExecutionAlternative,
+  validateManagedEconomicAmount,
+  type ManagedEconomicEvidenceIdentity,
+  type ManagedEconomicExecutionAlternative,
+  type ManagedEconomicPriceEvidence,
+  type ManagedEconomicQuotaEvidence,
+  type ManagedEconomicReservation,
+  type ManagedEconomicSelectionRequest,
+  type ManagedEconomicSettlement,
+} from "../../src/cost/managed-route-economics.js";
+
+const CURRENT_AT = "2026-07-29T12:00:00.000Z";
+
+const currentEvidence: ManagedEconomicEvidenceIdentity = {
+  sourceIdentity: "synthetic-catalog",
+  sourceRevision: "revision-7",
+  sourceDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  observedAt: "2026-07-29T11:00:00.000Z",
+  validUntil: "2026-07-29T13:00:00.000Z",
+  confidence: "high",
+  authority: "configured",
+};
+
+function amount(atoms: string, currency = "USD") {
+  return {
+    atoms,
+    scale: 2,
+    unit: "currency",
+    scheme: { kind: "currency" as const, currency },
+  };
+}
+
+function price(
+  kind: ManagedEconomicPriceEvidence["kind"],
+  evidence: ManagedEconomicEvidenceIdentity = currentEvidence,
+): ManagedEconomicPriceEvidence {
+  const identity = {
+    providerId: "provider",
+    modelId: "model",
+    authBillingChannel: "oauth-subscription",
+    executionMode: "standard",
+    serviceTier: "default",
+    rateCardId: "rate-card",
+    rateCardRevision: "7",
+    unit: "currency",
+    scheme: { kind: "currency" as const, currency: "USD" },
+    unitScheduleDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    contextClass: "standard",
+    cacheClass: "default",
+    auxiliaryScheduleDigest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    evidence,
+  };
+
+  switch (kind) {
+    case "subscription":
+      return { kind, identity };
+    case "included":
+      return { kind, identity, allowanceId: "included-window" };
+    case "free":
+      return { kind, identity };
+    case "metered":
+      return { kind, identity };
+    case "unknown":
+      return { kind, identity, reason: "provider-price-unavailable" };
+    case "estimated":
+      return { kind, identity, estimationMethod: "configured-rate-card" };
+  }
+}
+
+function alternative(
+  routeId: string,
+  options: {
+    account?: string;
+    domainId?: string;
+    domainRank?: number;
+    priorityRank?: number;
+    reservation?: ReturnType<typeof amount> | null;
+    price?: ManagedEconomicPriceEvidence | null;
+    quota?: ManagedEconomicEvidenceIdentity | null;
+    quotaEvidence?: ManagedEconomicQuotaEvidence | null;
+    bounded?: boolean;
+    ceiling?: ReturnType<typeof amount> | null;
+  } = {},
+): ManagedEconomicExecutionAlternative {
+  const account = options.account ?? "account-a";
+  return {
+    identity: {
+      route: {
+        routeId,
+        providerId: "provider",
+        modelId: "model",
+        adapterCapabilityId: "direct-provider",
+        adapterCapabilityVersion: "1",
+        authBillingChannel: "oauth-subscription",
+        executionMode: "standard",
+        serviceTier: "default",
+        accountPolicyId: account === "accountless" ? null : "account-policy",
+        fallbackPosture: "disabled",
+        overagePosture: "disabled",
+        rateCardId: "rate-card",
+        rateCardRevision: "7",
+        priceEvidenceDigest: currentEvidence.sourceDigest,
+        unit: "currency",
+        scheme: { kind: "currency", currency: "USD" },
+        contextClass: "standard",
+        cacheClass: "default",
+        auxiliaryScheduleDigest:
+          "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        envelopeDigest:
+          "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      },
+      account:
+        account === "accountless"
+          ? { kind: "accountless" }
+          : {
+              kind: "account-bound",
+              capacityIdentity: account,
+              accountRef: `ref-${account}`,
+              credentialRevision: "credential-3",
+              creditPosture: "disabled",
+              overagePosture: "disabled",
+              quotaEvidence: options.quotaEvidence !== undefined
+                ? options.quotaEvidence
+                : options.quota === null
+                  ? null
+                  : {
+                    kind: "known",
+                    capacityIdentity: account,
+                    subscriptionClass: "metered",
+                    quotaClassId: "quota-class",
+                    buckets: [{
+                      bucketId: "primary",
+                      dimension: "currency",
+                      remaining: amount("10000"),
+                      resetsAt: "2026-07-30T12:00:00.000Z",
+                    }],
+                    evidence: options.quota ?? currentEvidence,
+                  },
+            },
+    },
+    comparisonDomain: {
+      id: options.domainId ?? "usd-standard",
+      rank: options.domainRank ?? 0,
+      basis: {
+        unit: "currency",
+        scheme: { kind: "currency", currency: "USD" },
+        rateCardBasis: "rate-card:7",
+        envelopeSemantics: "worst-case-v1",
+      },
+    },
+    priorityRank: options.priorityRank ?? 0,
+    priceEvidence: options.price === undefined ? price("metered") : options.price,
+    executionEnvelope:
+      options.bounded === false
+        ? { kind: "unbounded", missingDimensions: ["output-tokens"] }
+        : {
+            kind: "bounded",
+            digest:
+              "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            limits: [amount("10000")],
+          },
+    worstCaseReservation:
+      options.reservation === null
+        ? { kind: "not-comparable", reason: "economic-basis-unavailable" }
+        : { kind: "exact", amount: options.reservation ?? amount("100") },
+    ceiling:
+      options.ceiling === null || options.ceiling === undefined
+        ? { kind: "none" }
+        : { kind: "finite", amount: options.ceiling },
+    accountSelectionReason: account === "accountless" ? "accountless" : "least-pressure",
+    observedAffinityRevision: account === "accountless" ? null : "affinity-4",
+  };
+}
+
+function request(
+  alternatives: readonly ManagedEconomicExecutionAlternative[],
+  overrides: Partial<ManagedEconomicSelectionRequest> = {},
+): ManagedEconomicSelectionRequest {
+  return {
+    decisionAt: CURRENT_AT,
+    evidenceRequirements: {
+      quota: "required-for-account-bound",
+      price: "required",
+    },
+    alternatives,
+    ...overrides,
+  };
+}
+
+describe("managed route economics", () => {
+  it.each([
+    ["subscription", false, "selected"],
+    ["included", false, "selected"],
+    ["free", true, "selected"],
+    ["metered", true, "selected"],
+    ["unknown", false, "denied"],
+    ["estimated", false, "selected"],
+  ] as const)("keeps %s price evidence semantically distinct", (kind, comparable, expected) => {
+    const candidate = alternative(`route-${kind}`, {
+      account: "accountless",
+      price: price(kind),
+      reservation: comparable ? amount("0") : null,
+    });
+    const decision = selectManagedEconomicExecutionAlternative(request([candidate]));
+
+    expect(decision.kind).toBe(expected);
+    if (decision.kind === "selected") {
+      expect(decision.selected.priceEvidence?.kind).toBe(kind);
+      expect(decision.selected.worstCaseReservation.kind === "exact").toBe(comparable);
+    }
+  });
+
+  it("never represents subscription, included, or unknown absence as numeric zero", () => {
+    for (const kind of ["subscription", "included", "unknown"] as const) {
+      const evidence = price(kind);
+      expect("amount" in evidence).toBe(false);
+      expect(alternative(`route-${kind}`, { price: evidence, reservation: null }).worstCaseReservation)
+        .toEqual({ kind: "not-comparable", reason: "economic-basis-unavailable" });
+    }
+  });
+
+  it.each([
+    ["", 0, "currency"],
+    ["00", 0, "currency"],
+    ["01", 0, "currency"],
+    ["-1", 0, "currency"],
+    ["1.0", 0, "currency"],
+    ["1", -1, "currency"],
+    ["1", 1.5, "currency"],
+    ["1", 19, "currency"],
+    ["1", 0, ""],
+  ])("rejects invalid canonical decimal atoms=%j scale=%j unit=%j", (atoms, scale, unit) => {
+    expect(() =>
+      validateManagedEconomicAmount({
+        atoms,
+        scale,
+        unit,
+        scheme: { kind: "currency", currency: "USD" },
+      }),
+    ).toThrow();
+  });
+
+  it("compares decimals exactly across scales with bigint arithmetic", () => {
+    expect(compareManagedEconomicAmounts(amount("10"), {
+      ...amount("100"),
+      scale: 3,
+    })).toBe(0);
+    expect(compareManagedEconomicAmounts(amount("900719925474099300"), amount("900719925474099301")))
+      .toBe(-1);
+  });
+
+  it("keeps currency, credit, and physical unit schemes distinct", () => {
+    const currency = amount("100");
+    const credit = {
+      atoms: "100",
+      scale: 2,
+      unit: "credit",
+      scheme: { kind: "credit" as const, creditSchemeId: "provider-credit-v1" },
+    };
+    const requests = {
+      atoms: "1",
+      scale: 0,
+      unit: "request",
+      scheme: { kind: "unit" as const },
+    };
+    expect(() => validateManagedEconomicAmount(currency)).not.toThrow();
+    expect(() => validateManagedEconomicAmount(credit)).not.toThrow();
+    expect(() => validateManagedEconomicAmount(requests)).not.toThrow();
+    expect(() => compareManagedEconomicAmounts(currency, credit)).toThrow(
+      "incompatible units or schemes",
+    );
+  });
+
+  it("represents known, unlimited, and unknown quota evidence without invented fields", () => {
+    const variants: readonly ManagedEconomicQuotaEvidence[] = [
+      {
+        kind: "known",
+        capacityIdentity: "account-a",
+        subscriptionClass: "metered",
+        quotaClassId: "rolling-window",
+        buckets: [{
+          bucketId: "primary",
+          dimension: "credit",
+          remaining: amount("500"),
+          resetsAt: "2026-07-30T12:00:00.000Z",
+        }],
+        evidence: currentEvidence,
+      },
+      {
+        kind: "unlimited",
+        capacityIdentity: "account-a",
+        subscriptionClass: "subscription",
+        quotaClassId: "provider-reported-unlimited",
+        evidence: currentEvidence,
+      },
+      {
+        kind: "unknown",
+        capacityIdentity: "account-a",
+        subscriptionClass: "unknown",
+        reason: "provider-does-not-expose-quota",
+        evidence: null,
+      },
+    ];
+    expect(variants.map(({ kind }) => kind)).toEqual(["known", "unlimited", "unknown"]);
+    expect(variants[2]).not.toHaveProperty("buckets");
+  });
+
+  it.each([
+    ["quota-evidence-missing", alternative("route", { quota: null })],
+    [
+      "quota-evidence-stale",
+      alternative("route", {
+        quota: { ...currentEvidence, validUntil: "2026-07-29T11:59:59.999Z" },
+      }),
+    ],
+    ["price-evidence-missing", alternative("route", { price: null })],
+    [
+      "price-evidence-stale",
+      alternative("route", {
+        price: price("metered", {
+          ...currentEvidence,
+          validUntil: "2026-07-29T11:59:59.999Z",
+        }),
+      }),
+    ],
+    [
+      "comparison-domain-incompatible",
+      {
+        ...alternative("route"),
+        comparisonDomain: {
+          ...alternative("route").comparisonDomain,
+          basis: {
+            ...alternative("route").comparisonDomain.basis,
+            scheme: { kind: "currency" as const, currency: "EUR" },
+          },
+        },
+      },
+    ],
+    ["execution-envelope-unbounded", alternative("route", { bounded: false })],
+    [
+      "ceiling-exceeded",
+      alternative("route", { reservation: amount("101"), ceiling: amount("100") }),
+    ],
+  ] as const)("returns the Core-owned %s rejection", (reason, candidate) => {
+    const decision = selectManagedEconomicExecutionAlternative(request([candidate]));
+    expect(decision).toMatchObject({
+      kind: "denied",
+      rejected: [{ stage: "economic-selection", reason }],
+    });
+  });
+
+  it("admits a reservation exactly at its ceiling", () => {
+    const decision = selectManagedEconomicExecutionAlternative(request([
+      alternative("route", { reservation: amount("100"), ceiling: amount("100") }),
+    ]));
+    expect(decision.kind).toBe("selected");
+  });
+
+  it("rejects an explicit unknown price basis without erasing the unknown evidence", () => {
+    const candidate = alternative("route", {
+      account: "accountless",
+      price: price("unknown"),
+      reservation: null,
+    });
+    const decision = selectManagedEconomicExecutionAlternative(request([candidate]));
+    expect(decision).toMatchObject({
+      kind: "denied",
+      rejected: [{
+        reason: "price-evidence-missing",
+        alternativeIdentity: candidate.identity,
+      }],
+    });
+  });
+
+  it("rejects same-rank domains with incompatible currency schemes", () => {
+    const usd = alternative("usd");
+    const eurBase = alternative("eur");
+    const eur: ManagedEconomicExecutionAlternative = {
+      ...eurBase,
+      identity: {
+        ...eurBase.identity,
+        route: {
+          ...eurBase.identity.route,
+          scheme: { kind: "currency", currency: "EUR" },
+        },
+      },
+      comparisonDomain: {
+        ...eurBase.comparisonDomain,
+        basis: {
+          ...eurBase.comparisonDomain.basis,
+          scheme: { kind: "currency", currency: "EUR" },
+        },
+      },
+      worstCaseReservation: {
+        kind: "exact",
+        amount: amount("100", "EUR"),
+      },
+    };
+    const decision = selectManagedEconomicExecutionAlternative(request([usd, eur]));
+    expect(decision).toMatchObject({
+      kind: "denied",
+      rejected: [
+        { reason: "comparison-domain-incompatible" },
+        { reason: "comparison-domain-incompatible" },
+      ],
+    });
+  });
+
+  it("rejects an execution envelope whose digest is not the committed route digest", () => {
+    const candidate = alternative("route");
+    const mismatched: ManagedEconomicExecutionAlternative = {
+      ...candidate,
+      executionEnvelope: {
+        ...candidate.executionEnvelope as Extract<typeof candidate.executionEnvelope, { kind: "bounded" }>,
+        digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      },
+    };
+    expect(selectManagedEconomicExecutionAlternative(request([mismatched]))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+  });
+
+  it.each([
+    ["invalid authority", { authority: "self-asserted" }],
+    ["invalid confidence", { confidence: "certain" }],
+    ["non-canonical digest", { sourceDigest: `sha256:${"A".repeat(64)}` }],
+    ["impossible calendar date", { observedAt: "2026-02-30T11:00:00.000Z" }],
+    ["non-canonical timestamp", { observedAt: "2026-07-29T11:00:00Z" }],
+    [
+      "reversed validity interval",
+      {
+        observedAt: "2026-07-29T13:00:00.000Z",
+        validUntil: "2026-07-29T12:00:00.000Z",
+      },
+    ],
+  ])("fails closed for %s evidence", (_label, mutation) => {
+    const malformed = {
+      ...currentEvidence,
+      ...mutation,
+    } as unknown as ManagedEconomicEvidenceIdentity;
+    const candidate = alternative("route", { price: price("metered", malformed) });
+    expect(selectManagedEconomicExecutionAlternative(request([candidate]))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+  });
+
+  it("binds quota evidence to the selected stable account capacity identity", () => {
+    const mismatchedQuota: ManagedEconomicQuotaEvidence = {
+      kind: "known",
+      capacityIdentity: "different-account",
+      subscriptionClass: "metered",
+      quotaClassId: "quota-class",
+      buckets: [{
+        bucketId: "primary",
+        dimension: "currency",
+        remaining: amount("100"),
+        resetsAt: "2026-07-30T12:00:00.000Z",
+      }],
+      evidence: currentEvidence,
+    };
+    const decision = selectManagedEconomicExecutionAlternative(request([
+      alternative("route", { account: "account-a", quotaEvidence: mismatchedQuota }),
+    ]));
+    expect(decision).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+  });
+
+  it("preserves unknown quota evidence while rejecting it as unavailable", () => {
+    const unknownQuota: ManagedEconomicQuotaEvidence = {
+      kind: "unknown",
+      capacityIdentity: "account-a",
+      subscriptionClass: "unknown",
+      reason: "provider-does-not-expose-quota",
+      evidence: currentEvidence,
+    };
+    const decision = selectManagedEconomicExecutionAlternative(request([
+      alternative("route", { account: "account-a", quotaEvidence: unknownQuota }),
+    ]));
+    expect(decision).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "quota-evidence-missing" }],
+    });
+  });
+
+  it.each([
+    ["duplicate bucket identity", [
+      {
+        bucketId: "primary",
+        dimension: "currency",
+        remaining: amount("100"),
+        resetsAt: null,
+      },
+      {
+        bucketId: "primary",
+        dimension: "request",
+        remaining: null,
+        resetsAt: null,
+      },
+    ]],
+    ["invalid bucket reset", [{
+      bucketId: "primary",
+      dimension: "currency",
+      remaining: amount("100"),
+      resetsAt: "2026-02-30T12:00:00.000Z",
+    }]],
+  ] as const)("rejects %s in account quota evidence", (_label, buckets) => {
+    const quota: ManagedEconomicQuotaEvidence = {
+      kind: "known",
+      capacityIdentity: "account-a",
+      subscriptionClass: "metered",
+      quotaClassId: "quota-class",
+      buckets,
+      evidence: currentEvidence,
+    };
+    expect(selectManagedEconomicExecutionAlternative(request([
+      alternative("route", { account: "account-a", quotaEvidence: quota }),
+    ]))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+  });
+
+  it("rejects invalid quota class and exact remaining amount evidence", () => {
+    const invalidClass: ManagedEconomicQuotaEvidence = {
+      kind: "known",
+      capacityIdentity: "account-a",
+      subscriptionClass: "metered",
+      quotaClassId: "",
+      buckets: [{
+        bucketId: "primary",
+        dimension: "currency",
+        remaining: amount("100"),
+        resetsAt: null,
+      }],
+      evidence: currentEvidence,
+    };
+    expect(selectManagedEconomicExecutionAlternative(request([
+      alternative("route", { account: "account-a", quotaEvidence: invalidClass }),
+    ]))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+
+    const invalidRemaining: ManagedEconomicQuotaEvidence = {
+      ...invalidClass,
+      quotaClassId: "quota-class",
+      buckets: [{
+        bucketId: "primary",
+        dimension: "currency",
+        remaining: { ...amount("100"), atoms: "01" },
+        resetsAt: null,
+      }],
+    };
+    expect(selectManagedEconomicExecutionAlternative(request([
+      alternative("route", { account: "account-a", quotaEvidence: invalidRemaining }),
+    ]))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+  });
+
+  it("allows missing optional price only for a non-comparable commitment", () => {
+    const nonComparable = alternative("priority-only", {
+      account: "accountless",
+      price: null,
+      reservation: null,
+    });
+    const selected = selectManagedEconomicExecutionAlternative(request([nonComparable], {
+      evidenceRequirements: { quota: "optional", price: "optional" },
+    }));
+    expect(selected.kind).toBe("selected");
+
+    const invalidComparable = alternative("invented-price", {
+      account: "accountless",
+      price: null,
+      reservation: amount("0"),
+    });
+    expect(selectManagedEconomicExecutionAlternative(request([invalidComparable], {
+      evidenceRequirements: { quota: "optional", price: "optional" },
+    }))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+
+    const reservationPriceBinding: Pick<ManagedEconomicReservation, "priceIdentity"> = {
+      priceIdentity: null,
+    };
+    expect(reservationPriceBinding.priceIdentity).toBeNull();
+  });
+
+  it.each([
+    ["empty route identity", { routeId: "" }],
+    ["invalid route digest", { envelopeDigest: "sha256:not-a-digest" }],
+  ])("rejects malformed full route identity: %s", (_label, routeMutation) => {
+    const candidate = alternative("route");
+    const malformed: ManagedEconomicExecutionAlternative = {
+      ...candidate,
+      identity: {
+        ...candidate.identity,
+        route: { ...candidate.identity.route, ...routeMutation },
+      },
+    };
+    expect(selectManagedEconomicExecutionAlternative(request([malformed]))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+  });
+
+  it("rejects malformed full account identity", () => {
+    const candidate = alternative("route");
+    if (candidate.identity.account.kind !== "account-bound") {
+      throw new Error("fixture must be account-bound");
+    }
+    const malformed: ManagedEconomicExecutionAlternative = {
+      ...candidate,
+      identity: {
+        ...candidate.identity,
+        account: { ...candidate.identity.account, accountRef: "" },
+      },
+    };
+    expect(selectManagedEconomicExecutionAlternative(request([malformed]))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+  });
+
+  it("rejects price evidence bound to a different exact model identity", () => {
+    const candidate = alternative("route");
+    const wrongPrice = price("metered");
+    const malformed: ManagedEconomicExecutionAlternative = {
+      ...candidate,
+      priceEvidence: {
+        ...wrongPrice,
+        identity: { ...wrongPrice.identity, modelId: "different-model" },
+      },
+    };
+    expect(selectManagedEconomicExecutionAlternative(request([malformed]))).toMatchObject({
+      kind: "denied",
+      rejected: [{ reason: "comparison-domain-incompatible" }],
+    });
+  });
+
+  it("caller narrowing can only remove alternatives", () => {
+    const candidates = [alternative("route-a"), alternative("route-b")];
+    expect(narrowManagedEconomicExecutionAlternatives(candidates, {
+      routeIds: ["route-b", "route-not-admitted"],
+    }).map((candidate) => candidate.identity.route.routeId)).toEqual(["route-b"]);
+  });
+
+  it("keeps every settlement authority variant distinct and omits absent charges", () => {
+    const identity = alternative("route").identity;
+    const common = {
+      reservationId: "reservation-1",
+      dispatchFenceId: "dispatch-fence-1",
+      actualIdentity: identity,
+      units: [amount("10")],
+      evidence: currentEvidence,
+    };
+    const settlements: readonly ManagedEconomicSettlement[] = [
+      { kind: "charged", ...common, charge: amount("25") },
+      { kind: "estimated", ...common, estimate: amount("25") },
+      { kind: "subscription", ...common },
+      { kind: "included", ...common, allowanceId: "allowance-1" },
+      { kind: "free", ...common },
+      {
+        kind: "unknown",
+        reservationId: "reservation-1",
+        dispatchFenceId: "dispatch-fence-1",
+        actualIdentity: null,
+        reason: "settlement-unavailable",
+        evidence: null,
+      },
+      {
+        kind: "pending",
+        reservationId: "reservation-1",
+        dispatchFenceId: "dispatch-fence-1",
+      },
+      {
+        kind: "leaked",
+        reservationId: "reservation-1",
+        dispatchFenceId: "dispatch-fence-1",
+        reason: "external-work-unknown",
+      },
+    ];
+    expect(settlements.map(({ kind }) => kind)).toEqual([
+      "charged",
+      "estimated",
+      "subscription",
+      "included",
+      "free",
+      "unknown",
+      "pending",
+      "leaked",
+    ]);
+    for (const settlement of settlements.filter(({ kind }) =>
+      kind === "subscription" || kind === "included" || kind === "unknown")) {
+      expect(settlement).not.toHaveProperty("charge");
+      expect(settlement).not.toHaveProperty("estimate");
+    }
+  });
+});

--- a/packages/core/tests/engine/gateway/gateway-config.test.ts
+++ b/packages/core/tests/engine/gateway/gateway-config.test.ts
@@ -25,6 +25,135 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 }
 
 describe("GatewayConfig", () => {
+  const economicGatewayYaml = `
+port: 4800
+apps: []
+modelGateway:
+  port: 4801
+  accounts:
+    - id: account-a
+      providerId: codex-oauth
+      credentialId: credential-a
+      maxConcurrency: 2
+      reservedAffinitySlots: 1
+      economics:
+        capacityIdentity: capacity-a
+        subscriptionClass: metered
+        quotaClassId: codex-standard
+        creditPosture: disabled
+        overagePosture: disabled
+  replay: { ttlMs: 300000, maxEntries: 1000, hmacKeyEnv: KILN_REPLAY_KEY }
+  surfaces:
+    openAIResponses: { maxBodyBytes: 1048576, maxConcurrentRequests: 4 }
+  principals:
+    - { tokenEnv: TOKEN_ENV, ingress: openai-responses, tenantId: tenant, applicationId: app, callerId: caller, capabilityId: invoke, scopes: [model.invoke], budgetEvidenceId: budget, virtualModelIds: [codex] }
+  virtualModels:
+    - id: codex
+      providerId: codex-oauth
+      providerModelId: gpt-5.6-codex
+      accountIds: [account-a]
+      capabilities: [text]
+      affinity: { continuity: none }
+      economics:
+        adapterCapabilityId: codex-direct
+        adapterCapabilityVersion: v1
+        authBillingChannel: oauth-subscription
+        executionMode: responses-api
+        serviceTier: standard
+        rateCardBasis: public-metered
+        envelopeSemantics: configured-upper-bound
+        fallbackPosture: disabled
+        overagePosture: disabled
+        contextClass: standard-context
+        cacheClass: provider-cache
+        priceEvidence:
+          kind: metered
+          rateCardId: codex-public
+          rateCardRevision: rev-2026-07
+          unitPrices:
+            - usageUnit: input-token
+              price: { atoms: "125", scale: 6, unit: input-token, scheme: { kind: currency, currency: USD } }
+          evidence:
+            sourceIdentity: openai-pricing
+            sourceRevision: rev-2026-07
+            sourceDigest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            observedAt: "2026-07-29T00:00:00.000Z"
+            validUntil: "2026-08-29T00:00:00.000Z"
+            confidence: high
+            authority: provider-reported
+        auxiliaryCharges: []
+        executionEnvelope:
+          limits:
+            - { atoms: "200000", scale: 0, unit: input-token, scheme: { kind: unit } }
+`;
+
+  it("parses exact account and route economics without numeric coercion", () => {
+    const modelGateway = parseGatewayYaml(economicGatewayYaml).modelGateway;
+
+    expect(modelGateway?.accounts[0]?.economics).toEqual({
+      capacityIdentity: "capacity-a",
+      subscriptionClass: "metered",
+      quotaClassId: "codex-standard",
+      creditPosture: "disabled",
+      overagePosture: "disabled",
+    });
+    expect(modelGateway?.virtualModels[0]?.economics?.priceEvidence).toMatchObject({
+      kind: "metered",
+      unitPrices: [{ price: { atoms: "125", scale: 6, scheme: { kind: "currency", currency: "USD" } } }],
+    });
+    expect(modelGateway?.virtualModels[0]?.economics).toMatchObject({
+      adapterCapabilityId: "codex-direct",
+      adapterCapabilityVersion: "v1",
+      rateCardBasis: "public-metered",
+      envelopeSemantics: "configured-upper-bound",
+    });
+  });
+
+  it("rejects unknown nested economic fields and duplicate capacity identities", () => {
+    expect(() => parseGatewayYaml(economicGatewayYaml.replace(
+      "currency: USD",
+      "currency: USD, approximation: float",
+    ))).toThrow(/approximation.*not supported/);
+
+    const duplicateAccount = `    - id: account-b
+      providerId: codex-oauth
+      credentialId: credential-b
+      maxConcurrency: 1
+      reservedAffinitySlots: 0
+      economics:
+        capacityIdentity: capacity-a
+        subscriptionClass: metered
+        quotaClassId: codex-standard
+        creditPosture: disabled
+        overagePosture: disabled
+`;
+    expect(() => parseGatewayYaml(economicGatewayYaml
+      .replace("  replay:", `${duplicateAccount}  replay:`)
+      .replace("accountIds: [account-a]", "accountIds: [account-a, account-b]")))
+      .toThrow(/capacityIdentity.*unique/);
+  });
+
+  it("fails closed for malformed exact amounts, evidence, postures, and envelopes", () => {
+    const malformed = [
+      economicGatewayYaml.replace('atoms: "125"', 'atoms: "01"'),
+      economicGatewayYaml.replace("scale: 6", "scale: 19"),
+      economicGatewayYaml.replace("sourceDigest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "sourceDigest: sha256:nope"),
+      economicGatewayYaml.replace('observedAt: "2026-07-29T00:00:00.000Z"', 'observedAt: "2026-07-29"'),
+      economicGatewayYaml.replace("authority: provider-reported", "authority: operator-assumed"),
+      economicGatewayYaml.replace("fallbackPosture: disabled", "fallbackPosture: implicit"),
+      economicGatewayYaml.replace("adapterCapabilityId: codex-direct\n", ""),
+      economicGatewayYaml.replace("adapterCapabilityVersion: v1\n", ""),
+      economicGatewayYaml.replace("rateCardBasis: public-metered\n", ""),
+      economicGatewayYaml.replace("envelopeSemantics: configured-upper-bound\n", ""),
+      economicGatewayYaml.replace("usageUnit: input-token", "usageUnit: output-token"),
+      economicGatewayYaml.replace("unit: input-token, scheme: { kind: currency", "unit: output-token, scheme: { kind: currency"),
+      economicGatewayYaml.replace("unit: input-token, scheme: { kind: unit }", "unit: output-token, scheme: { kind: unit }"),
+      economicGatewayYaml.replace('            - { atoms: "200000", scale: 0, unit: input-token, scheme: { kind: unit } }', "            []"),
+    ];
+
+    for (const yaml of malformed) expect(() => parseGatewayYaml(yaml)).toThrow();
+  });
+
   it("parses an explicit secret-free model gateway surface", () => {
     const parsed = parseGatewayYaml(`
 port: 4800

--- a/packages/runtime/src/agents/credential-pool/codex-oauth-credential-pool.ts
+++ b/packages/runtime/src/agents/credential-pool/codex-oauth-credential-pool.ts
@@ -188,11 +188,29 @@ export class CodexOAuthCredentialPoolService {
     });
   }
 
-  /** Explicit secret-bearing read for native-harness projection (e.g. activating a Codex CLI/App account). */
-  async getCredentialTokenFile(credentialId: string): Promise<CodexOAuthTokenFile | null> {
+  /**
+   * Best-effort backfill for `id_token` on credentials linked before Kiln began capturing it.
+   * Native Codex CLI/App requires `id_token` in `~/.codex/auth.json`; refresh responses often
+   * include one even when the stored token file predates that capture. Never throws on refresh
+   * failure — callers must treat a still-missing `id_token` on the returned file as unusable for
+   * native projection rather than as an error.
+   */
+  async ensureCredentialIdToken(credentialId: string): Promise<CodexOAuthTokenFile | null> {
     assertSafeCredentialId(credentialId);
-    const credentials = await this.readCredentials();
-    return credentials.find((credential) => credential.id === credentialId)?.tokenFile ?? null;
+    return this.withCredentialLocks([credentialId], async () => {
+      const record = (await this.readCredentials()).find((entry) => entry.id === credentialId);
+      if (!record) return null;
+      if (record.tokenFile.id_token) return record.tokenFile;
+      let refreshed: CodexOAuthTokenFile;
+      try {
+        refreshed = await new CodexOAuthAuth({ tokenPath: record.tokenPath }).refreshToken(record.tokenFile);
+      } catch {
+        return record.tokenFile;
+      }
+      if (!refreshed.id_token) return refreshed;
+      await atomicReplaceCredentialFile(record.tokenPath, refreshed);
+      return refreshed;
+    });
   }
 
   async getValidAccessToken(): Promise<string> {

--- a/packages/runtime/src/agents/credential-pool/codex-oauth-credential-pool.ts
+++ b/packages/runtime/src/agents/credential-pool/codex-oauth-credential-pool.ts
@@ -188,6 +188,13 @@ export class CodexOAuthCredentialPoolService {
     });
   }
 
+  /** Explicit secret-bearing read for native-harness projection (e.g. activating a Codex CLI/App account). */
+  async getCredentialTokenFile(credentialId: string): Promise<CodexOAuthTokenFile | null> {
+    assertSafeCredentialId(credentialId);
+    const credentials = await this.readCredentials();
+    return credentials.find((credential) => credential.id === credentialId)?.tokenFile ?? null;
+  }
+
   async getValidAccessToken(): Promise<string> {
     const candidates = await this.listValidAccessTokenCandidates();
     return candidates[0]?.accessToken ?? "";
@@ -692,11 +699,15 @@ function validateCodexOAuthTokenFile(value: unknown, filePath: string): CodexOAu
   if (typeof record.client_id !== "string" || record.client_id.trim().length === 0) {
     throw new CodexOAuthCredentialShapeError(filePath);
   }
+  const idToken = typeof record.id_token === "string" && record.id_token.trim().length > 0
+    ? record.id_token
+    : undefined;
   return {
     access_token: record.access_token,
     refresh_token: record.refresh_token,
     expires_at: record.expires_at,
     client_id: record.client_id,
+    ...(idToken ? { id_token: idToken } : {}),
   };
 }
 

--- a/packages/runtime/src/agents/credential-pool/codex-oauth-credential-pool.ts
+++ b/packages/runtime/src/agents/credential-pool/codex-oauth-credential-pool.ts
@@ -339,6 +339,17 @@ export class CodexOAuthCredentialPoolService {
     return this.usageStore.list(CODEX_OAUTH_POOL_PROVIDER_ID, now);
   }
 
+  /** Opt-in identity lookup decoded from already-local token claims; never fetched from the provider. */
+  async listCredentialEmails(): Promise<ReadonlyMap<string, string>> {
+    const credentials = await this.readCredentials();
+    const emails = new Map<string, string>();
+    for (const credential of credentials) {
+      const email = readCodexOAuthProfileEmail(credential.tokenFile.access_token);
+      if (email) emails.set(credential.id, email);
+    }
+    return emails;
+  }
+
   async removeCredential(credentialId: string): Promise<void> {
     assertSafeCredentialId(credentialId);
     await this.withCatalogLock(() => this.withCredentialLocks([credentialId], async () => {
@@ -615,6 +626,20 @@ function readCodexOAuthAccountId(accessToken: string): string | null {
     if (typeof auth !== "object" || auth === null || Array.isArray(auth)) return null;
     const accountId = (auth as Record<string, unknown>).chatgpt_account_id;
     return typeof accountId === "string" && accountId.trim().length > 0 ? accountId.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function readCodexOAuthProfileEmail(accessToken: string): string | null {
+  const payload = accessToken.split(".")[1];
+  if (!payload) return null;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<string, unknown>;
+    const profile = claims["https://api.openai.com/profile"];
+    if (typeof profile !== "object" || profile === null || Array.isArray(profile)) return null;
+    const email = (profile as Record<string, unknown>).email;
+    return typeof email === "string" && email.trim().length > 0 ? email.trim() : null;
   } catch {
     return null;
   }

--- a/packages/runtime/src/agents/credential-pool/credential-file-store.ts
+++ b/packages/runtime/src/agents/credential-pool/credential-file-store.ts
@@ -1,6 +1,6 @@
 import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { CredentialSource } from "@kilnai/core";
+import { CREDENTIAL_FILE_MODE, applyCredentialFileMode, type CredentialSource } from "@kilnai/core";
 
 export interface CredentialFileStoreConfig {
   readonly rootDir: string;
@@ -86,7 +86,13 @@ export class CredentialFileStore<TAuth> {
     };
 
     await mkdir(this.providerDirectory(input.providerId), { recursive: true });
-    await writeFile(filePath, `${JSON.stringify(credential, null, 2)}\n`, "utf8");
+    await writeFile(filePath, `${JSON.stringify(credential, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: CREDENTIAL_FILE_MODE,
+    });
+    // Every provider on this store inherits the owner-only invariant, including
+    // credentials written before it existed, which repair on their next write.
+    await applyCredentialFileMode(filePath);
     return credential;
   }
 

--- a/packages/runtime/src/agents/credential-pool/credential-permission-diagnostic.ts
+++ b/packages/runtime/src/agents/credential-pool/credential-permission-diagnostic.ts
@@ -1,0 +1,77 @@
+import { readdir, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { isOverPermissiveCredentialMode } from "@kilnai/core";
+
+export interface OverPermissiveCredentialFile {
+  /** Path relative to the credential root, so diagnostics never leak the operator's home path. */
+  readonly relativePath: string;
+  /** Octal permission string, such as `644`. */
+  readonly mode: string;
+}
+
+export interface CredentialPermissionDiagnosticConfig {
+  readonly rootDir: string;
+  readonly platform?: NodeJS.Platform;
+}
+
+/**
+ * Reports credential files readable beyond their owner.
+ *
+ * Write paths enforce owner-only mode, so an actively used credential repairs
+ * itself on its next persist. This covers the remainder: credentials that are
+ * linked once and never rewritten would otherwise keep a pre-invariant mode
+ * indefinitely with nothing surfacing it.
+ *
+ * Read-only by contract. Operator surfaces report the finding; they do not
+ * repair it here, because silently changing permissions during an inspection
+ * command would hide the exposure that just occurred rather than explain it.
+ */
+export async function listOverPermissiveCredentialFiles(
+  config: CredentialPermissionDiagnosticConfig,
+): Promise<readonly OverPermissiveCredentialFile[]> {
+  // Windows does not implement POSIX mode bits, so every file would report the
+  // same synthetic mode and the diagnostic would be noise rather than evidence.
+  if ((config.platform ?? process.platform) === "win32") return [];
+  const findings: OverPermissiveCredentialFile[] = [];
+  await collect(config.rootDir, config.rootDir, findings);
+  return findings.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+async function collect(
+  rootDir: string,
+  currentDir: string,
+  findings: OverPermissiveCredentialFile[],
+): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(currentDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const path = join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      await collect(rootDir, path, findings);
+      continue;
+    }
+    // Health and usage metadata are operational evidence, not credential secrets.
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    if (currentDir !== rootDir && isMetadataDirectory(currentDir, rootDir)) continue;
+    let mode: number;
+    try {
+      mode = (await stat(path)).mode & 0o777;
+    } catch {
+      continue;
+    }
+    if (!isOverPermissiveCredentialMode(mode)) continue;
+    findings.push({
+      relativePath: relative(rootDir, path).split(/[\\/]/).join("/"),
+      mode: mode.toString(8).padStart(3, "0"),
+    });
+  }
+}
+
+function isMetadataDirectory(currentDir: string, rootDir: string): boolean {
+  const segment = relative(rootDir, currentDir).split(/[\\/]/)[0];
+  return segment !== undefined && segment.startsWith(".");
+}

--- a/packages/runtime/src/agents/credential-pool/index.ts
+++ b/packages/runtime/src/agents/credential-pool/index.ts
@@ -96,3 +96,9 @@ export type {
   OpenCodeExecutionCredential,
   OpenCodeExecutionProviderId,
 } from "./opencode-credential-pool.js";
+
+export { listOverPermissiveCredentialFiles } from "./credential-permission-diagnostic.js";
+export type {
+  CredentialPermissionDiagnosticConfig,
+  OverPermissiveCredentialFile,
+} from "./credential-permission-diagnostic.js";

--- a/packages/runtime/src/agents/managed-invocation/index.ts
+++ b/packages/runtime/src/agents/managed-invocation/index.ts
@@ -239,8 +239,15 @@ export {
   MANAGED_AGENT_STATUS_CAPABILITY,
   MANAGED_AGENT_STATUS_TOOL,
   MANAGED_AGENT_STATUS_TOOL_NAME,
+  collectManagedEconomicCandidates,
 } from "./runtime-tool.js";
 export type {
+  ManagedCommittedInvocationRequest,
+  ManagedEconomicCandidateDescriptor,
+  ManagedEconomicCandidateRejection,
+  ManagedEconomicCandidateRejectionReason,
+  ManagedEconomicCandidateSet,
+  ManagedEconomicInvocationCommand,
   ManagedInvocationContextResolution,
   ManagedInvocationContextResolver,
   ManagedInvocationContextResolverInput,

--- a/packages/runtime/src/agents/managed-invocation/orchestration-lifecycle.ts
+++ b/packages/runtime/src/agents/managed-invocation/orchestration-lifecycle.ts
@@ -16,10 +16,12 @@ import {
   type ManagedAgentRequestedAuthority,
   type ManagedAgentWorkingDirectory,
 } from "@kilnai/core";
-import type {
-  ManagedInvocationRouteProfile,
-  ManagedInvocationToolOptions,
-  ManagedInvocationToolRoute,
+import {
+  collectManagedEconomicCandidates,
+  type ManagedEconomicCandidateSet,
+  type ManagedInvocationRouteProfile,
+  type ManagedInvocationToolOptions,
+  type ManagedInvocationToolRoute,
 } from "./runtime-tool.js";
 import {
   RuntimeBudgetAdmissionService,
@@ -75,6 +77,15 @@ export interface ManagedAgentOrchestrationLifecycleResult {
   readonly childRecords: readonly ManagedAgentOrchestrationLifecycleChildRecord[];
 }
 
+export class ManagedEconomicCommitmentUnavailableError extends Error {
+  readonly code = "economic_commitment_unavailable";
+
+  constructor(readonly candidateSet: ManagedEconomicCandidateSet) {
+    super("Managed orchestration requires a durable economic commitment before execution");
+    this.name = "ManagedEconomicCommitmentUnavailableError";
+  }
+}
+
 interface PreparedOrchestrationChild {
   readonly child: ManagedAgentOrchestrationRequest["childRequests"][number];
   readonly agentProfile?: string;
@@ -101,6 +112,30 @@ export async function runManagedAgentOrchestrationLifecycle(
     }
     if (agent?.authorityProfile && agent.authorityProfile !== input.profile) {
       throw new Error(`Managed orchestration agent profile '${agent.name}' requires '${agent.authorityProfile}', not '${input.profile}'`);
+    }
+    if (agent?.economicPolicyId && agent.economicPolicyRevision) {
+      throw new ManagedEconomicCommitmentUnavailableError(
+        collectManagedEconomicCandidates({
+          economicPolicyId: agent.economicPolicyId,
+          economicPolicyRevision: agent.economicPolicyRevision,
+          configuredAgentProfileId: agent.name,
+          admissionProfileId: input.profile,
+          ...(child.routeId ?? input.routeSelector?.routeId
+            ? { routeId: child.routeId ?? input.routeSelector?.routeId }
+            : {}),
+          ...(input.routeSelector?.providerId
+            ? {
+                providerRoute: {
+                  providerId: input.routeSelector.providerId,
+                  surface: "configured",
+                  ...(input.routeSelector.model
+                    ? { model: input.routeSelector.model }
+                    : {}),
+                },
+              }
+            : {}),
+        }, input.managedInvocation.routes, input.managedInvocation.unavailableRoutes),
+      );
     }
     if (child.routeId && agent?.routeId && child.routeId !== agent.routeId) {
       throw new Error(`Managed orchestration child route '${child.routeId}' contradicts agent profile '${agent.name}' route '${agent.routeId}'`);
@@ -231,7 +266,11 @@ async function runOrchestrationBatch(input: {
   readonly lifecycleObserver?: ManagedAgentOrchestrationLifecycleObserver;
 }): Promise<readonly ManagedAgentOrchestrationLifecycleChildRecord[]> {
   const startResults = await Promise.allSettled(input.entries.map(async ({ request, route }) => {
-    const startResult = await input.service.start(request, route.adapter, {
+    const adapter = route.adapter;
+    if (!adapter) {
+      throw new Error("economic_commitment_unavailable");
+    }
+    const startResult = await input.service.start(request, adapter, {
       routeId: route.routeId,
       routeSource: route.routeSource,
       // Roadmap 01 Slice 3.1 (F3) - managed_agent.orchestrate has no input
@@ -248,7 +287,7 @@ async function runOrchestrationBatch(input: {
       providerModelProof: {
         status: "live-proven",
         source: "managed-orchestration-lifecycle-route",
-        requiresToolCalls: route.adapter.descriptor.adapterKind === "direct",
+        requiresToolCalls: adapter.descriptor.adapterKind === "direct",
       },
       resourcePlane: {
         available: true,
@@ -452,6 +491,7 @@ function selectOrchestrationRoute(
     return profile !== undefined
       && profile.workingDirectory.mode === workingDirectoryMode
       && (workingDirectoryMode !== "isolated-worktree" || profile.workingDirectoryLease !== undefined)
+      && route.adapter !== undefined
       && route.adapter.descriptor.lifecycle.exposesStart
       && route.adapter.descriptor.lifecycle.exposesTerminal;
   });
@@ -505,6 +545,10 @@ function buildOrchestrationChildInvocationRequest(input: {
   readonly requestedAuthority: ManagedAgentRequestedAuthority;
   readonly admissionProfile: ManagedAgentAdmissionProfile;
 }): ManagedAgentInvocationRequest {
+  const adapter = input.route.adapter;
+  if (!adapter) {
+    throw new Error("economic_commitment_unavailable");
+  }
   const invocationId = sanitizeInvocationId(input.childId);
   const workingDirectory = resolveOrchestrationWorkingDirectory(input.profile, invocationId);
   const authority: ManagedAgentAuthorityProfile = {
@@ -555,11 +599,11 @@ function buildOrchestrationChildInvocationRequest(input: {
     requestedAuthority: input.requestedAuthority,
     providerRoute: {
       providerId: input.route.providerId,
-      surface: input.route.surface ?? input.route.adapter.descriptor.supportedExecutionModes[0] ?? "cli-harness",
+      surface: input.route.surface ?? adapter.descriptor.supportedExecutionModes[0] ?? "cli-harness",
       ...(input.route.model ? { model: input.route.model } : {}),
     },
-    adapterKind: input.route.adapter.descriptor.adapterKind,
-    executionMode: input.route.adapter.descriptor.supportedExecutionModes[0] ?? "cli-harness",
+    adapterKind: adapter.descriptor.adapterKind,
+    executionMode: adapter.descriptor.supportedExecutionModes[0] ?? "cli-harness",
     authority,
     input: {
       summary: `${input.roleIntent} ${input.ordinal}: ${input.orchestrationRequest.task}`,

--- a/packages/runtime/src/agents/managed-invocation/runtime-tool.ts
+++ b/packages/runtime/src/agents/managed-invocation/runtime-tool.ts
@@ -41,6 +41,7 @@ import type {
   ManagedAgentRequestedAuthority,
   ManagedAgentRouteSource,
   ManagedAgentWorkingDirectory,
+  ManagedEconomicCommitment,
   ModelTaskSuitability,
   ModelTaskSuitabilityTask,
   WorkClassification,
@@ -137,14 +138,33 @@ export interface ManagedInvocationRouteProfile {
   readonly writeAuthority?: ManagedAgentAuthorityProfile["writeAuthority"];
 }
 
+export type ManagedEconomicRouteCapability =
+  | {
+      readonly status: "verified";
+      readonly adapterCapabilityId: string;
+      readonly adapterCapabilityVersion: string;
+    }
+  | {
+      readonly status: "unverified";
+    };
+
 export interface ManagedInvocationToolRoute {
   readonly routeId: string;
+  readonly economicPolicyIds?: readonly string[];
   readonly accountPolicyId?: string;
   readonly routeSource: ManagedAgentRouteSource;
   readonly providerId: string;
   readonly model?: string;
   readonly voiceProfile?: string;
-  readonly adapter: ManagedAgentRuntimeAdapter;
+  /**
+   * Fixed-route execution only. Economic policy candidates must not carry an
+   * adapter across the precommit boundary.
+   */
+  readonly adapter?: ManagedAgentRuntimeAdapter;
+  readonly economicCapability?: ManagedEconomicRouteCapability;
+  readonly createCommittedAdapter?: (
+    request: ManagedCommittedInvocationRequest,
+  ) => Promise<ManagedAgentRuntimeAdapter | undefined>;
   readonly surface?: string;
   readonly providerModelProof?: ManagedAgentCapabilitySnapshotInput["providerModelProof"];
   readonly taskSuitability?: readonly ModelTaskSuitability[];
@@ -162,6 +182,9 @@ export interface ManagedInvocationToolRoute {
 
 export interface ManagedInvocationUnavailableRoute {
   readonly routeId: string;
+  readonly economicPolicyIds?: readonly string[];
+  readonly accountPolicyId?: string;
+  readonly economicCapability?: ManagedEconomicRouteCapability;
   readonly routeSource: ManagedAgentRouteSource;
   readonly providerId: string;
   readonly model?: string;
@@ -232,6 +255,9 @@ export interface ManagedInvocationAgentCatalogEntry {
   readonly authorityProfile?: ManagedAgentAdmissionProfile;
   readonly skills?: readonly string[];
   readonly taskAffinity?: readonly ModelTaskSuitabilityTask[];
+  readonly economicPolicyId?: string;
+  readonly economicPolicyRevision?: string;
+  readonly economicPolicyCandidateRouteIds?: readonly string[];
   readonly routeId?: string;
   readonly providerRoute?: {
     readonly providerId: string;
@@ -301,6 +327,197 @@ export interface ManagedInvocationContextResolution {
 export type ManagedInvocationContextResolver = (
   input: ManagedInvocationContextResolverInput,
 ) => ManagedInvocationContextResolution | Promise<ManagedInvocationContextResolution>;
+
+export interface ManagedEconomicInvocationCommand {
+  readonly economicPolicyId: string;
+  readonly economicPolicyRevision: string;
+  readonly configuredAgentProfileId: string;
+  readonly admissionProfileId: ManagedAgentAdmissionProfile;
+  readonly routeId?: string;
+  readonly providerRoute?: ManagedAgentProviderRoute;
+  readonly callerIdentity?: ManagedAgentCallerAttachmentIdentity;
+  readonly requiredToolNames?: readonly string[];
+  readonly requiredReadPaths?: readonly string[];
+  readonly requestedAuthority?: ManagedAgentRequestedAuthority;
+  readonly requiresNetwork?: boolean;
+  readonly requiresWrite?: boolean;
+}
+
+type ManagedInvocationExecutableRoute = ManagedInvocationToolRoute & {
+  readonly adapter: ManagedAgentRuntimeAdapter;
+};
+
+export type ManagedEconomicCandidateRejectionReason =
+  | "not-in-policy"
+  | "caller-constraint-excluded"
+  | "non-economic-admission-failed"
+  | "economic-capability-unverified";
+
+export interface ManagedEconomicCandidateRejection {
+  readonly stage: "managed-candidate-admission";
+  readonly routeId: string;
+  readonly reason: ManagedEconomicCandidateRejectionReason;
+}
+
+export interface ManagedEconomicCandidateDescriptor {
+  readonly routeId: string;
+  readonly routeSource: ManagedAgentRouteSource;
+  readonly providerId: string;
+  readonly model?: string;
+  readonly accountPolicyId?: string;
+  readonly surface?: string;
+  readonly adapterCapabilityId: string;
+  readonly adapterCapabilityVersion: string;
+}
+
+export interface ManagedEconomicCandidateSet {
+  readonly economicPolicyId: string;
+  readonly economicPolicyRevision: string;
+  readonly admissionProfileId: ManagedAgentAdmissionProfile;
+  readonly constraints: {
+    readonly routeId?: string;
+    readonly providerId?: string;
+    readonly model?: string;
+  };
+  readonly candidates: readonly ManagedEconomicCandidateDescriptor[];
+  readonly rejections: readonly ManagedEconomicCandidateRejection[];
+}
+
+export function collectManagedEconomicCandidates(
+  command: ManagedEconomicInvocationCommand,
+  routes: readonly ManagedInvocationToolRoute[],
+  unavailableRoutes: readonly ManagedInvocationUnavailableRoute[] = [],
+): ManagedEconomicCandidateSet {
+  const policyRouteIds = new Set(
+    routes
+      .filter((route) => route.economicPolicyIds?.includes(command.economicPolicyId))
+      .map((route) => route.routeId),
+  );
+  const candidates: ManagedEconomicCandidateDescriptor[] = [];
+  const rejections: ManagedEconomicCandidateRejection[] = [];
+
+  for (const route of unavailableRoutes) {
+    rejections.push({
+      stage: "managed-candidate-admission",
+      routeId: route.routeId,
+      reason: route.economicPolicyIds?.includes(command.economicPolicyId)
+        ? "non-economic-admission-failed"
+        : "not-in-policy",
+    });
+  }
+
+  for (const route of routes) {
+    const profile = route.profiles[command.admissionProfileId];
+    const nonEconomicAdmissionFailed = (
+      !profile
+      || missingManagedInvocationRequiredTools(
+        command.requiredToolNames ?? [],
+        profile.allowedToolNames,
+      ).length > 0
+      || missingManagedInvocationRequiredCapabilities(
+        command.requiredToolNames ?? [],
+        profile,
+      ).length > 0
+      || missingManagedInvocationRequiredReadPaths(
+        command.requiredReadPaths ?? [],
+        profile,
+      ).length > 0
+      || (command.requiresNetwork === true && profile.networkAllowed !== true)
+      || (command.requiresWrite === true && profile.writeAllowed !== true)
+      || (
+        command.requestedAuthority !== undefined
+        && !validateManagedInvocationRequestedAuthority(
+          command.requestedAuthority,
+          command.admissionProfileId,
+          MANAGED_AGENT_INVOKE_TOOL_NAME,
+        ).ok
+      )
+      || (
+        command.callerIdentity !== undefined
+        && evaluateManagedInvocationCallerCapability({
+          callerIdentity: command.callerIdentity,
+          providerId: route.providerId,
+          ...(route.model ? { model: route.model } : {}),
+          adapterEvidence: {
+            adapterDescriptorId:
+              route.economicCapability?.status === "verified"
+                ? route.economicCapability.adapterCapabilityId
+                : "economic-capability-unverified",
+            adapterId: "kiln-managed-invocation",
+          },
+        }).decision === "denied"
+      )
+    );
+    if (nonEconomicAdmissionFailed) {
+      rejections.push({
+        stage: "managed-candidate-admission",
+        routeId: route.routeId,
+        reason: "non-economic-admission-failed",
+      });
+      continue;
+    }
+    const economicCapability = route.economicCapability;
+    if (economicCapability?.status !== "verified") {
+      rejections.push({
+        stage: "managed-candidate-admission",
+        routeId: route.routeId,
+        reason: "economic-capability-unverified",
+      });
+      continue;
+    }
+    let reason: ManagedEconomicCandidateRejectionReason | undefined;
+    if (!policyRouteIds.has(route.routeId)) {
+      reason = "not-in-policy";
+    } else if (
+      (command.routeId && route.routeId !== command.routeId)
+      || (command.providerRoute?.providerId && route.providerId !== command.providerRoute.providerId)
+      || (command.providerRoute?.model && route.model !== command.providerRoute.model)
+    ) {
+      reason = "caller-constraint-excluded";
+    }
+
+    if (reason) {
+      rejections.push({
+        stage: "managed-candidate-admission",
+        routeId: route.routeId,
+        reason,
+      });
+      continue;
+    }
+    candidates.push({
+      routeId: route.routeId,
+      routeSource: route.routeSource,
+      providerId: route.providerId,
+      ...(route.model ? { model: route.model } : {}),
+      ...(route.accountPolicyId ? { accountPolicyId: route.accountPolicyId } : {}),
+      ...(route.surface ? { surface: route.surface } : {}),
+      adapterCapabilityId: economicCapability.adapterCapabilityId,
+      adapterCapabilityVersion: economicCapability.adapterCapabilityVersion,
+    });
+  }
+
+  return {
+    economicPolicyId: command.economicPolicyId,
+    economicPolicyRevision: command.economicPolicyRevision,
+    admissionProfileId: command.admissionProfileId,
+    constraints: {
+      ...(command.routeId ? { routeId: command.routeId } : {}),
+      ...(command.providerRoute?.providerId ? { providerId: command.providerRoute.providerId } : {}),
+      ...(command.providerRoute?.model ? { model: command.providerRoute.model } : {}),
+    },
+    candidates,
+    rejections,
+  };
+}
+
+/**
+ * Slice 4 is the sole producer of this postcommit request. Declaring the
+ * boundary here prevents adapters from accepting precommit commands.
+ */
+export interface ManagedCommittedInvocationRequest {
+  readonly commitment: ManagedEconomicCommitment;
+  readonly dispatchFenceId: string;
+}
 
 interface ManagedInvocationToolInput {
   readonly profile: ManagedAgentAdmissionProfile;
@@ -575,7 +792,7 @@ export const MANAGED_AGENT_INVOKE_TOOL: ToolDefinition = {
         description: "Optional governed execution phase contract returned by work_item.execution.start. Pass it through unchanged when invoking the managed child.",
       },
     },
-    required: ["profile", "providerRoute", "task"],
+    required: ["profile", "task"],
     additionalProperties: false,
   },
   tags: new Set<string>(["managed-invocation", "operator-approval"]),
@@ -1118,6 +1335,23 @@ export function createManagedInvocationToolCallMetadataResolver(
       return undefined;
     }
     const agentProfile = resolveManagedInvocationAgentProfile(options, parsed.input.agentProfile);
+    if (agentProfile?.economicPolicyId && agentProfile.economicPolicyRevision) {
+      return {
+        kind: "managed-economic-invocation-precommit",
+        profile: parsed.input.profile,
+        economicPolicyId: agentProfile.economicPolicyId,
+        economicPolicyRevision: agentProfile.economicPolicyRevision,
+        ...(parsed.input.routeId ? { routeIdConstraint: parsed.input.routeId } : {}),
+        ...(parsed.input.providerRoute.providerId
+          ? {
+              providerRouteConstraint: {
+                providerId: parsed.input.providerRoute.providerId,
+                ...(parsed.input.providerRoute.model ? { model: parsed.input.providerRoute.model } : {}),
+              },
+            }
+          : {}),
+      };
+    }
     const agentRouteValidation = validateAgentRouteHint(parsed.input, agentProfile);
     if (!agentRouteValidation.ok) {
       return undefined;
@@ -1127,6 +1361,9 @@ export function createManagedInvocationToolCallMetadataResolver(
       return undefined;
     }
     const route = routeResolution.route;
+    if (!route.adapter) {
+      return undefined;
+    }
     const profileDefaults = route.profiles[parsed.input.profile];
     if (!profileDefaults) {
       return undefined;
@@ -1188,7 +1425,7 @@ interface PreparedManagedInvocationRequest {
   readonly context: RuntimeBuiltinToolExecutionContext;
   readonly parsed: ManagedInvocationToolInput;
   readonly canonicalizedRawInput: Record<string, unknown>;
-  readonly route: ManagedInvocationToolRoute;
+  readonly route: ManagedInvocationExecutableRoute;
   readonly request: ReturnType<typeof defineManagedAgentInvocationRequest>;
   readonly capabilitySnapshotInput: ManagedAgentCapabilitySnapshotInput;
   readonly canonicalizedForbiddenInputFields?: readonly string[];
@@ -1305,6 +1542,93 @@ async function prepareManagedInvocationRequest(
   }
 
   const agentProfile = resolveManagedInvocationAgentProfile(options, parsed.input.agentProfile);
+  if (agentProfile?.economicPolicyId && agentProfile.economicPolicyRevision) {
+    const authorityAdmission = validateManagedInvocationRequestedAuthority(
+      requestedAuthority,
+      parsed.input.profile,
+      toolName,
+    );
+    if (!authorityAdmission.ok) {
+      return {
+        ok: false,
+        result: errorResult(authorityAdmission.error, {
+          profile: parsed.input.profile,
+          requestedAuthority,
+          economicPolicyId: agentProfile.economicPolicyId,
+        }, toolName),
+      };
+    }
+    const contextResolution = await resolveInvocationContext(parsed.input, options, undefined);
+    if (!contextResolution.ok) {
+      return {
+        ok: false,
+        result: errorResult(contextResolution.error, {
+          profile: parsed.input.profile,
+          economicPolicyId: agentProfile.economicPolicyId,
+          status: contextResolution.status,
+          context: buildManagedInvocationContextMetadata(parsed.input, contextResolution.resolution),
+        }, toolName),
+      };
+    }
+    const authorityApproval = await requestManagedInvocationAuthorityApproval({
+      requestedAuthority,
+      target: {
+        kind: "economic-policy",
+        economicPolicyId: agentProfile.economicPolicyId,
+      },
+      profile: parsed.input.profile,
+      context,
+      toolName,
+    });
+    if (!authorityApproval.ok) {
+      return {
+        ok: false,
+        result: errorResult(authorityApproval.error, {
+          profile: parsed.input.profile,
+          requestedAuthority,
+          economicPolicyId: agentProfile.economicPolicyId,
+        }, toolName),
+      };
+    }
+    const candidateSet = collectManagedEconomicCandidates({
+      economicPolicyId: agentProfile.economicPolicyId,
+      economicPolicyRevision: agentProfile.economicPolicyRevision,
+      configuredAgentProfileId: agentProfile.name,
+      admissionProfileId: parsed.input.profile,
+      ...(parsed.input.routeId ? { routeId: parsed.input.routeId } : {}),
+        ...(parsed.input.providerRoute.providerId
+          ? { providerRoute: parsed.input.providerRoute }
+          : {}),
+      callerIdentity,
+      ...(parsed.input.requiredToolNames
+        ? { requiredToolNames: parsed.input.requiredToolNames }
+        : {}),
+      ...(parsed.input.requiredReadPaths
+        ? { requiredReadPaths: parsed.input.requiredReadPaths }
+        : {}),
+      requestedAuthority,
+      requiresNetwork: (parsed.input.requiredToolNames ?? []).some(requiresNetworkCapability),
+      requiresWrite: parsed.input.profile !== "foundation-readonly-plan",
+    }, options.routes, options.unavailableRoutes);
+    return {
+      ok: false,
+      result: errorResult(
+        "Managed economic invocation requires a durable route commitment before execution.",
+        {
+          errorCode: "economic_commitment_unavailable",
+          status: "denied",
+          candidateSet,
+        },
+        toolName,
+      ),
+    };
+  }
+  if (!parsed.input.providerRoute.providerId) {
+    return {
+      ok: false,
+      result: errorResult(`${toolName} requires providerRoute.providerId for a fixed-route invocation.`, {}, toolName),
+    };
+  }
   const agentRouteValidation = validateAgentRouteHint(parsed.input, agentProfile, toolName);
   if (!agentRouteValidation.ok) {
     const recovery = buildRouteProfileConflictRecovery(parsed.input, agentRouteValidation, context, toolName);
@@ -1355,6 +1679,20 @@ async function prepareManagedInvocationRequest(
     };
   }
   const route = routeResolution.route;
+  if (!route.adapter) {
+    return {
+      ok: false,
+      result: errorResult(
+        "Managed invocation requires a durable economic commitment before adapter construction.",
+        { errorCode: "economic_commitment_unavailable", status: "denied" },
+        toolName,
+      ),
+    };
+  }
+  const executableRoute: ManagedInvocationExecutableRoute = {
+    ...route,
+    adapter: route.adapter,
+  };
   const invocationCapabilityEvidence = evaluateManagedInvocationCallerCapability({
     callerIdentity,
     providerId: route.providerId,
@@ -1619,7 +1957,7 @@ async function prepareManagedInvocationRequest(
   const contextMetadata = buildManagedInvocationContextMetadata(parsed.input, contextResolution.resolution);
   const authorityApproval = await requestManagedInvocationAuthorityApproval({
     requestedAuthority,
-    routeId: route.routeId,
+    target: { kind: "route", routeId: route.routeId },
     profile: parsed.input.profile,
     context,
     toolName,
@@ -1708,7 +2046,7 @@ async function prepareManagedInvocationRequest(
       context,
       parsed: parsed.input,
       canonicalizedRawInput: canonicalizedRawInput.input,
-      route,
+      route: executableRoute,
       request,
       capabilitySnapshotInput: {
         routeId: route.routeId,
@@ -2537,6 +2875,7 @@ function eligibleManagedOrchestrationRoutes(
     return routeProfile !== undefined
       && routeProfile.workingDirectory.mode !== "workspace-write"
       && (routeProfile.workingDirectory.mode !== "isolated-worktree" || routeProfile.workingDirectoryLease !== undefined)
+      && route.adapter !== undefined
       && route.adapter.descriptor.lifecycle.exposesStart
       && route.adapter.descriptor.lifecycle.exposesTerminal;
   });
@@ -3470,7 +3809,7 @@ function buildManagedRouteCatalogDescription(options: ManagedInvocationToolOptio
         .map((route) => {
           const suitability = formatTaskSuitability(route.taskSuitability, managedInvocationSkillNames(options));
           const timeoutSummary = formatRouteTimeoutSummary(route.profiles);
-          return `- ${route.routeId}: routeSource=${route.routeSource}, providerRoute.providerId=${route.providerId}${route.model ? `, model=${route.model}` : ""}, surface=${route.surface ?? route.adapter.descriptor.supportedExecutionModes[0] ?? "configured"}, profiles=${Object.keys(route.profiles).join(",")}${timeoutSummary ? `, ${timeoutSummary}` : ""}${suitability ? `, taskSuitability=${suitability}` : ""}`;
+          return `- ${route.routeId}: routeSource=${route.routeSource}, providerRoute.providerId=${route.providerId}${route.model ? `, model=${route.model}` : ""}, surface=${route.surface ?? route.adapter?.descriptor.supportedExecutionModes[0] ?? "configured"}, profiles=${Object.keys(route.profiles).join(",")}${timeoutSummary ? `, ${timeoutSummary}` : ""}${suitability ? `, taskSuitability=${suitability}` : ""}`;
         })
         .join("\n")
     : "- none";
@@ -3734,10 +4073,7 @@ function parseInput(
     return { ok: false, error: `${toolName} profile is not supported.` };
   }
   const providerRoute = readRecord(input.providerRoute);
-  const providerId = readText(providerRoute?.providerId);
-  if (!providerId) {
-    return { ok: false, error: `${toolName} requires providerRoute.providerId.` };
-  }
+  const providerId = readText(providerRoute?.providerId) ?? "";
   const task = readText(input.task);
   if (!task) {
     return { ok: false, error: `${toolName} requires task.` };
@@ -4044,7 +4380,9 @@ function validateManagedInvocationRequestedAuthority(
 
 async function requestManagedInvocationAuthorityApproval(input: {
   readonly requestedAuthority: ManagedAgentRequestedAuthority;
-  readonly routeId: string;
+  readonly target:
+    | { readonly kind: "route"; readonly routeId: string }
+    | { readonly kind: "economic-policy"; readonly economicPolicyId: string };
   readonly profile: ManagedAgentAdmissionProfile;
   readonly context: RuntimeBuiltinToolExecutionContext;
   readonly toolName?: string;
@@ -4063,7 +4401,10 @@ async function requestManagedInvocationAuthorityApproval(input: {
     };
   }
 
-  const description = `${toolName} requests destructive authority for route '${input.routeId}' and profile '${input.profile}'.`;
+  const authorityTarget = input.target.kind === "route"
+    ? `route '${input.target.routeId}'`
+    : `economic policy '${input.target.economicPolicyId}'`;
+  const description = `${toolName} requests destructive authority for ${authorityTarget} and profile '${input.profile}'.`;
   const approval = await input.context.requestApproval(description);
   if (!approval.approved) {
     return {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -193,6 +193,7 @@ export {
   OpenCodeCredentialPoolService,
   isHarnessPoolProviderId,
   isPooledDirectProviderId,
+  listOverPermissiveCredentialFiles,
   mapCodexOAuthProviderError,
   mapDirectProviderError,
   mapOpenCodeProviderError,
@@ -209,6 +210,7 @@ export type {
   CredentialFileStoreConfig,
   CredentialHealthRecord,
   CredentialHealthStoreConfig,
+  CredentialPermissionDiagnosticConfig,
   CredentialPoolFactoryConfig,
   CredentialWatcherConfig,
   CredentialWatcherListener,
@@ -226,6 +228,7 @@ export type {
   LinkOpenCodeCredentialOptions,
   OpenCodeCredentialPoolServiceConfig,
   OpenCodeCredentialStatus,
+  OverPermissiveCredentialFile,
   PooledDirectProviderId,
   RuntimeCredentialFile,
   WriteRuntimeCredential,
@@ -339,6 +342,12 @@ export type {
   ManagedAgentOrchestrationLifecycleInput,
   ManagedAgentOrchestrationLifecycleResult,
   ManagedAgentOrchestrationLifecycleRouteSelector,
+  ManagedCommittedInvocationRequest,
+  ManagedEconomicCandidateDescriptor,
+  ManagedEconomicCandidateRejection,
+  ManagedEconomicCandidateRejectionReason,
+  ManagedEconomicCandidateSet,
+  ManagedEconomicInvocationCommand,
   ManagedInvocationContextResolution,
   ManagedInvocationContextResolver,
   ManagedInvocationContextResolverInput,
@@ -350,12 +359,12 @@ export type {
   ManagedInvocationToolRoute,
 } from "./agents/managed-invocation/index.js";
 export { createProviderCatalogService } from "./gateway/provider-catalog-service.js";
+export { collectManagedEconomicCandidates } from "./agents/managed-invocation/index.js";
 export {
   FilesystemManagedJobStore,
   InMemoryManagedJobStore,
   ManagedJobApplicationError,
   ManagedJobApplicationService,
-  createRuntimeManagedJobInvocationPort,
 } from "./managed-jobs/index.js";
 export type {
   ManagedJobDiagnosticCode,
@@ -367,11 +376,7 @@ export type {
   ManagedJobLifecycleEntry,
   ManagedJobRecord,
   ManagedJobReplayQuery,
-  ManagedJobRoute,
   ManagedJobRoutePort,
-  ManagedJobRuntimeInvocationPort,
-  ManagedJobRuntimeInvocationResolver,
-  ManagedJobRuntimeResult,
   ManagedJobResult,
   ManagedJobResultAvailability,
   ManagedJobResultQuery,

--- a/packages/runtime/src/managed-jobs/index.ts
+++ b/packages/runtime/src/managed-jobs/index.ts
@@ -4,16 +4,12 @@ import { resolve } from "node:path";
 import {
   defineManagedAccountLeaseEvidence,
   type ManagedAccountLeaseEvidence,
-  type ManagedAgentAuthorityProfile,
-  type ManagedAgentCapabilitySnapshotInput,
-  type ManagedAgentInvocationRequest,
+  type ManagedAgentAdmissionProfile,
   type ManagedAgentResultHandoff,
 } from "@kilnai/core";
-import {
-  ManagedAccountLeaseUnavailableError,
-  RuntimeManagedAgentInvocationService,
-} from "../agents/managed-invocation/index.js";
-import type { ManagedAgentRuntimeAdapter } from "../agents/managed-invocation/index.js";
+import type {
+  ManagedEconomicCandidateSet,
+} from "../agents/managed-invocation/runtime-tool.js";
 
 export const MANAGED_JOB_STATES = ["queued", "running", "succeeded", "failed", "timed_out", "interrupted", "cancelled"] as const;
 export type ManagedJobState = typeof MANAGED_JOB_STATES[number];
@@ -44,6 +40,7 @@ export type ManagedJobDiagnosticCode =
   | "provider_rejected"
   | "provider_timeout"
   | "account_lease_unavailable"
+  | "economic_commitment_unavailable"
   | "invocation_failed"
   | "unauthorized_job"
   | "result_pending"
@@ -79,34 +76,18 @@ export interface ManagedJobGovernanceEvidence {
   readonly validUntil: string;
 }
 
-/** Operator-configured child identity; it requests a specific canonical route. */
-export interface ManagedJobProfile {
+export interface ManagedJobEconomicProfile {
   readonly id: string;
-  readonly routeId: string;
-}
-export interface ManagedJobRoute {
-  readonly id: string;
-  readonly accountPolicyId: string;
-  readonly admissionProfileId: string;
-  readonly supportedAdmissionProfileIds: readonly string[];
-  readonly providerId: string;
-  readonly timeoutSource: "default" | "explicit-route";
-  /** Canonical route evidence, validated before a managed job may be reserved. */
-  readonly scope: {
-    readonly project: "validated";
-    readonly read: "validated";
-    readonly tools: "validated";
-    readonly network: "validated";
-    readonly write: "validated";
+  readonly economicPolicyId: string;
+  readonly economicPolicyRevision: string;
+  readonly admissionProfileId: ManagedAgentAdmissionProfile;
+  readonly constraints?: {
+    readonly routeId?: string;
+    readonly providerId?: string;
+    readonly model?: string;
   };
-  readonly eligibility: {
-    readonly authority: "authoritative";
-    readonly observedAt: string;
-    readonly validUntil: string;
-  };
-  readonly authority: ManagedAgentAuthorityProfile;
 }
-
+export type ManagedJobProfile = ManagedJobEconomicProfile;
 interface ManagedJobRecordBase {
   readonly id: string;
   readonly state: ManagedJobState;
@@ -117,7 +98,7 @@ interface ManagedJobRecordBase {
   readonly providerId: string;
   readonly governanceSource: string;
   readonly admissionId: string;
-  readonly timeoutSource: ManagedJobRoute["timeoutSource"];
+  readonly timeoutSource: "default" | "explicit-route";
   readonly requestFingerprint: string;
   readonly idempotencyKeyHash: string;
   readonly createdAt: string;
@@ -164,7 +145,34 @@ export interface ManagedJobRecordV4 extends Omit<ManagedJobRecordV3, "version"> 
   readonly accountLeaseHistory: readonly ManagedAccountLeaseEvidence[];
 }
 
-export type ManagedJobRecord = ManagedJobRecordV3 | ManagedJobRecordV4;
+export interface ManagedJobRecordV5 {
+  readonly version: 5;
+  readonly id: string;
+  readonly state: ManagedJobState;
+  readonly projectId: string;
+  readonly callerId: string;
+  readonly configuredAgentProfileId: string;
+  readonly admissionProfileId: ManagedAgentAdmissionProfile;
+  readonly economicPolicyId: string;
+  readonly economicPolicyRevision: string;
+  readonly constraints: {
+    readonly routeId?: string;
+    readonly providerId?: string;
+    readonly model?: string;
+  };
+  readonly candidateSet: ManagedEconomicCandidateSet;
+  readonly governanceSource: string;
+  readonly admissionId: string;
+  readonly requestFingerprint: string;
+  readonly idempotencyKeyHash: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly parent?: { readonly invocationId: string; readonly turnId: string };
+  readonly diagnostic?: ManagedJobDiagnosticCode;
+  readonly lifecycle: readonly ManagedJobLifecycleEntry[];
+}
+
+export type ManagedJobRecord = ManagedJobRecordV3 | ManagedJobRecordV4 | ManagedJobRecordV5;
 export type ManagedJobResultAvailability = "pending" | "available" | "unavailable" | "failed" | "unresolved";
 export interface ManagedJobResultQuery {
   readonly jobId: string;
@@ -172,8 +180,8 @@ export interface ManagedJobResultQuery {
   readonly lifecycleState: ManagedJobState;
   readonly configuredAgentProfileId: string;
   readonly admissionProfileId: string;
-  readonly routeId: string;
-  readonly providerId: string;
+  readonly routeId?: string;
+  readonly providerId?: string;
   readonly completedAt?: string;
   readonly provenance?: ManagedJobResult["provenance"];
   readonly handoff?: ManagedAgentResultHandoff;
@@ -187,8 +195,8 @@ export interface ManagedJobReplayQuery {
   readonly lifecycleState: ManagedJobState;
   readonly configuredAgentProfileId: string;
   readonly admissionProfileId: string;
-  readonly routeId: string;
-  readonly providerId: string;
+  readonly routeId?: string;
+  readonly providerId?: string;
   readonly lifecycle: readonly ManagedJobLifecycleEntry[];
   readonly resultAvailability: ManagedJobResultAvailability;
   readonly diagnostic?: ManagedJobDiagnosticCode;
@@ -202,91 +210,16 @@ export interface ManagedJobGovernancePort {
   admit(input: { readonly project: TrustedManagedJobProject; readonly objective: string; readonly configuredAgentProfileId: string; readonly admissionProfileId: string; readonly evidence: ManagedJobGovernanceEvidence }): Promise<{ readonly admitted: true; readonly admissionId: string; readonly source: string } | { readonly admitted: false }>;
 }
 export interface ManagedJobProfilePort { resolve(id: string): Promise<ManagedJobProfile | undefined>; }
-export interface ManagedJobRoutePort { resolve(profile: ManagedJobProfile): Promise<ManagedJobRoute | undefined>; }
-export interface ManagedJobRuntimeInvocationPort {
-  invoke(input: { readonly jobId: string; readonly project: TrustedManagedJobProject; readonly objective: string; readonly profile: ManagedJobProfile; readonly route: ManagedJobRoute; readonly parent?: ManagedJobSubmission["parent"]; readonly accountLeaseObserver: (evidence: ManagedAccountLeaseEvidence) => Promise<void> }): Promise<
-    | { readonly state: "succeeded"; readonly result?: ManagedJobRuntimeResult }
-    | { readonly state: "failed" | "timed_out" }
-  >;
-  cancel?(input: { readonly jobId: string; readonly reason: string }): Promise<void>;
+export interface ManagedJobRoutePort {
+  resolve(profile: ManagedJobProfile): Promise<ManagedEconomicCandidateSet | undefined>;
 }
-/** Safe Runtime completion evidence; it deliberately excludes record transcripts, prompts, diagnostics, and provider payloads. */
-export interface ManagedJobRuntimeResult {
-  readonly runtimeInvocationId: string;
-  readonly configuredAgentProfileId: string;
-  readonly admissionProfileId: string;
-  readonly routeId: string;
-  readonly providerId: string;
-  readonly terminalState: "completed";
-  readonly resultHandoff: ManagedAgentResultHandoff;
-}
-export interface ManagedJobRuntimeInvocationResolver {
-  resolve(input: Parameters<ManagedJobRuntimeInvocationPort["invoke"]>[0]): Promise<{
-    readonly request: ManagedAgentInvocationRequest;
-    readonly adapter: ManagedAgentRuntimeAdapter;
-    readonly capabilitySnapshot: ManagedAgentCapabilitySnapshotInput;
-  }>;
-}
-
-/** Connects the application boundary to Runtime's existing managed-agent owner. */
-export function createRuntimeManagedJobInvocationPort(input: {
-  readonly service: RuntimeManagedAgentInvocationService;
-  readonly resolver: ManagedJobRuntimeInvocationResolver;
-}): ManagedJobRuntimeInvocationPort {
-  return {
-    async invoke(invocation) {
-      const resolved = await input.resolver.resolve(invocation);
-      if (resolved.request.invocationId !== invocation.jobId) throw new ManagedJobApplicationError("invocation_failed", "Bind the Runtime invocation identity to the canonical managed-job identifier.");
-      const result = await input.service.invoke(
-        resolved.request,
-        resolved.adapter,
-        resolved.capabilitySnapshot,
-        {
-          accountLeaseObserver: invocation.accountLeaseObserver,
-        },
-      ).catch((error: unknown) => {
-        if (error instanceof ManagedAccountLeaseUnavailableError) {
-          throw new ManagedJobApplicationError(
-            "account_lease_unavailable",
-            "Wait for managed account settlement or repair account eligibility evidence.",
-          );
-        }
-        throw error;
-      });
-      if (result.status === "denied") throw new ManagedJobApplicationError("provider_rejected", "Review the Runtime managed-agent admission diagnostic.");
-      const record = result.record;
-      return {
-        state: result.record.lifecycleState === "completed" ? "succeeded"
-          : result.record.lifecycleState === "timed_out" ? "timed_out"
-            : "failed",
-        ...(record.lifecycleState === "completed" && record.resultHandoff !== undefined
-          ? {
-              result: {
-                runtimeInvocationId: record.invocationId,
-                configuredAgentProfileId: invocation.profile.id,
-                admissionProfileId: record.profile,
-                routeId: record.capabilitySnapshot.routeId,
-                providerId: record.providerRoute.providerId,
-                terminalState: "completed" as const,
-                resultHandoff: record.resultHandoff,
-              },
-            }
-          : {}),
-      };
-    },
-    async cancel(cancellation) {
-      await input.service.cancel(cancellation.jobId, cancellation.reason);
-    },
-  };
-}
-
 export type ManagedJobReservation =
   | { readonly kind: "created"; readonly job: ManagedJobRecord }
   | { readonly kind: "existing"; readonly job: ManagedJobRecord }
   | { readonly kind: "conflict" };
 
 export interface ManagedJobStore {
-  reserve(input: { readonly job: ManagedJobRecord }): Promise<ManagedJobReservation>;
+  reserve(input: { readonly job: ManagedJobRecordV5 }): Promise<ManagedJobReservation>;
   get(id: string): Promise<ManagedJobRecord | undefined>;
   transition(id: string, state: ManagedJobState, diagnostic?: ManagedJobDiagnosticCode, updatedAt?: string): Promise<ManagedJobRecord>;
   completeSuccess(id: string, result: ManagedJobResult, updatedAt?: string): Promise<ManagedJobRecord>;
@@ -299,7 +232,6 @@ export interface ManagedJobApplicationOptions {
   readonly governance: ManagedJobGovernancePort;
   readonly profiles: ManagedJobProfilePort;
   readonly routes: ManagedJobRoutePort;
-  readonly runtime: ManagedJobRuntimeInvocationPort;
   readonly lineage?: { validate(input: { readonly project: TrustedManagedJobProject; readonly callerId: string; readonly parent: NonNullable<ManagedJobSubmission["parent"]> }): Promise<boolean> };
   readonly store: ManagedJobStore;
   readonly clock?: () => Date;
@@ -309,7 +241,6 @@ export interface ManagedJobApplicationOptions {
 export class ManagedJobApplicationService {
   private readonly clock: () => Date;
   private readonly idGenerator: () => string;
-  private readonly activeExecutions = new Map<string, Promise<ManagedJobRecord>>();
 
   constructor(private readonly options: ManagedJobApplicationOptions) {
     this.clock = options.clock ?? (() => new Date());
@@ -317,10 +248,7 @@ export class ManagedJobApplicationService {
   }
 
   async submit(input: unknown): Promise<ManagedJobRecord> {
-    const started = await this.start(input);
-    const active = this.activeExecutions.get(started.id);
-    if (active) return active;
-    return await this.options.store.get(started.id) ?? started;
+    return await this.start(input);
   }
 
   async start(input: unknown): Promise<ManagedJobRecord> {
@@ -331,87 +259,97 @@ export class ManagedJobApplicationService {
     let profile: ManagedJobProfile | undefined;
     try { profile = await this.options.profiles.resolve(request.configuredAgentProfileId); } catch { throw new ManagedJobApplicationError("profile_unavailable", "Choose a configured admitted agent profile."); }
     if (!profile) throw new ManagedJobApplicationError("profile_unavailable", "Choose a configured admitted agent profile.");
-    if (!isIdentifier(profile.id) || profile.id !== request.configuredAgentProfileId || !isIdentifier(profile.routeId)) throw new ManagedJobApplicationError("profile_unavailable", "Choose a configured admitted agent profile.");
-    let route: ManagedJobRoute | undefined;
-    try { route = await this.options.routes.resolve(profile); } catch { throw new ManagedJobApplicationError("route_unavailable", "Configure an admitted managed-agent route."); }
-    if (!route || !isAdmittedRoute(route, profile, this.clock())) throw new ManagedJobApplicationError("route_unavailable", "Configure an admitted managed-agent route.");
-    let admission: Awaited<ReturnType<ManagedJobGovernancePort["admit"]>>;
-    try { admission = await this.options.governance.admit({ project, objective: request.objective, configuredAgentProfileId: profile.id, admissionProfileId: route.admissionProfileId, evidence: governance }); }
-    catch { throw new ManagedJobApplicationError("governance_unavailable", "Restore authoritative Kiln governance evidence."); }
-    if (!admission.admitted) throw new ManagedJobApplicationError("admission_denied", "Review the authoritative work-governance policy.");
-    if (!isIdentifier(admission.admissionId) || !isIdentifier(admission.source)) throw new ManagedJobApplicationError("governance_not_authoritative", "Refresh authoritative Kiln governance evidence.");
+    if (!isIdentifier(profile.id) || profile.id !== request.configuredAgentProfileId) throw new ManagedJobApplicationError("profile_unavailable", "Choose a configured admitted agent profile.");
+    return await this.startEconomicPrecommit(request, project, governance, profile);
+  }
 
+  private async startEconomicPrecommit(
+    request: ManagedJobSubmission,
+    project: TrustedManagedJobProject,
+    governance: ManagedJobGovernanceEvidence,
+    profile: ManagedJobEconomicProfile,
+  ): Promise<ManagedJobRecordV5> {
+    if (!isValidEconomicManagedJobProfile(profile)) {
+      throw new ManagedJobApplicationError("profile_unavailable", "Choose a configured admitted economic policy profile.");
+    }
+    let admission: Awaited<ReturnType<ManagedJobGovernancePort["admit"]>>;
+    try {
+      admission = await this.options.governance.admit({
+        project,
+        objective: request.objective,
+        configuredAgentProfileId: profile.id,
+        admissionProfileId: profile.admissionProfileId,
+        evidence: governance,
+      });
+    } catch {
+      throw new ManagedJobApplicationError("governance_unavailable", "Restore authoritative Kiln governance evidence.");
+    }
+    if (!admission.admitted) throw new ManagedJobApplicationError("admission_denied", "Review the authoritative work-governance policy.");
+    if (!isIdentifier(admission.admissionId) || !isIdentifier(admission.source)) {
+      throw new ManagedJobApplicationError("governance_not_authoritative", "Refresh authoritative Kiln governance evidence.");
+    }
+    let candidateSet: ManagedEconomicCandidateSet | undefined;
+    try {
+      const resolved = await this.options.routes.resolve(profile);
+      if (isManagedEconomicCandidateSet(resolved)) candidateSet = resolved;
+    } catch {
+      throw new ManagedJobApplicationError("route_unavailable", "Refresh managed economic candidate admission.");
+    }
+    if (
+      !candidateSet
+      || candidateSet.economicPolicyId !== profile.economicPolicyId
+      || candidateSet.economicPolicyRevision !== profile.economicPolicyRevision
+      || candidateSet.admissionProfileId !== profile.admissionProfileId
+      || !sameManagedJobConstraints(candidateSet.constraints, profile.constraints ?? {})
+    ) {
+      throw new ManagedJobApplicationError("route_unavailable", "Refresh managed economic candidate admission.");
+    }
     const now = this.now();
-    const requestFingerprint = fingerprint({ objective: request.objective, configuredAgentProfileId: request.configuredAgentProfileId, parent: request.parent });
-    const job: ManagedJobRecordV4 = {
-      version: 4,
+    const constraints = normalizeManagedJobConstraints(profile.constraints);
+    const requestFingerprint = fingerprint({
+      objective: request.objective,
+      configuredAgentProfileId: request.configuredAgentProfileId,
+      economicPolicyId: profile.economicPolicyId,
+      economicPolicyRevision: profile.economicPolicyRevision,
+      constraints,
+      parent: request.parent,
+    });
+    const queued: ManagedJobRecordV5 = {
+      version: 5,
       id: this.newJobId(),
       state: "queued",
       projectId: project.id,
       callerId: request.callerId,
       configuredAgentProfileId: profile.id,
-      admissionProfileId: route.admissionProfileId,
-      routeId: route.id,
-      providerId: route.providerId,
+      admissionProfileId: profile.admissionProfileId,
+      economicPolicyId: profile.economicPolicyId,
+      economicPolicyRevision: profile.economicPolicyRevision,
+      constraints,
+      candidateSet,
       governanceSource: admission.source,
       admissionId: admission.admissionId,
-      timeoutSource: route.timeoutSource,
       requestFingerprint,
-      idempotencyKeyHash: fingerprint({ projectId: project.id, callerId: request.callerId, idempotencyKey: request.idempotencyKey }),
+      idempotencyKeyHash: fingerprint({
+        projectId: project.id,
+        callerId: request.callerId,
+        idempotencyKey: request.idempotencyKey,
+      }),
       createdAt: now,
       updatedAt: now,
       lifecycle: [{ sequence: 1, state: "queued", observedAt: now }],
-      accountLeaseHistory: [],
       ...(request.parent ? { parent: request.parent } : {}),
     };
-    const reservation = await this.reserve(job);
+    const reservation = await this.reserve(queued);
     if (reservation.kind === "conflict") throw new ManagedJobApplicationError("idempotency_conflict", "Use a new idempotency identity for different managed work.");
-    if (reservation.kind === "existing") return reservation.job;
-
-    const running = await this.transition(job.id, "running");
-    const execution = this.execute(running, project, request, profile, route);
-    this.activeExecutions.set(running.id, execution);
-    void execution.finally(() => {
-      if (this.activeExecutions.get(running.id) === execution) this.activeExecutions.delete(running.id);
-    }).catch(() => undefined);
-    return running;
-  }
-
-  private async execute(
-    running: ManagedJobRecord,
-    project: TrustedManagedJobProject,
-    request: ManagedJobSubmission,
-    profile: ManagedJobProfile,
-    route: ManagedJobRoute,
-  ): Promise<ManagedJobRecord> {
-    try {
-      const result = await this.options.runtime.invoke({
-        jobId: running.id,
-        project,
-        objective: request.objective,
-        profile,
-        route,
-        accountLeaseObserver: async (evidence) => {
-          await this.options.store.recordAccountLease(running.id, evidence, this.now());
-        },
-        ...(request.parent ? { parent: request.parent } : {}),
-      });
-      const current = await this.options.store.get(running.id);
-      if (current?.state === "cancelled") return current;
-      if (current?.version !== 4 || current.accountLease === undefined) {
-        return this.transition(running.id, "failed", "account_lease_unavailable");
-      }
-      if (result.state === "succeeded") {
-        if (!result.result) return this.transition(running.id, "failed", "result_persistence_failure");
-        return await this.completeSuccess(running, result.result, request.objective);
-      }
-      return this.transition(running.id, result.state, result.state === "timed_out" ? "provider_timeout" : "provider_rejected");
-    } catch (error) {
-      const current = await this.options.store.get(running.id).catch(() => undefined);
-      if (current?.state === "cancelled") return current;
-      const diagnostic = error instanceof ManagedJobApplicationError ? error.code : "invocation_failed";
-      return this.transition(running.id, diagnostic === "provider_timeout" ? "timed_out" : "failed", diagnostic);
+    if (reservation.kind === "existing") {
+      if (reservation.job.version !== 5) throw new ManagedJobApplicationError("idempotency_conflict", "Use a new idempotency identity for different managed work.");
+      return reservation.job;
     }
+    return await this.transition(
+      queued.id,
+      "failed",
+      "economic_commitment_unavailable",
+    ) as ManagedJobRecordV5;
   }
 
   async getStatus(context: TrustedManagedJobQueryContext, id: string): Promise<ManagedJobRecord> {
@@ -428,6 +366,7 @@ export class ManagedJobApplicationService {
     const job = await this.getStatus(context, id);
     if (job.state === "queued" || job.state === "running") return resultQuery(job, "pending", "result_pending");
     if (job.state !== "succeeded") return resultQuery(job, "failed", job.diagnostic ?? "invocation_failed");
+    if (job.version === 5) return resultQuery(job, "unresolved", "result_persistence_failure");
     if (!job.result) return resultQuery(job, "unresolved", "result_persistence_failure");
     return resultQuery(job, "available");
   }
@@ -437,14 +376,10 @@ export class ManagedJobApplicationService {
     if (job.state !== "queued" && job.state !== "running") {
       throw new ManagedJobApplicationError("invalid_transition", "Cancel only active managed work.");
     }
-    const reason = "Operator cancelled managed work.";
-    try {
-      if (!this.options.runtime.cancel) throw new Error("cancellation unavailable");
-      await this.options.runtime.cancel({ jobId: id, reason });
-    } catch {
-      throw new ManagedJobApplicationError("invocation_failed", "Retry cancellation while the managed Runtime invocation is active.");
-    }
-    return this.transition(id, "cancelled", "cancelled");
+    throw new ManagedJobApplicationError(
+      "invocation_failed",
+      "Historical active records have no live Runtime ownership after recovery.",
+    );
   }
 
   async getReplay(context: TrustedManagedJobQueryContext, id: string): Promise<ManagedJobReplayQuery> {
@@ -458,7 +393,9 @@ export class ManagedJobApplicationService {
   async recoverInterrupted(): Promise<readonly ManagedJobRecord[]> {
     try {
       const jobs = await this.options.store.listNonterminal();
-      return Promise.all(jobs.map((job) => this.transition(job.id, "interrupted", "invocation_failed")));
+      return Promise.all(jobs.map((job) => job.version === 5
+        ? this.transition(job.id, "failed", "economic_commitment_unavailable")
+        : this.transition(job.id, "interrupted", "invocation_failed")));
     } catch (error) { throw normalizeStoreError(error); }
   }
 
@@ -489,18 +426,12 @@ export class ManagedJobApplicationService {
     return evidence;
   }
 
-  private async reserve(job: ManagedJobRecord): Promise<ManagedJobReservation> {
+  private async reserve(job: ManagedJobRecordV5): Promise<ManagedJobReservation> {
     try { return await this.options.store.reserve({ job }); } catch (error) { throw normalizeStoreError(error); }
   }
 
   private async transition(id: string, state: ManagedJobState, diagnostic?: ManagedJobDiagnosticCode): Promise<ManagedJobRecord> {
     try { return await this.options.store.transition(id, state, diagnostic, this.now()); } catch (error) { throw normalizeStoreError(error); }
-  }
-
-  private async completeSuccess(job: ManagedJobRecord, runtimeResult: ManagedJobRuntimeResult, objective: string): Promise<ManagedJobRecord> {
-    const completedAt = this.now();
-    const result = createManagedJobResult(job, runtimeResult, completedAt, objective);
-    try { return await this.options.store.completeSuccess(job.id, result, completedAt); } catch (error) { throw normalizeStoreError(error); }
   }
 
   private authorizeQuery(context: TrustedManagedJobQueryContext, job: ManagedJobRecord): void {
@@ -522,17 +453,36 @@ export class ManagedJobApplicationService {
 export class InMemoryManagedJobStore implements ManagedJobStore {
   private readonly jobs = new Map<string, ManagedJobRecord>();
   private readonly bindings = new Map<string, { readonly fingerprint: string; readonly jobId: string }>();
-  async reserve(input: { readonly job: ManagedJobRecord }): Promise<ManagedJobReservation> {
-    const binding = this.bindings.get(input.job.idempotencyKeyHash);
-    if (binding) {
-      if (binding.fingerprint !== input.job.requestFingerprint) return { kind: "conflict" };
-      const job = this.jobs.get(binding.jobId);
-      if (!job) throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
-      return { kind: "existing", job: cloneManagedJob(job) };
+
+  constructor(storedJobs: readonly unknown[] = []) {
+    for (const storedJob of storedJobs) {
+      const job = validateStoredJob(storedJob);
+      if (this.jobs.has(job.id) || this.bindings.has(job.idempotencyKeyHash)) {
+        throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
+      }
+      this.jobs.set(job.id, cloneManagedJob(job));
+      this.bindings.set(job.idempotencyKeyHash, {
+        fingerprint: job.requestFingerprint,
+        jobId: job.id,
+      });
     }
-    this.jobs.set(input.job.id, cloneManagedJob(input.job));
-    this.bindings.set(input.job.idempotencyKeyHash, { fingerprint: input.job.requestFingerprint, jobId: input.job.id });
-    return { kind: "created", job: cloneManagedJob(input.job) };
+  }
+
+  async reserve(input: { readonly job: ManagedJobRecordV5 }): Promise<ManagedJobReservation> {
+    const job = validateStoredJob(input.job);
+    if (job.version !== 5) {
+      throw new ManagedJobApplicationError("invalid_request", "Create only canonical V5 managed jobs.");
+    }
+    const binding = this.bindings.get(job.idempotencyKeyHash);
+    if (binding) {
+      if (binding.fingerprint !== job.requestFingerprint) return { kind: "conflict" };
+      const existing = this.jobs.get(binding.jobId);
+      if (!existing) throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
+      return { kind: "existing", job: cloneManagedJob(existing) };
+    }
+    this.jobs.set(job.id, cloneManagedJob(job));
+    this.bindings.set(job.idempotencyKeyHash, { fingerprint: job.requestFingerprint, jobId: job.id });
+    return { kind: "created", job: cloneManagedJob(job) };
   }
   async get(id: string): Promise<ManagedJobRecord | undefined> { const job = this.jobs.get(id); return job ? cloneManagedJob(job) : undefined; }
   async transition(id: string, state: ManagedJobState, diagnostic?: ManagedJobDiagnosticCode, updatedAt?: string): Promise<ManagedJobRecord> {
@@ -554,6 +504,7 @@ export class InMemoryManagedJobStore implements ManagedJobStore {
   async completeSuccess(id: string, result: ManagedJobResult, updatedAt?: string): Promise<ManagedJobRecord> {
     const current = this.jobs.get(id);
     if (!current) throw new ManagedJobApplicationError("unknown_job", "Verify the managed-job identifier.");
+    if (current.version === 5) throw new ManagedJobApplicationError("invalid_transition", "V5 precommit jobs cannot contain execution results.");
     if (current.state !== "running" || current.result !== undefined) throw new ManagedJobApplicationError("invalid_transition", "Keep terminal managed-job results immutable.");
     const timestamp = updatedAt ?? new Date().toISOString();
     if (!isIso(timestamp) || Date.parse(timestamp) < Date.parse(current.updatedAt) || !isValidManagedJobResult(result, current, timestamp)) {
@@ -606,7 +557,7 @@ export class InMemoryManagedJobStore implements ManagedJobStore {
 export class FilesystemManagedJobStore implements ManagedJobStore {
   private readonly root: string;
   constructor(rootPath: string, private readonly staleLockMs = 60000) { this.root = resolve(rootPath); }
-  async reserve(input: { readonly job: ManagedJobRecord }): Promise<ManagedJobReservation> {
+  async reserve(input: { readonly job: ManagedJobRecordV5 }): Promise<ManagedJobReservation> {
     return this.withLock(async () => {
       const memory = await this.loadMemory();
       const result = await memory.reserve(input);
@@ -626,22 +577,23 @@ export class FilesystemManagedJobStore implements ManagedJobStore {
   }
   async listNonterminal(): Promise<readonly ManagedJobRecord[]> { return (await this.loadMemory()).listNonterminal(); }
   private async loadMemory(): Promise<InMemoryManagedJobStore> {
-    const memory = new InMemoryManagedJobStore();
     try {
       const parsed = JSON.parse(await readFile(resolve(this.root, "managed-jobs.json"), "utf8")) as unknown;
       if (!Array.isArray(parsed)) throw new Error("corrupt");
-      for (const job of parsed) {
-        const validated = validateStoredJob(job);
-        const reservation = await memory.reserve({ job: validated });
-        if (reservation.kind !== "created") throw new Error("corrupt");
-      }
+      return new InMemoryManagedJobStore(parsed);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        if (error instanceof SyntaxError || error instanceof ManagedJobApplicationError) throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
-        throw new ManagedJobApplicationError("job_persistence_unavailable", "Restore the managed-job store and retry safely.");
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return new InMemoryManagedJobStore();
       }
+      if (
+        error instanceof SyntaxError
+        || error instanceof ManagedJobApplicationError
+        || (error instanceof Error && error.message === "corrupt")
+      ) {
+        throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
+      }
+      throw new ManagedJobApplicationError("job_persistence_unavailable", "Restore the managed-job store and retry safely.");
     }
-    return memory;
   }
   private async saveMemory(memory: InMemoryManagedJobStore): Promise<void> {
     await mkdir(this.root, { recursive: true });
@@ -681,12 +633,75 @@ function parseManagedJobSubmission(value: unknown): ManagedJobSubmission {
   return { objective, configuredAgentProfileId, callerId, idempotencyKey, ...(parent ? { parent } : {}) };
 }
 function validateStoredJob(value: unknown): ManagedJobRecord {
+  if (isRecord(value) && value.version === 5) {
+    const allowed = [
+      "version", "id", "state", "projectId", "callerId",
+      "configuredAgentProfileId", "admissionProfileId", "economicPolicyId",
+      "economicPolicyRevision", "constraints", "candidateSet",
+      "governanceSource", "admissionId", "requestFingerprint",
+      "idempotencyKeyHash", "createdAt", "updatedAt", "parent",
+      "diagnostic", "lifecycle",
+    ];
+    if (
+      !hasOnly(value, allowed)
+      || !isIdentifier(value.id)
+      || !MANAGED_JOB_STATES.includes(value.state as ManagedJobState)
+      || !isIdentifier(value.projectId)
+      || !isIdentifier(value.callerId)
+      || !isIdentifier(value.configuredAgentProfileId)
+      || !isManagedAgentAdmissionProfile(value.admissionProfileId)
+      || !isIdentifier(value.economicPolicyId)
+      || !isIdentifier(value.economicPolicyRevision)
+      || !isIdentifier(value.governanceSource)
+      || !isIdentifier(value.admissionId)
+      || !isHash(value.requestFingerprint)
+      || !isHash(value.idempotencyKeyHash)
+      || !isIso(value.createdAt)
+      || !isIso(value.updatedAt)
+      || Date.parse(value.createdAt) > Date.parse(value.updatedAt)
+      || !isValidManagedJobConstraints(value.constraints)
+      || !isManagedEconomicCandidateSet(
+        value.candidateSet as ManagedEconomicCandidateSet
+      )
+      || (value.diagnostic !== undefined && !isDiagnostic(value.diagnostic))
+      || (
+        value.parent !== undefined
+        && (
+          !isRecord(value.parent)
+          || !hasOnly(value.parent, ["invocationId", "turnId"])
+          || !isIdentifier(value.parent.invocationId)
+          || !isIdentifier(value.parent.turnId)
+        )
+      )
+      || !isValidLifecycle(
+        value.lifecycle,
+        value.state as ManagedJobState,
+        value.createdAt,
+        value.updatedAt,
+      )
+    ) {
+      throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
+    }
+    const candidateSet = value.candidateSet as ManagedEconomicCandidateSet;
+    if (
+      candidateSet.economicPolicyId !== value.economicPolicyId
+      || candidateSet.economicPolicyRevision !== value.economicPolicyRevision
+      || candidateSet.admissionProfileId !== value.admissionProfileId
+      || !sameManagedJobConstraints(
+        candidateSet.constraints,
+        value.constraints as ManagedJobEconomicProfile["constraints"],
+      )
+    ) {
+      throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
+    }
+    return value as unknown as ManagedJobRecordV5;
+  }
   const base = ["version", "id", "state", "projectId", "configuredAgentProfileId", "admissionProfileId", "routeId", "providerId", "governanceSource", "admissionId", "timeoutSource", "requestFingerprint", "idempotencyKeyHash", "createdAt", "updatedAt", "parent", "diagnostic"];
   const allowed = value && isRecord(value) && value.version === 4
     ? [...base, "callerId", "result", "lifecycle", "accountLease", "accountLeaseHistory"]
     : [...base, "callerId", "result", "lifecycle"];
   if (!isRecord(value) || !hasOnly(value, allowed) || (value.version !== 3 && value.version !== 4) || !isIdentifier(value.id) || !MANAGED_JOB_STATES.includes(value.state as ManagedJobState) || !isIdentifier(value.projectId) || !isIdentifier(value.configuredAgentProfileId) || !isIdentifier(value.admissionProfileId) || !isIdentifier(value.routeId) || !isIdentifier(value.providerId) || !isIdentifier(value.governanceSource) || !isIdentifier(value.admissionId) || (value.timeoutSource !== "default" && value.timeoutSource !== "explicit-route") || !isHash(value.requestFingerprint) || !isHash(value.idempotencyKeyHash) || !isIso(value.createdAt) || !isIso(value.updatedAt) || Date.parse(value.createdAt) > Date.parse(value.updatedAt) || (value.parent !== undefined && (!isRecord(value.parent) || !hasOnly(value.parent, ["invocationId", "turnId"]) || !isIdentifier(value.parent.invocationId) || !isIdentifier(value.parent.turnId))) || (value.diagnostic !== undefined && !isDiagnostic(value.diagnostic))) throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
-  if (!isIdentifier(value.callerId) || (value.result !== undefined && !isValidManagedJobResult(value.result, value as unknown as ManagedJobRecord, value.updatedAt)) || (value.state === "succeeded" && value.result === undefined) || (value.state !== "succeeded" && value.result !== undefined)) {
+  if (!isIdentifier(value.callerId) || (value.result !== undefined && !isValidManagedJobResult(value.result, value as unknown as ManagedJobRecordV3 | ManagedJobRecordV4, value.updatedAt)) || (value.state === "succeeded" && value.result === undefined) || (value.state !== "succeeded" && value.result !== undefined)) {
     throw new ManagedJobApplicationError("job_persistence_corrupt", "Repair the managed-job store before retrying.");
   }
   if (!isValidLifecycle(value.lifecycle, value.state as ManagedJobState, value.createdAt, value.updatedAt)) {
@@ -698,7 +713,7 @@ function validateStoredJob(value: unknown): ManagedJobRecord {
   return value as unknown as ManagedJobRecord;
 }
 function normalizeStoreError(error: unknown): ManagedJobApplicationError { return error instanceof ManagedJobApplicationError ? error : new ManagedJobApplicationError("job_persistence_unavailable", "Restore the managed-job store and retry safely."); }
-function canTransition(from: ManagedJobState, to: ManagedJobState): boolean { if (from === to) return false; if (from === "queued") return to === "running" || to === "interrupted" || to === "cancelled"; return from === "running" && (to === "succeeded" || to === "failed" || to === "timed_out" || to === "interrupted" || to === "cancelled"); }
+function canTransition(from: ManagedJobState, to: ManagedJobState): boolean { if (from === to) return false; if (from === "queued") return to === "running" || to === "failed" || to === "interrupted" || to === "cancelled"; return from === "running" && (to === "succeeded" || to === "failed" || to === "timed_out" || to === "interrupted" || to === "cancelled"); }
 function lifecycleEntry(sequence: number, state: ManagedJobState, observedAt: string, diagnostic?: ManagedJobDiagnosticCode): ManagedJobLifecycleEntry {
   return { sequence, state, observedAt, ...(diagnostic ? { diagnostic } : {}) };
 }
@@ -783,57 +798,7 @@ function sameManagedAccountLeaseIdentity(
     && left.route.scope === right.route.scope;
 }
 function isFreshEvidence(value: ManagedJobGovernanceEvidence, now: Date): boolean { return isIso(value.issuedAt) && isIso(value.validUntil) && Date.parse(value.issuedAt) <= now.getTime() && now.getTime() <= Date.parse(value.validUntil); }
-function isAdmittedRoute(route: ManagedJobRoute, profile: ManagedJobProfile, now: Date): boolean {
-  return isIdentifier(route.id)
-    && isIdentifier(route.accountPolicyId)
-    && route.id === profile.routeId
-    && isIdentifier(route.admissionProfileId)
-    && route.supportedAdmissionProfileIds.every(isIdentifier)
-    && route.supportedAdmissionProfileIds.includes(route.admissionProfileId)
-    && isIdentifier(route.providerId)
-    && route.scope.project === "validated"
-    && route.scope.read === "validated"
-    && route.scope.tools === "validated"
-    && route.scope.network === "validated"
-    && route.scope.write === "validated"
-    && route.eligibility.authority === "authoritative"
-    && isFreshRouteEligibility(route.eligibility, now)
-    && isBoundedRouteAuthority(route.authority);
-}
-function isFreshRouteEligibility(value: ManagedJobRoute["eligibility"], now: Date): boolean { return isIso(value.observedAt) && isIso(value.validUntil) && Date.parse(value.observedAt) <= now.getTime() && now.getTime() <= Date.parse(value.validUntil); }
-function isBoundedRouteAuthority(value: ManagedAgentAuthorityProfile): boolean {
-  return isIdentifier(value.authorityProfileId)
-    && isIdentifier(value.permissionProfile)
-    && value.toolAuthority.allowedToolNames.length > 0
-    && value.toolAuthority.allowedToolNames.every(isIdentifier)
-    && value.toolAuthority.writeAllowed === false
-    && typeof value.toolAuthority.networkAllowed === "boolean"
-    && value.workingDirectory.mode === "read-only"
-    && Number.isInteger(value.timeoutMs)
-    && value.timeoutMs > 0
-    && (value.memoryScope.access === "none" || value.memoryScope.access === "read-only")
-    && value.writeAuthority === undefined;
-}
-function createManagedJobResult(job: ManagedJobRecord, runtime: ManagedJobRuntimeResult, completedAt: string, objective: string): ManagedJobResult {
-  const result: ManagedJobResult = {
-    version: 1,
-    jobId: job.id,
-    runtimeInvocationId: runtime.runtimeInvocationId,
-    configuredAgentProfileId: runtime.configuredAgentProfileId,
-    admissionProfileId: runtime.admissionProfileId,
-    routeId: runtime.routeId,
-    providerId: runtime.providerId,
-    terminalState: runtime.terminalState,
-    completedAt,
-    provenance: { source: "runtime-managed-invocation", trust: "untrusted-child-output" },
-    resultHandoff: normalizeManagedJobResultHandoff(runtime.resultHandoff, objective),
-  };
-  if (!isValidManagedJobResult(result, job, completedAt)) {
-    throw new ManagedJobApplicationError("result_corrupt", "Persist only validated canonical Runtime result evidence.");
-  }
-  return result;
-}
-function isValidManagedJobResult(value: unknown, job: ManagedJobRecord, updatedAt: string): value is ManagedJobResult {
+function isValidManagedJobResult(value: unknown, job: ManagedJobRecordV3 | ManagedJobRecordV4, updatedAt: string): value is ManagedJobResult {
   if (!isRecord(value) || !hasOnly(value, ["version", "jobId", "runtimeInvocationId", "configuredAgentProfileId", "admissionProfileId", "routeId", "providerId", "terminalState", "completedAt", "provenance", "resultHandoff"]) || value.version !== 1 || value.jobId !== job.id || value.runtimeInvocationId !== job.id || value.configuredAgentProfileId !== job.configuredAgentProfileId || value.admissionProfileId !== job.admissionProfileId || value.routeId !== job.routeId || value.providerId !== job.providerId || value.terminalState !== "completed" || !isIso(value.completedAt) || Date.parse(value.completedAt) !== Date.parse(updatedAt) || !isRecord(value.provenance) || !hasOnly(value.provenance, ["source", "trust"]) || value.provenance.source !== "runtime-managed-invocation" || value.provenance.trust !== "untrusted-child-output" || !isSafeResultHandoff(value.resultHandoff)) return false;
   return true;
 }
@@ -896,15 +861,14 @@ function looksLikeRawProviderPayload(value: string): boolean {
   return /(?:\{\s*"[^"\n]{1,200}"\s*:|\[\s*\{)/u.test(value);
 }
 function resultQuery(job: ManagedJobRecord, availability: ManagedJobResultAvailability, diagnostic?: ManagedJobDiagnosticCode): ManagedJobResultQuery {
-  const result = job.result;
+  const result = job.version === 5 ? undefined : job.result;
   return {
     jobId: job.id,
     availability,
     lifecycleState: job.state,
     configuredAgentProfileId: job.configuredAgentProfileId,
     admissionProfileId: job.admissionProfileId,
-    routeId: job.routeId,
-    providerId: job.providerId,
+    ...(job.version !== 5 ? { routeId: job.routeId, providerId: job.providerId } : {}),
     ...(result ? { completedAt: result.completedAt, provenance: { ...result.provenance }, handoff: normalizeManagedJobResultHandoff(result.resultHandoff) } : {}),
     ...(job.version === 4 && job.accountLease ? { accountLease: defineManagedAccountLeaseEvidence(job.accountLease) } : {}),
     ...(diagnostic ? { diagnostic } : {}),
@@ -914,7 +878,7 @@ function replayQuery(job: ManagedJobRecord, availability: ManagedJobReplayQuery[
   const resultAvailability: ManagedJobResultAvailability = job.state === "queued" || job.state === "running"
     ? "pending"
     : job.state === "succeeded"
-      ? job.result ? "available" : "unavailable"
+      ? job.version !== 5 && job.result ? "available" : "unavailable"
       : "failed";
   return {
     jobId: job.id,
@@ -922,8 +886,7 @@ function replayQuery(job: ManagedJobRecord, availability: ManagedJobReplayQuery[
     lifecycleState: job.state,
     configuredAgentProfileId: job.configuredAgentProfileId,
     admissionProfileId: job.admissionProfileId,
-    routeId: job.routeId,
-    providerId: job.providerId,
+    ...(job.version !== 5 ? { routeId: job.routeId, providerId: job.providerId } : {}),
     lifecycle,
     accountLeaseHistory: job.version === 4
       ? job.accountLeaseHistory.map(defineManagedAccountLeaseEvidence)
@@ -934,9 +897,118 @@ function replayQuery(job: ManagedJobRecord, availability: ManagedJobReplayQuery[
   };
 }
 function cloneManagedJob(value: ManagedJobRecord): ManagedJobRecord { return structuredClone(value); }
+function isValidEconomicManagedJobProfile(profile: ManagedJobEconomicProfile): boolean {
+  return isIdentifier(profile.economicPolicyId)
+    && isIdentifier(profile.economicPolicyRevision)
+    && isManagedAgentAdmissionProfile(profile.admissionProfileId)
+    && isValidManagedJobConstraints(profile.constraints ?? {});
+}
+function normalizeManagedJobConstraints(
+  constraints: ManagedJobEconomicProfile["constraints"] | undefined,
+): NonNullable<ManagedJobEconomicProfile["constraints"]> {
+  return {
+    ...(constraints?.routeId ? { routeId: constraints.routeId } : {}),
+    ...(constraints?.providerId ? { providerId: constraints.providerId } : {}),
+    ...(constraints?.model ? { model: constraints.model } : {}),
+  };
+}
+function sameManagedJobConstraints(
+  left: ManagedEconomicCandidateSet["constraints"],
+  right: ManagedJobEconomicProfile["constraints"],
+): boolean {
+  return JSON.stringify(normalizeManagedJobConstraints(left))
+    === JSON.stringify(normalizeManagedJobConstraints(right));
+}
+function isManagedEconomicCandidateSet(
+  value: ManagedEconomicCandidateSet | undefined,
+): value is ManagedEconomicCandidateSet {
+  if (
+    value === undefined
+    || !isIdentifier(value.economicPolicyId)
+    || !isIdentifier(value.economicPolicyRevision)
+    || !isManagedAgentAdmissionProfile(value.admissionProfileId)
+    || !isValidManagedJobConstraints(value.constraints)
+    || !Array.isArray(value.candidates)
+    || !Array.isArray(value.rejections)
+  ) {
+    return false;
+  }
+  const candidateRouteIds = new Set<string>();
+  for (const candidate of value.candidates) {
+    if (
+      !isRecord(candidate)
+      || !hasOnly(candidate, [
+        "routeId", "routeSource", "providerId", "model", "accountPolicyId",
+        "surface", "adapterCapabilityId", "adapterCapabilityVersion",
+      ])
+      || !isIdentifier(candidate.routeId)
+      || !isManagedAgentRouteSource(candidate.routeSource)
+      || !isIdentifier(candidate.providerId)
+      || (candidate.model !== undefined && !isBoundedOpaqueIdentity(candidate.model))
+      || (
+        candidate.accountPolicyId !== undefined
+        && !isIdentifier(candidate.accountPolicyId)
+      )
+      || (candidate.surface !== undefined && !isIdentifier(candidate.surface))
+      || !isIdentifier(candidate.adapterCapabilityId)
+      || !isIdentifier(candidate.adapterCapabilityVersion)
+      || candidateRouteIds.has(candidate.routeId)
+    ) {
+      return false;
+    }
+    candidateRouteIds.add(candidate.routeId);
+  }
+  const rejectedRouteIds = new Set<string>();
+  for (const rejection of value.rejections) {
+    if (
+      !isRecord(rejection)
+      || !hasOnly(rejection, ["stage", "routeId", "reason"])
+      || rejection.stage !== "managed-candidate-admission"
+      || !isIdentifier(rejection.routeId)
+      || ![
+        "not-in-policy",
+        "caller-constraint-excluded",
+        "non-economic-admission-failed",
+        "economic-capability-unverified",
+      ].includes(String(rejection.reason))
+      || candidateRouteIds.has(rejection.routeId)
+      || rejectedRouteIds.has(rejection.routeId)
+    ) {
+      return false;
+    }
+    rejectedRouteIds.add(rejection.routeId);
+  }
+  return true;
+}
 function isIdentifier(value: unknown): value is string { return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/u.test(value); }
+function isBoundedOpaqueIdentity(value: unknown): value is string {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= 300
+    && value.trim() === value
+    && !/[\u0000-\u001F\u007F]/u.test(value);
+}
+function isManagedAgentAdmissionProfile(value: unknown): value is ManagedAgentAdmissionProfile {
+  return value === "foundation-readonly-plan"
+    || value === "foundation-propose-writes"
+    || value === "foundation-apply-approved-writes"
+    || value === "foundation-memory-write-proposals";
+}
+function isManagedAgentRouteSource(value: unknown): boolean {
+  return value === "ordered-routing"
+    || value === "explicit-managed-route"
+    || value === "managed-default-route"
+    || value === "enabled-engine-fallback";
+}
+function isValidManagedJobConstraints(value: unknown): boolean {
+  return isRecord(value)
+    && hasOnly(value, ["routeId", "providerId", "model"])
+    && (value.routeId === undefined || isIdentifier(value.routeId))
+    && (value.providerId === undefined || isIdentifier(value.providerId))
+    && (value.model === undefined || isBoundedOpaqueIdentity(value.model));
+}
 function isHash(value: unknown): value is string { return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value); }
-function isDiagnostic(value: unknown): value is ManagedJobDiagnosticCode { return typeof value === "string" && ["invalid_request", "project_identity_unavailable", "governance_unavailable", "governance_not_authoritative", "admission_denied", "profile_unavailable", "route_unavailable", "idempotency_conflict", "job_persistence_unavailable", "job_persistence_corrupt", "unknown_job", "invalid_transition", "provider_rejected", "provider_timeout", "account_lease_unavailable", "invocation_failed", "unauthorized_job", "result_pending", "result_unavailable", "result_persistence_failure", "result_corrupt", "cancelled", "replay_unavailable"].includes(value); }
+function isDiagnostic(value: unknown): value is ManagedJobDiagnosticCode { return typeof value === "string" && ["invalid_request", "project_identity_unavailable", "governance_unavailable", "governance_not_authoritative", "admission_denied", "profile_unavailable", "route_unavailable", "idempotency_conflict", "job_persistence_unavailable", "job_persistence_corrupt", "unknown_job", "invalid_transition", "provider_rejected", "provider_timeout", "account_lease_unavailable", "economic_commitment_unavailable", "invocation_failed", "unauthorized_job", "result_pending", "result_unavailable", "result_persistence_failure", "result_corrupt", "cancelled", "replay_unavailable"].includes(value); }
 function isIso(value: unknown): value is string { return typeof value === "string" && !Number.isNaN(Date.parse(value)); }
 function fingerprint(value: unknown): string { return createHash("sha256").update(JSON.stringify(value)).digest("hex"); }
 function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }

--- a/packages/runtime/tests/agents/codex-oauth-credential-pool.test.ts
+++ b/packages/runtime/tests/agents/codex-oauth-credential-pool.test.ts
@@ -27,6 +27,14 @@ function accountToken(accountId: string, overrides: Partial<CodexOAuthTokenFile>
   return token({ access_token: `header.${payload}.signature`, ...overrides });
 }
 
+function tokenWithEmail(email: string, overrides: Partial<CodexOAuthTokenFile> = {}): CodexOAuthTokenFile {
+  const payload = Buffer.from(JSON.stringify({
+    exp: 4_070_908_800,
+    "https://api.openai.com/profile": { email },
+  })).toString("base64url");
+  return token({ access_token: `header.${payload}.signature`, ...overrides });
+}
+
 function makeOptions(): CreateMessageOptions {
   return {
     system: "system",
@@ -289,6 +297,18 @@ describe("CodexOAuthCredentialPoolService", () => {
     }]);
     expect(JSON.stringify(status)).not.toContain("access-work");
     expect(JSON.stringify(status)).not.toContain("refresh-work");
+  });
+
+  it("decodes credential emails from local token claims only when explicitly requested, and keeps listStatus silent on it", async () => {
+    const service = new CodexOAuthCredentialPoolService({ rootDir });
+    await service.linkCredential({ id: "work", tokenFile: tokenWithEmail("operator@example.test") });
+    await service.linkCredential({ id: "no-profile", tokenFile: token() });
+
+    const emails = await service.listCredentialEmails();
+    expect(emails.get("work")).toBe("operator@example.test");
+    expect(emails.has("no-profile")).toBe(false);
+
+    expect(JSON.stringify(await service.listStatus())).not.toContain("operator@example.test");
   });
 
   it("cleans secret-bearing temporary files when atomic link replacement fails", async () => {

--- a/packages/runtime/tests/agents/credential-permission-diagnostic.test.ts
+++ b/packages/runtime/tests/agents/credential-permission-diagnostic.test.ts
@@ -1,0 +1,73 @@
+import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CredentialFileStore } from "../../src/agents/credential-pool/credential-file-store.js";
+import { listOverPermissiveCredentialFiles } from "../../src/agents/credential-pool/credential-permission-diagnostic.js";
+
+// POSIX-only assertions: Windows does not implement mode bits. CI runs Linux.
+const isWindows = process.platform === "win32";
+
+describe("credential permission diagnostic", () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "kiln-credential-permissions-"));
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(isWindows)("reports credential files readable beyond their owner", async () => {
+    await mkdir(join(rootDir, "codex-oauth"), { recursive: true });
+    await writeFile(join(rootDir, "codex-oauth", "loose.json"), "{}", "utf8");
+    await chmod(join(rootDir, "codex-oauth", "loose.json"), 0o644);
+    await writeFile(join(rootDir, "codex-oauth", "tight.json"), "{}", "utf8");
+    await chmod(join(rootDir, "codex-oauth", "tight.json"), 0o600);
+
+    const findings = await listOverPermissiveCredentialFiles({ rootDir });
+
+    expect(findings).toEqual([{ relativePath: "codex-oauth/loose.json", mode: "644" }]);
+  });
+
+  it.skipIf(isWindows)("ignores health and usage metadata, which carry no credential secrets", async () => {
+    await mkdir(join(rootDir, ".health"), { recursive: true });
+    await writeFile(join(rootDir, ".health", "codex-oauth.json"), "[]", "utf8");
+    await chmod(join(rootDir, ".health", "codex-oauth.json"), 0o644);
+
+    await expect(listOverPermissiveCredentialFiles({ rootDir })).resolves.toEqual([]);
+  });
+
+  it("reports nothing on Windows, where POSIX mode bits are not implemented", async () => {
+    await mkdir(join(rootDir, "codex-oauth"), { recursive: true });
+    await writeFile(join(rootDir, "codex-oauth", "any.json"), "{}", "utf8");
+
+    await expect(listOverPermissiveCredentialFiles({ rootDir, platform: "win32" })).resolves.toEqual([]);
+  });
+
+  it("returns nothing when the credential root does not exist", async () => {
+    await expect(listOverPermissiveCredentialFiles({ rootDir: join(rootDir, "absent") })).resolves.toEqual([]);
+  });
+
+  it.skipIf(isWindows)("repairs a pre-existing loose credential on its next write", async () => {
+    const store = new CredentialFileStore<{ api_key: string }>({ rootDir });
+    await store.writeCredential({ id: "go-primary", label: "go-primary", providerId: "opencode-api", auth: { api_key: "k" } });
+    const filePath = join(rootDir, "opencode-api", "go-primary.json");
+    await chmod(filePath, 0o644);
+    expect(await listOverPermissiveCredentialFiles({ rootDir })).toHaveLength(1);
+
+    await store.writeCredential({ id: "go-primary", label: "go-primary", providerId: "opencode-api", auth: { api_key: "k2" } });
+
+    expect((await stat(filePath)).mode & 0o777).toBe(0o600);
+    await expect(listOverPermissiveCredentialFiles({ rootDir })).resolves.toEqual([]);
+  });
+
+  it.skipIf(isWindows)("creates new credential files owner-only", async () => {
+    const store = new CredentialFileStore<{ api_key: string }>({ rootDir });
+
+    await store.writeCredential({ id: "zen-primary", label: "zen-primary", providerId: "opencode-api", auth: { api_key: "k" } });
+
+    expect((await stat(join(rootDir, "opencode-api", "zen-primary.json"))).mode & 0o777).toBe(0o600);
+  });
+});

--- a/packages/runtime/tests/gateway/attached-runtime-tool-surface.test.ts
+++ b/packages/runtime/tests/gateway/attached-runtime-tool-surface.test.ts
@@ -2621,7 +2621,7 @@ expect(config.effectiveTurnAuthority?.toolCount).toBe(config.toolAllowlist?.size
       reason: "Managed child invocation failed before work item execution could start.",
       managedInvocation: expect.objectContaining({
         isError: true,
-        output: "managed_agent.invoke requires providerRoute.providerId.",
+        output: "managed_agent.invoke requires providerRoute.providerId for a fixed-route invocation.",
       }),
     });
     expect(startTool.calls).toHaveLength(1);

--- a/packages/runtime/tests/managed-agent/economic-route-capability-admission.test.ts
+++ b/packages/runtime/tests/managed-agent/economic-route-capability-admission.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  collectManagedEconomicCandidates,
+  createManagedInvocationLifecycleToolExecutors,
+  MANAGED_AGENT_INVOKE_TOOL,
+  RuntimeManagedAgentInvocationService,
+  type ManagedInvocationToolAttachment,
+  type ManagedInvocationToolRoute,
+} from "../../src/agents/managed-invocation/index.js";
+import type { RuntimeBuiltinToolExecutionContext } from "../../src/session/runtime-session-orchestrator.types.js";
+
+const readonlyProfile = {
+  authorityProfileId: "readonly",
+  permissionProfile: "read-only",
+  allowedToolNames: ["read"],
+  writeAllowed: false,
+  networkAllowed: false,
+  workingDirectory: { path: "C:/workspace", mode: "read-only" as const },
+  timeoutMs: 300_000,
+  credentialRoute: { mode: "credentialless" as const },
+  memoryScope: {
+    scope: { kind: "project" as const, id: "kiln" },
+    access: "read-only" as const,
+  },
+};
+
+function route(input: {
+  readonly routeId: string;
+  readonly providerId: string;
+  readonly model?: string;
+  readonly policy?: boolean;
+  readonly capability?: "verified" | "unverified";
+  readonly profile?: boolean;
+}): ManagedInvocationToolRoute {
+  return {
+    routeId: input.routeId,
+    ...(input.policy ? { economicPolicyIds: ["economy-policy"] } : {}),
+    routeSource: "explicit-managed-route",
+    providerId: input.providerId,
+    ...(input.model ? { model: input.model } : {}),
+    ...(input.capability
+      ? {
+          economicCapability: {
+            status: input.capability,
+            ...(input.capability === "verified"
+              ? {
+                  adapterCapabilityId: `${input.providerId}-direct`,
+                  adapterCapabilityVersion: "1",
+                }
+              : {}),
+          },
+        }
+      : {}),
+    profiles: input.profile === false
+      ? {}
+      : { "foundation-readonly-plan": readonlyProfile },
+  };
+}
+
+const command = {
+  economicPolicyId: "economy-policy",
+  economicPolicyRevision: "revision-001",
+  configuredAgentProfileId: "scout",
+  admissionProfileId: "foundation-readonly-plan" as const,
+};
+
+describe("managed economic candidate admission", () => {
+  it("makes providerRoute optional at the public policy-owned command boundary", () => {
+    expect(MANAGED_AGENT_INVOKE_TOOL.inputSchema.required).toEqual([
+      "profile",
+      "task",
+    ]);
+  });
+
+  it("collects every admitted cross-provider candidate without selecting one", () => {
+    const candidates = collectManagedEconomicCandidates(command, [
+      route({
+        routeId: "codex-primary",
+        providerId: "codex-oauth",
+        model: "gpt-test",
+        policy: true,
+        capability: "verified",
+      }),
+      route({
+        routeId: "opencode-secondary",
+        providerId: "opencode-go",
+        model: "go-test",
+        policy: true,
+        capability: "verified",
+      }),
+    ]);
+
+    expect(candidates.candidates.map((candidate) => candidate.routeId)).toEqual([
+      "codex-primary",
+      "opencode-secondary",
+    ]);
+    expect(candidates.candidates[0]).toMatchObject({
+      adapterCapabilityId: "codex-oauth-direct",
+      adapterCapabilityVersion: "1",
+    });
+    expect(candidates).not.toHaveProperty("selectedRoute");
+    expect(candidates).not.toHaveProperty("adapter");
+  });
+
+  it("uses caller route/provider/model fields only to remove candidates", () => {
+    const candidates = collectManagedEconomicCandidates({
+      ...command,
+      providerRoute: {
+        providerId: "opencode-go",
+        model: "go-test",
+        surface: "configured",
+      },
+    }, [
+      route({
+        routeId: "codex-primary",
+        providerId: "codex-oauth",
+        model: "gpt-test",
+        policy: true,
+        capability: "verified",
+      }),
+      route({
+        routeId: "opencode-secondary",
+        providerId: "opencode-go",
+        model: "go-test",
+        policy: true,
+        capability: "verified",
+      }),
+    ]);
+
+    expect(candidates.candidates).toEqual([
+      expect.objectContaining({ routeId: "opencode-secondary" }),
+    ]);
+    expect(candidates.rejections).toContainEqual({
+      stage: "managed-candidate-admission",
+      routeId: "codex-primary",
+      reason: "caller-constraint-excluded",
+    });
+  });
+
+  it("owns exactly the four canonical rejection reasons at one stage", () => {
+    const outsidePolicy = collectManagedEconomicCandidates(command, [
+      route({
+        routeId: "outside-policy",
+        providerId: "codex-oauth",
+        capability: "verified",
+      }),
+    ]);
+    const constrained = collectManagedEconomicCandidates({
+      ...command,
+      routeId: "selected-route",
+    }, [
+      route({
+        routeId: "constraint-excluded",
+        providerId: "opencode-go",
+        policy: true,
+        capability: "verified",
+      }),
+    ]);
+    const admissionFailed = collectManagedEconomicCandidates({
+      ...command,
+      requiredToolNames: ["shell"],
+    }, [
+      route({
+        routeId: "admission-failed",
+        providerId: "codex-oauth",
+        policy: true,
+        capability: "verified",
+      }),
+    ]);
+    const capabilityUnverified = collectManagedEconomicCandidates(command, [
+      route({
+        routeId: "capability-unverified",
+        providerId: "codex-oauth",
+        policy: true,
+        capability: "unverified",
+      }),
+    ]);
+
+    const rejections = [
+      ...outsidePolicy.rejections,
+      ...constrained.rejections,
+      ...admissionFailed.rejections,
+      ...capabilityUnverified.rejections,
+    ];
+    expect(rejections.every(
+      (rejection) => rejection.stage === "managed-candidate-admission",
+    )).toBe(true);
+    expect(rejections.map((rejection) => rejection.reason)).toEqual([
+      "not-in-policy",
+      "caller-constraint-excluded",
+      "non-economic-admission-failed",
+      "economic-capability-unverified",
+    ]);
+  });
+
+  it("rejects unhealthy policy routes before economic capability evaluation", () => {
+    const result = collectManagedEconomicCandidates(command, [], [{
+      routeId: "unhealthy-route",
+      economicPolicyIds: ["economy-policy"],
+      economicCapability: { status: "unverified" },
+      routeSource: "explicit-managed-route",
+      providerId: "codex-oauth",
+      profiles: ["foundation-readonly-plan"],
+      reason: "Route health proof is stale.",
+    }]);
+
+    expect(result.rejections).toEqual([{
+      stage: "managed-candidate-admission",
+      routeId: "unhealthy-route",
+      reason: "non-economic-admission-failed",
+    }]);
+  });
+
+  it("performs no construction or execution side effects during admission", () => {
+    const createAdapter = vi.fn();
+    const materializeCredential = vi.fn();
+    const acquireLease = vi.fn();
+    const reserve = vi.fn();
+    const invokeProvider = vi.fn();
+    const candidate = {
+      ...route({
+        routeId: "codex-primary",
+        providerId: "codex-oauth",
+        policy: true,
+        capability: "verified",
+      }),
+      createCommittedAdapter: createAdapter,
+    };
+
+    collectManagedEconomicCandidates(command, [candidate]);
+
+    expect(createAdapter).not.toHaveBeenCalled();
+    expect(materializeCredential).not.toHaveBeenCalled();
+    expect(acquireLease).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+    expect(invokeProvider).not.toHaveBeenCalled();
+  });
+
+  it("fails a provider-free policy invocation at commitment without starting Runtime", async () => {
+    const service = new RuntimeManagedAgentInvocationService();
+    const start = vi.spyOn(service, "start");
+    const attachment: ManagedInvocationToolAttachment = {
+      options: {
+        routes: [route({
+          routeId: "codex-primary",
+          providerId: "codex-oauth",
+          policy: true,
+          capability: "verified",
+        })],
+        agentCatalog: [{
+          name: "scout",
+          role: "Scout",
+          goal: "Inspect bounded work.",
+          tier: "reasoning",
+          economicPolicyId: "economy-policy",
+          economicPolicyRevision: "revision-001",
+          economicPolicyCandidateRouteIds: ["codex-primary"],
+        }],
+        contextResolver: async () => ({ admittedAgentProfile: "scout" }),
+        invocationService: service,
+      },
+      callerIdentity: {
+        kind: "kiln-runtime",
+        surface: "test",
+        attachmentId: "attachment:test",
+      },
+    };
+    const executor = createManagedInvocationLifecycleToolExecutors(attachment)
+      .get("managed_agent.invoke");
+    if (!executor) throw new Error("managed_agent.invoke was not registered");
+
+    const result = await executor({
+      profile: "foundation-readonly-plan",
+      agentProfile: "scout",
+      task: "Inspect the policy boundary.",
+    }, {
+      session: { id: "session-test" } as RuntimeBuiltinToolExecutionContext["session"],
+      turnId: "turn-test",
+      toolCall: {
+        id: "tool-call-test",
+        name: "managed_agent.invoke",
+        input: {},
+      },
+    }) as {
+      readonly isError: boolean;
+      readonly metadata: Record<string, unknown>;
+    };
+
+    expect(result).toMatchObject({
+      isError: true,
+      metadata: {
+        errorCode: "economic_commitment_unavailable",
+        candidateSet: {
+          candidates: [{ routeId: "codex-primary" }],
+        },
+      },
+    });
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("denies skills before exposing economic candidates", async () => {
+    const service = new RuntimeManagedAgentInvocationService();
+    const attachment: ManagedInvocationToolAttachment = {
+      options: {
+        routes: [route({
+          routeId: "codex-primary",
+          providerId: "codex-oauth",
+          policy: true,
+          capability: "verified",
+        })],
+        agentCatalog: [{
+          name: "scout",
+          role: "Scout",
+          goal: "Inspect bounded work.",
+          tier: "reasoning",
+          economicPolicyId: "economy-policy",
+          economicPolicyRevision: "revision-001",
+          economicPolicyCandidateRouteIds: ["codex-primary"],
+        }],
+        contextResolver: async () => ({ deniedSkills: ["forbidden-skill"] }),
+        invocationService: service,
+      },
+      callerIdentity: {
+        kind: "kiln-runtime",
+        surface: "test",
+        attachmentId: "attachment:test",
+      },
+    };
+    const executor = createManagedInvocationLifecycleToolExecutors(attachment)
+      .get("managed_agent.invoke");
+    if (!executor) throw new Error("managed_agent.invoke was not registered");
+
+    const result = await executor({
+      profile: "foundation-readonly-plan",
+      agentProfile: "scout",
+      skills: ["forbidden-skill"],
+      task: "Inspect the policy boundary.",
+    }, {
+      session: { id: "session-test" } as RuntimeBuiltinToolExecutionContext["session"],
+      turnId: "turn-test",
+      toolCall: { id: "tool-call-test", name: "managed_agent.invoke", input: {} },
+    }) as { readonly output: string; readonly metadata: Record<string, unknown> };
+
+    expect(result.output).toContain("Managed invocation denied skill(s): forbidden-skill");
+    expect(result.metadata).not.toHaveProperty("candidateSet");
+  });
+
+  it("denies destructive authority before exposing economic candidates", async () => {
+    const service = new RuntimeManagedAgentInvocationService();
+    const requestApproval = vi.fn(async () => ({ approved: false as const, reason: "operator denied" }));
+    const attachment: ManagedInvocationToolAttachment = {
+      options: {
+        routes: [],
+        agentCatalog: [{
+          name: "writer",
+          role: "Writer",
+          goal: "Apply bounded work.",
+          tier: "reasoning",
+          economicPolicyId: "economy-policy",
+          economicPolicyRevision: "revision-001",
+          economicPolicyCandidateRouteIds: [],
+        }],
+        contextResolver: async () => ({ admittedAgentProfile: "writer" }),
+        invocationService: service,
+      },
+      callerIdentity: {
+        kind: "kiln-runtime",
+        surface: "test",
+        attachmentId: "attachment:test",
+      },
+    };
+    const executor = createManagedInvocationLifecycleToolExecutors(attachment)
+      .get("managed_agent.invoke");
+    if (!executor) throw new Error("managed_agent.invoke was not registered");
+
+    const result = await executor({
+      profile: "foundation-apply-approved-writes",
+      agentProfile: "writer",
+      requestedAuthority: "destructive",
+      task: "Apply the policy boundary.",
+    }, {
+      session: { id: "session-test" } as RuntimeBuiltinToolExecutionContext["session"],
+      turnId: "turn-test",
+      toolCall: { id: "tool-call-test", name: "managed_agent.invoke", input: {} },
+      requestApproval,
+    }) as { readonly output: string; readonly metadata: Record<string, unknown> };
+
+    expect(requestApproval).toHaveBeenCalledOnce();
+    expect(result.output).toContain("destructive requested authority denied: operator denied");
+    expect(result.metadata).not.toHaveProperty("candidateSet");
+  });
+});

--- a/packages/runtime/tests/managed-agent/orchestration-lifecycle.test.ts
+++ b/packages/runtime/tests/managed-agent/orchestration-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildManagedAgentDecompositionOrchestrationRequest,
   buildManagedAgentFanOutOrchestrationRequest,
@@ -493,6 +493,53 @@ describe("runManagedAgentOrchestrationLifecycle", () => {
       },
       profile: "foundation-apply-approved-writes",
     })).rejects.toThrow("Managed orchestration requires an isolated-worktree");
+  });
+
+  it("candidate-admits a policy child without selecting or starting a route", async () => {
+    const managedInvocation = createManagedInvocation();
+    const primaryRoute = managedInvocation.routes[0]!;
+    const start = vi.spyOn(managedInvocation.invocationService!, "start");
+    const orchestrationRequest = request(2);
+
+    await expect(runManagedAgentOrchestrationLifecycle({
+      orchestrationRequest: {
+        ...orchestrationRequest,
+        childRequests: orchestrationRequest.childRequests.map((child) => ({
+          ...child,
+          agentProfile: "economic-worker",
+        })),
+      },
+      managedInvocation: {
+        ...managedInvocation,
+        routes: [{
+          ...primaryRoute,
+          adapter: undefined,
+          economicPolicyIds: ["economy-policy"],
+          economicCapability: {
+            status: "verified",
+            adapterCapabilityId: "codex-direct",
+            adapterCapabilityVersion: "1",
+          },
+        }],
+        agentCatalog: [{
+          name: "economic-worker",
+          role: "Economic worker",
+          goal: "Execute only after durable commitment.",
+          tier: "reasoning",
+          authorityProfile: "foundation-apply-approved-writes",
+          economicPolicyId: "economy-policy",
+          economicPolicyRevision: "revision-001",
+          economicPolicyCandidateRouteIds: [primaryRoute.routeId],
+        }],
+      },
+      profile: "foundation-apply-approved-writes",
+    })).rejects.toMatchObject({
+      code: "economic_commitment_unavailable",
+      candidateSet: {
+        candidates: [{ routeId: primaryRoute.routeId }],
+      },
+    });
+    expect(start).not.toHaveBeenCalled();
   });
 
   it("fails closed when lifecycle route selection is ambiguous", async () => {

--- a/packages/runtime/tests/managed-jobs/managed-job-application.test.ts
+++ b/packages/runtime/tests/managed-jobs/managed-job-application.test.ts
@@ -1,694 +1,454 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
-  defineManagedAgentAdapterDescriptor,
-  defineManagedAgentInvocationRecord,
-  defineManagedAgentInvocationRequest,
-} from "@kilnai/core";
-import {
-  createRuntimeManagedJobInvocationPort,
   FilesystemManagedJobStore,
   InMemoryManagedJobStore,
-  ManagedJobApplicationError,
   ManagedJobApplicationService,
+  type ManagedJobApplicationOptions,
+  type ManagedJobEconomicProfile,
+  type ManagedJobRecordV3,
+  type ManagedJobRecordV4,
+  type ManagedJobRecordV5,
 } from "../../src/managed-jobs/index.js";
-import { RuntimeManagedAgentInvocationService } from "../../src/agents/managed-invocation/index.js";
-import type { ManagedJobApplicationOptions, ManagedJobStore } from "../../src/managed-jobs/index.js";
+import type { ManagedEconomicCandidateSet } from "../../src/agents/managed-invocation/runtime-tool.js";
 
-const now = new Date("2026-07-13T22:00:00.000Z");
-const request = { objective: "Inspect the managed job boundary.", configuredAgentProfileId: "scout", callerId: "codex-app:caller-001", idempotencyKey: "caller-001" };
-const scope = { project: "validated", read: "validated", tools: "validated", network: "validated", write: "validated" } as const;
-const eligibility = { authority: "authoritative", observedAt: "2026-07-13T21:59:00.000Z", validUntil: "2026-07-13T22:01:00.000Z" } as const;
-const authority = {
-  authorityProfileId: "authority-readonly",
-  permissionProfile: "read-only",
-  toolAuthority: { allowedToolNames: ["read"], writeAllowed: false, networkAllowed: false },
-  workingDirectory: { path: "C:/workspace", mode: "read-only" },
-  timeoutMs: 300000,
-  credentialRoute: { mode: "credentialless" },
-  memoryScope: { scope: { kind: "project", id: "kiln" }, access: "read-only" },
+const now = new Date("2026-07-29T18:00:00.000Z");
+const submission = {
+  objective: "Inspect the policy-owned precommit boundary.",
+  configuredAgentProfileId: "scout",
+  callerId: "codex-app:caller-001",
+  idempotencyKey: "caller-001",
+};
+const query = {
+  project: { id: "kiln" },
+  callerId: "codex-app:caller-001",
 } as const;
 
-const query = { project: { id: "kiln" }, callerId: "codex-app:caller-001" } as const;
-
-function successfulRuntimeResult(input: {
-  readonly jobId: string;
-  readonly profile: { readonly id: string; };
-  readonly route: { readonly id: string; readonly admissionProfileId: string; readonly providerId: string; };
-}) {
+function profile(
+  constraints: ManagedJobEconomicProfile["constraints"] = {},
+): ManagedJobEconomicProfile {
   return {
-    state: "succeeded" as const,
-    result: {
-      runtimeInvocationId: input.jobId,
-      configuredAgentProfileId: input.profile.id,
-      admissionProfileId: input.route.admissionProfileId,
-      routeId: input.route.id,
-      providerId: input.route.providerId,
-      terminalState: "completed" as const,
-      resultHandoff: { summary: "done", resourceUris: [], memoryWriteProposalUris: [] },
-    },
-  };
-}
-
-async function observeAccountLease(
-  input: {
-    readonly jobId: string;
-    readonly route: { readonly accountPolicyId: string; readonly providerId: string };
-    readonly accountLeaseObserver: ManagedJobApplicationOptions["runtime"]["invoke"] extends (input: infer T) => unknown
-      ? T extends { readonly accountLeaseObserver: infer O } ? O : never
-      : never;
-  },
-  lifecycleState: "held" | "settlement-pending" | "released" = "released",
-): Promise<void> {
-  await input.accountLeaseObserver({
-    leaseId: `lease-${input.jobId}`,
-    accountPolicyId: input.route.accountPolicyId,
-    accountRef: "configured:account-a",
-    route: {
-      providerId: input.route.providerId,
-      providerModelId: "qwen3.6-plus",
-      scope: `virtual:${input.route.accountPolicyId}`,
-    },
-    jobId: input.jobId,
-    runtimeInvocationId: input.jobId,
-    credentialRevisionId: "a".repeat(64),
-    selectionReason: "least-pressure",
-    acquiredAt: now.toISOString(),
-    lifecycleState,
-    ...(lifecycleState === "released" ? { releasedAt: now.toISOString() } : {}),
-    ...(lifecycleState === "released" ? { affinityCommitOutcome: "won" as const } : {}),
-    resourceUris: [`kiln://managed-accounts/leases/lease-${input.jobId}`],
-    diagnosticUris: lifecycleState === "settlement-pending"
-      ? [`kiln://managed-accounts/leases/lease-${input.jobId}/settlement-pending`]
-      : [],
-  });
-}
-
-function admittedRoute(routeId: string, overrides: Record<string, unknown> = {}) {
-  return {
-    id: routeId,
-    accountPolicyId: "managed-opencode",
+    id: "scout",
+    economicPolicyId: "economy-policy",
+    economicPolicyRevision: "revision-001",
     admissionProfileId: "foundation-readonly-plan",
-    supportedAdmissionProfileIds: ["foundation-readonly-plan"],
-    providerId: "opencode-go",
-    timeoutSource: "explicit-route" as const,
-    scope,
-    eligibility,
-    authority,
-    ...overrides,
+    constraints,
   };
 }
 
-function createOptions(overrides: Partial<ManagedJobApplicationOptions> = {}): ManagedJobApplicationOptions {
-  const runtime = overrides.runtime ?? {
-    invoke: async (input: Parameters<ManagedJobApplicationOptions["runtime"]["invoke"]>[0]) => successfulRuntimeResult(input),
+function candidateSet(
+  constraints: ManagedJobEconomicProfile["constraints"] = {},
+): ManagedEconomicCandidateSet {
+  return {
+    economicPolicyId: "economy-policy",
+    economicPolicyRevision: "revision-001",
+    admissionProfileId: "foundation-readonly-plan",
+    constraints,
+    candidates: [{
+      routeId: "codex-primary",
+      routeSource: "explicit-managed-route",
+      providerId: "codex-oauth",
+      model: "gpt-test",
+      accountPolicyId: "codex-pool",
+      surface: "direct-provider",
+      adapterCapabilityId: "codex-oauth-direct",
+      adapterCapabilityVersion: "1",
+    }],
+    rejections: [{
+      stage: "managed-candidate-admission",
+      routeId: "remote-fallback",
+      reason: "economic-capability-unverified",
+    }],
   };
-  const { runtime: _runtime, ...remainingOverrides } = overrides;
+}
+
+function createOptions(input: {
+  readonly currentProfile?: () => ManagedJobEconomicProfile;
+  readonly currentCandidates?: () => ManagedEconomicCandidateSet;
+  readonly store?: ManagedJobApplicationOptions["store"];
+} = {}): ManagedJobApplicationOptions {
   return {
     project: { resolve: async () => ({ id: "kiln" }) },
     governance: {
-      resolve: async () => ({ version: 1, authority: "authoritative", source: "kiln-config-status", issuedAt: "2026-07-13T21:59:00.000Z", validUntil: "2026-07-13T22:01:00.000Z" }),
-      admit: async () => ({ admitted: true, admissionId: "admission-001", source: "kiln-config-status" }),
+      resolve: async () => ({
+        version: 1,
+        authority: "authoritative",
+        source: "kiln-config-status",
+        issuedAt: "2026-07-29T17:59:00.000Z",
+        validUntil: "2026-07-29T18:01:00.000Z",
+      }),
+      admit: async () => ({
+        admitted: true,
+        admissionId: "admission-001",
+        source: "kiln-work-governance",
+      }),
     },
-    profiles: { resolve: async (id) => id === "scout" ? { id, routeId: "opencode-go-scout-readonly" } : id === "researcher" ? { id, routeId: "opencode-go-researcher-readonly" } : undefined },
-    routes: { resolve: async (profile) => admittedRoute(profile.routeId) },
-    runtime: {
-      invoke: async (input) => {
-        const result = await runtime.invoke(input);
-        await observeAccountLease(input, result.state === "timed_out" ? "settlement-pending" : "released");
-        return result;
-      },
-      ...(runtime.cancel ? { cancel: runtime.cancel.bind(runtime) } : {}),
+    profiles: {
+      resolve: async (id) => id === "scout"
+        ? (input.currentProfile?.() ?? profile())
+        : undefined,
     },
-    store: new InMemoryManagedJobStore(),
+    routes: {
+      resolve: async () => input.currentCandidates?.() ?? candidateSet(),
+    },
+    store: input.store ?? new InMemoryManagedJobStore(),
     clock: () => now,
     idGenerator: () => "job-000000001",
-    ...remainingOverrides,
   };
 }
 
-describe("ManagedJobApplicationService", () => {
-  it("returns a durable background identity, cancels through Runtime, and replays monotonic lifecycle evidence", async () => {
-    let release: (() => void) | undefined;
-    const waiting = new Promise<void>((resolve) => { release = resolve; });
-    const runtime = {
-      invoke: vi.fn(async (input) => {
-        await waiting;
-        return successfulRuntimeResult(input);
-      }),
-      cancel: vi.fn(async () => { release?.(); }),
-    };
-    const service = new ManagedJobApplicationService(createOptions({ runtime }));
+describe("ManagedJobApplicationService V5 precommit", () => {
+  it("persists policy identity and candidates without selecting an execution route", async () => {
+    const service = new ManagedJobApplicationService(createOptions());
 
-    const submitted = await service.start(request);
-    expect(submitted).toMatchObject({ id: "job-000000001", state: "running" });
+    const job = await service.submit(submission);
 
-    const cancelled = await service.cancel(query, submitted.id);
-    expect(cancelled).toMatchObject({ state: "cancelled", diagnostic: "cancelled" });
-    expect(runtime.cancel).toHaveBeenCalledWith({ jobId: submitted.id, reason: "Operator cancelled managed work." });
-
-    await vi.waitFor(async () => expect((await service.getStatus(query, submitted.id)).state).toBe("cancelled"));
-    await expect(service.getReplay(query, submitted.id)).resolves.toMatchObject({
-      availability: "available",
-      jobId: submitted.id,
+    expect(job).toMatchObject({
+      version: 5,
+      state: "failed",
+      diagnostic: "economic_commitment_unavailable",
+      economicPolicyId: "economy-policy",
+      economicPolicyRevision: "revision-001",
+      constraints: {},
+      candidateSet: {
+        candidates: [{ routeId: "codex-primary" }],
+        rejections: [{ reason: "economic-capability-unverified" }],
+      },
       lifecycle: [
         { sequence: 1, state: "queued" },
-        { sequence: 2, state: "running" },
-        { sequence: 3, state: "cancelled", diagnostic: "cancelled" },
+        {
+          sequence: 2,
+          state: "failed",
+          diagnostic: "economic_commitment_unavailable",
+        },
       ],
-      resultAvailability: "failed",
+    });
+    expect(job).not.toHaveProperty("routeId");
+    expect(job).not.toHaveProperty("providerId");
+    expect(job).not.toHaveProperty("accountLease");
+    await expect(service.getResult(query, job.id)).resolves.toMatchObject({
+      availability: "failed",
+      diagnostic: "economic_commitment_unavailable",
+    });
+    await expect(service.getReplay(query, job.id)).resolves.toMatchObject({
+      availability: "unavailable",
+      diagnostic: "replay_unavailable",
     });
   });
 
-  it("creates one admitted canonical job and exposes its durable status", async () => {
-    const runtime = { invoke: vi.fn(async (input) => successfulRuntimeResult(input)) };
-    const service = new ManagedJobApplicationService(createOptions({ runtime }));
-    const submitted = await service.submit(request);
-    const status = await service.getStatus(query, submitted.id);
-    const result = await service.getResult(query, submitted.id);
-    const replay = await service.getReplay(query, submitted.id);
-
-    expect(submitted).toMatchObject({ id: "job-000000001", state: "succeeded", projectId: "kiln", configuredAgentProfileId: "scout", admissionProfileId: "foundation-readonly-plan", routeId: "opencode-go-scout-readonly", providerId: "opencode-go", governanceSource: "kiln-config-status", timeoutSource: "explicit-route" });
-    expect(submitted).toMatchObject({
-      version: 4,
-      accountLease: {
-        accountPolicyId: "managed-opencode",
-        accountRef: "configured:account-a",
-        lifecycleState: "released",
-        affinityCommitOutcome: "won",
-      },
-      accountLeaseHistory: [{ lifecycleState: "released", affinityCommitOutcome: "won" }],
-    });
-    expect(status).toEqual(submitted);
-    expect(result).toMatchObject({
-      availability: "available",
-      jobId: submitted.id,
-      configuredAgentProfileId: "scout",
-      provenance: { source: "runtime-managed-invocation", trust: "untrusted-child-output" },
-      handoff: { summary: "done", resourceUris: [], memoryWriteProposalUris: [] },
-      accountLease: { lifecycleState: "released", affinityCommitOutcome: "won" },
-    });
-    expect(replay).toMatchObject({
-      accountLease: { lifecycleState: "released", affinityCommitOutcome: "won" },
-      accountLeaseHistory: [{ lifecycleState: "released", affinityCommitOutcome: "won" }],
-    });
-    expect(runtime.invoke).toHaveBeenCalledWith(expect.objectContaining({ jobId: "job-000000001", route: expect.objectContaining({ providerId: "opencode-go" }) }));
-  });
-
-  it("fails closed when Runtime omits the required account lease observation", async () => {
+  it("never invokes an adapter, credential, lease, reservation, or provider port", async () => {
+    const sideEffect = vi.fn();
     const options = createOptions();
     const service = new ManagedJobApplicationService({
       ...options,
-      runtime: { invoke: async (input) => successfulRuntimeResult(input) },
+      // The application contract deliberately has no execution-side port.
+      routes: {
+        resolve: async () => {
+          expect(sideEffect).not.toHaveBeenCalled();
+          return candidateSet();
+        },
+      },
     });
 
-    await expect(service.submit(request)).resolves.toMatchObject({
-      version: 4,
-      state: "failed",
-      diagnostic: "account_lease_unavailable",
-      accountLeaseHistory: [],
-    });
+    await service.submit(submission);
+
+    expect(sideEffect).not.toHaveBeenCalled();
+    expect(Object.keys(options)).not.toContain("runtime");
   });
 
-  it("uses the existing Runtime invocation owner for a configured opencode-go direct route", async () => {
-    const runtimeService = new RuntimeManagedAgentInvocationService();
-    const adapter = {
-      descriptor: defineManagedAgentAdapterDescriptor({
-        adapterDescriptorId: "direct:opencode-go", providerId: "opencode-go", adapterKind: "direct",
-        supportedProfiles: ["foundation-readonly-plan"], supportedExecutionModes: ["direct-provider"],
-        lifecycle: { exposesStart: true, exposesTerminal: true, exposesCleanup: true }, cancellation: { supported: true },
-        timeout: { supported: true, diagnosticArtifactOnTimeout: true }, transcript: { supported: true, redactionKnown: true, truncationKnown: true, persistenceKnown: true, retentionKnown: true },
-        usage: { supported: true, preservesProviderTokenClasses: true, supportsExplicitUnknowns: true, tokenClasses: ["input"], semanticSourceGranularity: "unknown", evidenceBasis: "adapter" },
-        resultHandoff: { boundedSummary: true, resourcePointers: true }, credentialRoute: { supported: true }, memoryContext: { governedAdmission: true }, unsupportedFieldPolicy: "reject", cleanup: { supported: true },
-      }),
-      invoke: vi.fn(async ({ request, admission }) => defineManagedAgentInvocationRecord({
-        invocationId: request.invocationId, agentId: request.agentId, parentSessionId: request.parentSessionId, parentTurnId: request.parentTurnId,
-        profile: request.profile, lifecycleState: "completed", providerRoute: request.providerRoute, adapterKind: request.adapterKind, executionMode: request.executionMode,
-        authority: request.authority, capabilitySnapshot: admission.capabilitySnapshot, childSessionId: "child-session", resultHandoff: { summary: "done", resourceUris: [], memoryWriteProposalUris: [] },
-      })),
+  it("recovers a persisted V5 precommit crash as commitment unavailable", async () => {
+    const queued: ManagedJobRecordV5 = {
+      version: 5,
+      id: "job-precommit-001",
+      state: "queued",
+      projectId: "kiln",
+      callerId: "codex-app:caller-001",
+      configuredAgentProfileId: "scout",
+      admissionProfileId: "foundation-readonly-plan",
+      economicPolicyId: "economy-policy",
+      economicPolicyRevision: "revision-001",
+      constraints: {},
+      candidateSet: candidateSet(),
+      governanceSource: "kiln-work-governance",
+      admissionId: "admission-001",
+      requestFingerprint: "a".repeat(64),
+      idempotencyKeyHash: "b".repeat(64),
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+      lifecycle: [{ sequence: 1, state: "queued", observedAt: now.toISOString() }],
     };
-    const runtime = createRuntimeManagedJobInvocationPort({
-      service: runtimeService,
-      resolver: { resolve: async ({ jobId }) => {
-        const request = defineManagedAgentInvocationRequest({ invocationId: jobId, agentId: "configured-reviewer", parentSessionId: "parent-session", parentTurnId: "parent-turn", profile: "foundation-readonly-plan", requestedBy: "kiln", requestSource: "managed-job", providerRoute: { providerId: "opencode-go", surface: "direct-provider", model: "configured-model" }, adapterKind: "direct", executionMode: "direct-provider", authority: { authorityProfileId: "read-only", permissionProfile: "read-only", toolAuthority: { allowedToolNames: ["read"], writeAllowed: false, networkAllowed: false }, workingDirectory: { path: "C:/workspace", mode: "read-only" }, timeoutMs: 300000, timeoutSource: "explicit-route", credentialRoute: { mode: "credentialless" }, memoryScope: { scope: { kind: "project", id: "kiln" }, access: "read-only" } }, input: { summary: "Inspect boundary" } });
-        return { request, adapter, capabilitySnapshot: { routeId: "opencode-go-scout-readonly", routeSource: "explicit-managed-route", capturedAt: now.toISOString() } };
-      } },
-    });
-    const service = new ManagedJobApplicationService(createOptions({ runtime }));
-    const job = await service.submit(request);
-    await expect(service.getResult(query, job.id)).resolves.toMatchObject({ availability: "available", handoff: { summary: "done" } });
-    expect(job).toMatchObject({ id: "job-000000001", providerId: "opencode-go", state: "succeeded" });
-    expect(adapter.invoke).toHaveBeenCalledOnce();
-    expect(runtimeService.status("job-000000001")?.record?.invocationId).toBe("job-000000001");
-  });
+    const store = new InMemoryManagedJobStore([queued]);
+    const service = new ManagedJobApplicationService(createOptions({ store }));
 
-  it("requires fresh authoritative governance and denies before provider invocation", async () => {
-    const runtime = { invoke: vi.fn(async (input) => successfulRuntimeResult(input)) };
-    const service = new ManagedJobApplicationService(createOptions({
-      runtime,
-      governance: { resolve: async () => ({ version: 1, authority: "authoritative", source: "kiln-config-status", issuedAt: "2026-07-13T20:00:00.000Z", validUntil: "2026-07-13T21:00:00.000Z" }), admit: async () => ({ admitted: true, admissionId: "admission-001", source: "kiln-config-status" }) },
-    }));
-    await expect(service.submit(request)).rejects.toMatchObject({ code: "governance_not_authoritative" });
-    expect(runtime.invoke).not.toHaveBeenCalled();
-
-    const denied = new ManagedJobApplicationService(createOptions({ runtime, governance: { resolve: async () => ({ version: 1, authority: "authoritative", source: "kiln-config-status", issuedAt: "2026-07-13T21:59:00.000Z", validUntil: "2026-07-13T22:01:00.000Z" }), admit: async () => ({ admitted: false }) } }));
-    await expect(denied.submit(request)).rejects.toMatchObject({ code: "admission_denied" });
-    expect(runtime.invoke).not.toHaveBeenCalled();
-  });
-
-  it("rejects caller provider/model overrides and invalid parent lineage", async () => {
-    const service = new ManagedJobApplicationService(createOptions());
-    await expect(service.submit({ ...request, providerId: "opencode-go" })).rejects.toMatchObject({ code: "invalid_request" });
-    await expect(service.submit({ ...request, parent: { invocationId: "parent", turnId: "bad path/" } })).rejects.toMatchObject({ code: "invalid_request" });
-  });
-
-  it("selects the configured route even when agents share an admission profile", async () => {
-    const routes = { resolve: vi.fn(async (profile: { routeId: string }) => admittedRoute(profile.routeId)) };
-    const service = new ManagedJobApplicationService(createOptions({ routes }));
-    await expect(service.submit(request)).resolves.toMatchObject({ configuredAgentProfileId: "scout", routeId: "opencode-go-scout-readonly", admissionProfileId: "foundation-readonly-plan" });
-    await expect(service.submit({ ...request, configuredAgentProfileId: "researcher", idempotencyKey: "researcher-key" })).resolves.toMatchObject({ configuredAgentProfileId: "researcher", routeId: "opencode-go-researcher-readonly", admissionProfileId: "foundation-readonly-plan" });
-    expect(routes.resolve).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: "scout", routeId: "opencode-go-scout-readonly" }));
-    expect(routes.resolve).toHaveBeenNthCalledWith(2, expect.objectContaining({ id: "researcher", routeId: "opencode-go-researcher-readonly" }));
-  });
-
-  it("fails closed when the route contradicts the configured agent or admission profile", async () => {
-    const wrongRoute = new ManagedJobApplicationService(createOptions({ routes: { resolve: async () => admittedRoute("opencode-go-researcher-readonly") } }));
-    await expect(wrongRoute.submit(request)).rejects.toMatchObject({ code: "route_unavailable" });
-    const wrongAdmission = new ManagedJobApplicationService(createOptions({ routes: { resolve: async (profile) => admittedRoute(profile.routeId, { supportedAdmissionProfileIds: ["different-profile"] }) } }));
-    await expect(wrongAdmission.submit(request)).rejects.toMatchObject({ code: "route_unavailable" });
-  });
-
-  it("rejects a configured agent without an explicit route hint before a job is created", async () => {
-    const store = new InMemoryManagedJobStore();
-    const reserve = vi.spyOn(store, "reserve");
-    const runtime = { invoke: vi.fn(async (input) => successfulRuntimeResult(input)) };
-    const service = new ManagedJobApplicationService(createOptions({
-      store,
-      runtime,
-      profiles: { resolve: async () => ({ id: "scout", routeId: "" }) },
-    }));
-
-    await expect(service.submit(request)).rejects.toMatchObject({ code: "profile_unavailable" });
-    expect(reserve).not.toHaveBeenCalled();
-    expect(runtime.invoke).not.toHaveBeenCalled();
-  });
-
-  it.each(["project", "read", "tools", "network", "write"] as const)("rejects an unvalidated %s scope before a job is created", async (scopeName) => {
-    const store = new InMemoryManagedJobStore();
-    const reserve = vi.spyOn(store, "reserve");
-    const runtime = { invoke: vi.fn(async (input) => successfulRuntimeResult(input)) };
-    const scope = { project: "validated", read: "validated", tools: "validated", network: "validated", write: "validated", [scopeName]: "denied" };
-    const service = new ManagedJobApplicationService(createOptions({
-      store,
-      runtime,
-      routes: { resolve: async (profile) => ({
-        id: profile.routeId,
-        admissionProfileId: "foundation-readonly-plan",
-        supportedAdmissionProfileIds: ["foundation-readonly-plan"],
-        providerId: "opencode-go",
-        timeoutSource: "explicit-route",
-        scope,
-        eligibility: { authority: "authoritative", observedAt: now.toISOString(), validUntil: "2026-07-13T22:01:00.000Z" },
-      } as never) },
-    }));
-
-    await expect(service.submit(request)).rejects.toMatchObject({ code: "route_unavailable" });
-    expect(reserve).not.toHaveBeenCalled();
-    expect(runtime.invoke).not.toHaveBeenCalled();
-  });
-
-  it("rejects stale route eligibility before a job is created", async () => {
-    const store = new InMemoryManagedJobStore();
-    const reserve = vi.spyOn(store, "reserve");
-    const runtime = { invoke: vi.fn(async (input) => successfulRuntimeResult(input)) };
-    const service = new ManagedJobApplicationService(createOptions({
-      store,
-      runtime,
-      routes: { resolve: async (profile) => ({
-        id: profile.routeId,
-        admissionProfileId: "foundation-readonly-plan",
-        supportedAdmissionProfileIds: ["foundation-readonly-plan"],
-        providerId: "opencode-go",
-        timeoutSource: "explicit-route",
-        scope: { project: "validated", read: "validated", tools: "validated", network: "validated", write: "validated" },
-        eligibility: { authority: "authoritative", observedAt: "2026-07-13T21:58:00.000Z", validUntil: "2026-07-13T21:59:00.000Z" },
-      } as never) },
-    }));
-
-    await expect(service.submit(request)).rejects.toMatchObject({ code: "route_unavailable" });
-    expect(reserve).not.toHaveBeenCalled();
-    expect(runtime.invoke).not.toHaveBeenCalled();
-  });
-
-  it("is idempotent for an identical retry and conflicts for a different request", async () => {
-    const runtime = { invoke: vi.fn(async (input) => successfulRuntimeResult(input)) };
-    const service = new ManagedJobApplicationService(createOptions({ runtime }));
-    const first = await service.submit(request);
-    const retry = await service.submit(request);
-    await expect(service.submit({ ...request, objective: "Different objective." })).rejects.toMatchObject({ code: "idempotency_conflict" });
-    await expect(service.submit({ ...request, configuredAgentProfileId: "researcher" })).rejects.toMatchObject({ code: "idempotency_conflict" });
-    expect(retry.id).toBe(first.id);
-    expect(runtime.invoke).toHaveBeenCalledTimes(1);
-  });
-
-  it("serializes concurrent duplicate submissions at the job-owner store", async () => {
-    const runtime = { invoke: vi.fn(async (input) => successfulRuntimeResult(input)) };
-    const service = new ManagedJobApplicationService(createOptions({ runtime }));
-    const jobs = await Promise.all(Array.from({ length: 8 }, () => service.submit(request)));
-    expect(new Set(jobs.map((job) => job.id))).toEqual(new Set(["job-000000001"]));
-    expect(runtime.invoke).toHaveBeenCalledTimes(1);
-  });
-
-  it("maps provider failure and timeout to honest terminal states with safe diagnostics", async () => {
-    const failed = new ManagedJobApplicationService(createOptions({ runtime: { invoke: async () => ({ state: "failed" }) } }));
-    await expect(failed.submit(request)).resolves.toMatchObject({ state: "failed", diagnostic: "provider_rejected" });
-    const timedOut = new ManagedJobApplicationService(createOptions({ runtime: { invoke: async () => ({ state: "timed_out" }) } }));
-    await expect(timedOut.submit(request)).resolves.toMatchObject({ state: "timed_out", diagnostic: "provider_timeout" });
-    const rejected = new ManagedJobApplicationService(createOptions({ runtime: { invoke: async () => { throw new ManagedJobApplicationError("provider_rejected", "hidden provider payload"); } } }));
-    await expect(rejected.submit(request)).resolves.toMatchObject({ state: "failed", diagnostic: "provider_rejected" });
-  });
-
-  it("never exposes success without Runtime's canonical handoff and keeps pending reads truthful", async () => {
-    let release: (() => void) | undefined;
-    const waiting = new Promise<void>((resolve) => { release = resolve; });
-    const runtime = {
-      invoke: vi.fn(async (input) => {
-        await waiting;
-        return successfulRuntimeResult(input);
+    await expect(service.recoverInterrupted()).resolves.toEqual([
+      expect.objectContaining({
+        version: 5,
+        state: "failed",
+        diagnostic: "economic_commitment_unavailable",
       }),
+    ]);
+  });
+
+  it("binds idempotency to policy revision and normalized constraints", async () => {
+    let constraints: ManagedJobEconomicProfile["constraints"] = {
+      providerId: "codex-oauth",
+      model: "openai/gpt-test",
     };
-    const service = new ManagedJobApplicationService(createOptions({ runtime }));
-    const submitted = service.submit(request);
-    await vi.waitFor(async () => expect((await service.getStatus(query, "job-000000001")).state).toBe("running"));
-    await expect(service.getResult(query, "job-000000001")).resolves.toMatchObject({ availability: "pending", lifecycleState: "running" });
-    release?.();
-    const job = await submitted;
-    await expect(service.getResult(query, job.id)).resolves.toMatchObject({ availability: "available", lifecycleState: "succeeded", handoff: { summary: "done" } });
-
-    const noHandoff = new ManagedJobApplicationService(createOptions({ runtime: { invoke: async () => ({ state: "succeeded" }) } }));
-    await expect(noHandoff.submit(request)).resolves.toMatchObject({ state: "failed", diagnostic: "result_persistence_failure" });
-  });
-
-  it("normalizes untrusted child output before persistence and uses explicit bounded truncation without transcript references", async () => {
+    const store = new InMemoryManagedJobStore();
     const service = new ManagedJobApplicationService(createOptions({
-      runtime: {
-        invoke: async (input) => ({
-          ...successfulRuntimeResult(input),
-          result: {
-            ...successfulRuntimeResult(input).result!,
-            resultHandoff: {
-              summary: `system prompt: hidden\nhidden reasoning: private\nTOKEN=super-secret\nC:\\private\\result.json\nError: provider payload\n${"safe result ".repeat(300)}`,
-              resourceUris: ["kiln://managed-invocations/job-000000001/transcript"],
-              memoryWriteProposalUris: ["kiln://artifacts/job-000000001/private-proposal"],
-            },
-          },
-        }),
-      },
-    }));
-    const job = await service.submit(request);
-    const result = await service.getResult(query, job.id);
-    const serialized = JSON.stringify(result);
-    expect(result).toMatchObject({ availability: "available", handoff: { resourceUris: [], memoryWriteProposalUris: [] } });
-    expect(result.handoff?.summary).toContain("[TRUNCATED: safe inline result limit reached]");
-    expect(serialized).not.toContain("system prompt");
-    expect(serialized).not.toContain("hidden reasoning");
-    expect(serialized).not.toContain("super-secret");
-    expect(serialized).not.toContain("C:\\private");
-    expect(serialized).not.toContain("provider payload");
-    expect(serialized).not.toContain("transcript");
-  });
-
-  it("preserves benign narrative labels while redacting environment assignments and credential fields", async () => {
-    const service = new ManagedJobApplicationService(createOptions({
-      runtime: {
-        invoke: async (input) => ({
-          ...successfulRuntimeResult(input),
-          result: {
-            ...successfulRuntimeResult(input).result!,
-            resultHandoff: {
-              summary: [
-                "Finding: the progressive catalog remains replayable.",
-                "Status: verified with focused coverage.",
-                "Risk: no residual authority expansion was found.",
-                "DATABASE_URL=postgres://private-host/kiln",
-                "api_key:super-secret",
-                "Password=also-secret",
-              ].join("\n"),
-              resourceUris: [],
-              memoryWriteProposalUris: [],
-            },
-          },
-        }),
-      },
+      store,
+      currentProfile: () => profile(constraints),
+      currentCandidates: () => candidateSet(constraints),
     }));
 
-    const job = await service.submit(request);
-    const summary = (await service.getResult(query, job.id)).handoff?.summary;
+    const first = await service.submit(submission);
+    await expect(service.submit(submission)).resolves.toEqual(first);
+    expect(first).toMatchObject({ constraints: { model: "openai/gpt-test" } });
 
-    expect(summary).toContain("Finding: the progressive catalog remains replayable.");
-    expect(summary).toContain("Status: verified with focused coverage.");
-    expect(summary).toContain("Risk: no residual authority expansion was found.");
-    expect(summary).not.toContain("private-host");
-    expect(summary).not.toContain("super-secret");
-    expect(summary).not.toContain("also-secret");
-    expect(summary?.match(/\[REDACTED:environment\]/gu)).toHaveLength(3);
-  });
-
-  it("fails closed for unlabelled provider JSON and strips the submitted objective if the child echoes it", async () => {
-    const service = new ManagedJobApplicationService(createOptions({
-      runtime: {
-        invoke: async (input) => ({
-          ...successfulRuntimeResult(input),
-          result: {
-            ...successfulRuntimeResult(input).result!,
-            resultHandoff: { summary: `Provider output:\n\`\`\`json\n{"data":{"api_key":"super-secret","messages":[{"role":"system","content":"${request.objective}"}]}}\n\`\`\``, resourceUris: [], memoryWriteProposalUris: [] },
-          },
-        }),
-      },
-    }));
-    const job = await service.submit(request);
-    const serialized = JSON.stringify(await service.getResult(query, job.id));
-    expect(serialized).toContain("[REDACTED:unsafe raw provider payload]");
-    expect(serialized).not.toContain("super-secret");
-    expect(serialized).not.toContain(request.objective);
-  });
-
-  it("binds result and status reads to the persisted caller and project owner", async () => {
-    const service = new ManagedJobApplicationService(createOptions());
-    const job = await service.submit(request);
-    await expect(service.getStatus({ ...query, callerId: "codex-app:other" }, job.id)).rejects.toMatchObject({ code: "unauthorized_job" });
-    await expect(service.getResult({ project: { id: "other-project" }, callerId: query.callerId }, job.id)).rejects.toMatchObject({ code: "unauthorized_job" });
-  });
-
-  it("returns safe failed diagnostics for failed, timed-out, and recovered interrupted jobs", async () => {
-    const failed = new ManagedJobApplicationService(createOptions({ runtime: { invoke: async () => ({ state: "failed" }) } }));
-    const failedJob = await failed.submit(request);
-    await expect(failed.getResult(query, failedJob.id)).resolves.toMatchObject({ availability: "failed", lifecycleState: "failed", diagnostic: "provider_rejected" });
-
-    const timedOut = new ManagedJobApplicationService(createOptions({ runtime: { invoke: async () => ({ state: "timed_out" }) } }));
-    const timedOutJob = await timedOut.submit(request);
-    await expect(timedOut.getResult(query, timedOutJob.id)).resolves.toMatchObject({ availability: "failed", lifecycleState: "timed_out", diagnostic: "provider_timeout" });
-
-    const store = new InMemoryManagedJobStore();
-    await store.reserve({ job: { version: 3, id: "job-interrupted", state: "running", projectId: "kiln", callerId: query.callerId, configuredAgentProfileId: "scout", admissionProfileId: "foundation-readonly-plan", routeId: "opencode-go-scout-readonly", providerId: "opencode-go", governanceSource: "kiln-config-status", admissionId: "admission-001", timeoutSource: "default", requestFingerprint: "a".repeat(64), idempotencyKeyHash: "b".repeat(64), createdAt: now.toISOString(), updatedAt: now.toISOString(), lifecycle: [{ sequence: 1, state: "queued", observedAt: now.toISOString() }, { sequence: 2, state: "running", observedAt: now.toISOString() }] } });
-    const recovered = new ManagedJobApplicationService(createOptions({ store }));
-    await recovered.recoverInterrupted();
-    await expect(recovered.getResult(query, "job-interrupted")).resolves.toMatchObject({ availability: "failed", lifecycleState: "interrupted", diagnostic: "invocation_failed" });
-  });
-
-  it("rejects a runtime result that mismatches the admitted route and cannot make success observable after result persistence failure", async () => {
-    const mismatched = new ManagedJobApplicationService(createOptions({ runtime: { invoke: async (input) => ({ ...successfulRuntimeResult(input), result: { ...successfulRuntimeResult(input).result!, routeId: "other-route" } }) } }));
-    await expect(mismatched.submit(request)).resolves.toMatchObject({ state: "failed", diagnostic: "result_corrupt" });
-
-    const store = new InMemoryManagedJobStore();
-    const completeSuccess = store.completeSuccess.bind(store);
-    store.completeSuccess = async () => { throw new Error("persistence failed"); };
-    const service = new ManagedJobApplicationService(createOptions({ store }));
-    const job = await service.submit(request);
-    expect(job).toMatchObject({ state: "failed", diagnostic: "job_persistence_unavailable" });
-    store.completeSuccess = completeSuccess;
-  });
-
-  it("keeps persisted terminal results immutable", async () => {
-    const store = new InMemoryManagedJobStore();
-    const service = new ManagedJobApplicationService(createOptions({ store }));
-    const job = await service.submit(request);
-    await expect(store.completeSuccess(job.id, job.result!, now.toISOString())).rejects.toMatchObject({ code: "invalid_transition" });
-  });
-
-  it("reads the concrete V3 migration format without fabricating account evidence", async () => {
-    const store = new InMemoryManagedJobStore();
-    await store.reserve({ job: {
-      version: 3, id: "cdb98e81-002b-44a4-aac9-e08b2f861a6b", state: "failed", projectId: "kiln", callerId: query.callerId, configuredAgentProfileId: "scout", admissionProfileId: "foundation-readonly-plan", routeId: "opencode-go-scout-readonly", providerId: "opencode-go", governanceSource: "kiln-config-status", admissionId: "admission-001", timeoutSource: "default", requestFingerprint: "a".repeat(64), idempotencyKeyHash: "b".repeat(64), createdAt: now.toISOString(), updatedAt: now.toISOString(), diagnostic: "provider_rejected", lifecycle: [{ sequence: 1, state: "queued", observedAt: now.toISOString() }, { sequence: 2, state: "failed", observedAt: now.toISOString(), diagnostic: "provider_rejected" }],
-    } });
-    const service = new ManagedJobApplicationService(createOptions({ store }));
-    await expect(service.getResult(query, "cdb98e81-002b-44a4-aac9-e08b2f861a6b")).resolves.toEqual(expect.objectContaining({
-      availability: "failed",
-      lifecycleState: "failed",
-      diagnostic: "provider_rejected",
-    }));
-    await expect(service.getReplay(query, "cdb98e81-002b-44a4-aac9-e08b2f861a6b")).resolves.toMatchObject({
-      availability: "available",
-      accountLeaseHistory: [],
+    constraints = { providerId: "codex-oauth" };
+    await expect(service.submit(submission)).rejects.toMatchObject({
+      code: "idempotency_conflict",
     });
   });
 
-  it("persists lease-only aggregate updates without fabricating lifecycle transitions", async () => {
-    const root = await mkdtemp(join(tmpdir(), "kiln-managed-job-lease-"));
+  it("rejects candidate evidence that does not bind the profile policy and constraints", async () => {
+    const service = new ManagedJobApplicationService(createOptions({
+      currentProfile: () => profile({ routeId: "codex-primary" }),
+      currentCandidates: () => candidateSet(),
+    }));
+
+    await expect(service.submit(submission)).rejects.toMatchObject({
+      code: "route_unavailable",
+    });
+  });
+
+  it("fails before candidate admission and persistence when governance denies work", async () => {
+    const store = new InMemoryManagedJobStore();
+    const reserve = vi.spyOn(store, "reserve");
+    const options = createOptions({ store });
+    const resolveCandidates = vi.spyOn(options.routes, "resolve");
+    const service = new ManagedJobApplicationService({
+      ...options,
+      governance: {
+        ...options.governance,
+        admit: async () => ({ admitted: false }),
+      },
+    });
+
+    await expect(service.submit(submission)).rejects.toMatchObject({
+      code: "admission_denied",
+    });
+    expect(resolveCandidates).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+  });
+
+  it("serializes concurrent duplicate submissions at the store owner", async () => {
+    const store = new InMemoryManagedJobStore();
+    const service = new ManagedJobApplicationService(createOptions({ store }));
+
+    const jobs = await Promise.all([
+      service.submit(submission),
+      service.submit(submission),
+      service.submit(submission),
+    ]);
+
+    expect(new Set(jobs.map((job) => job.id))).toEqual(
+      new Set(["job-000000001"]),
+    );
+    expect(store.all()).toHaveLength(1);
+  });
+
+  it("binds status and result queries to the persisted caller and project", async () => {
+    const service = new ManagedJobApplicationService(createOptions());
+    const job = await service.submit(submission);
+
+    await expect(service.getStatus({
+      ...query,
+      callerId: "different-caller",
+    }, job.id)).rejects.toMatchObject({ code: "unauthorized_job" });
+    await expect(service.getResult({
+      project: { id: "different-project" },
+      callerId: query.callerId,
+    }, job.id)).rejects.toMatchObject({ code: "unauthorized_job" });
+  });
+
+  it("keeps terminal V5 records immutable and cancellation honest", async () => {
+    const store = new InMemoryManagedJobStore();
+    const service = new ManagedJobApplicationService(createOptions({ store }));
+    const job = await service.submit(submission);
+
+    await expect(service.cancel(query, job.id)).rejects.toMatchObject({
+      code: "invalid_transition",
+    });
+    await expect(store.transition(job.id, "cancelled")).rejects.toMatchObject({
+      code: "invalid_transition",
+    });
+  });
+
+  it("preserves V5 idempotency across a filesystem restart", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kiln-managed-jobs-v5-"));
     try {
-      const store = new FilesystemManagedJobStore(root);
-      const options = createOptions();
-      const service = new ManagedJobApplicationService({
-        ...options,
-        store,
-        runtime: { invoke: async (input) => successfulRuntimeResult(input) },
+      const first = new ManagedJobApplicationService(createOptions({
+        store: new FilesystemManagedJobStore(root),
+      }));
+      const created = await first.submit(submission);
+      const second = new ManagedJobApplicationService({
+        ...createOptions({ store: new FilesystemManagedJobStore(root) }),
+        idGenerator: () => "job-000000002",
       });
-      const job = await service.submit(request);
-      const observedAt = new Date(now.getTime() + 1000).toISOString();
-      await store.recordAccountLease(job.id, {
-        leaseId: `lease-${job.id}`,
-        accountPolicyId: "managed-opencode",
-        accountRef: "configured:account-a",
-        route: { providerId: "opencode-go", providerModelId: "qwen3.6-plus", scope: "virtual:managed-opencode" },
-        jobId: job.id,
-        runtimeInvocationId: job.id,
-        credentialRevisionId: "a".repeat(64),
-        selectionReason: "least-pressure",
-        acquiredAt: now.toISOString(),
-        lifecycleState: "held",
-        resourceUris: [`kiln://managed-accounts/leases/lease-${job.id}`],
-        diagnosticUris: [],
-      }, observedAt);
 
-      const restored = await new FilesystemManagedJobStore(root).get(job.id);
-      expect(restored).toMatchObject({
-        updatedAt: observedAt,
-        accountLease: { lifecycleState: "held" },
-      });
-      expect(restored?.lifecycle.at(-1)?.observedAt).toBe(now.toISOString());
+      await expect(second.submit(submission)).resolves.toEqual(created);
+      const persisted = JSON.parse(
+        await readFile(join(root, "managed-jobs.json"), "utf8"),
+      ) as unknown[];
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0]).toMatchObject({ version: 5 });
     } finally {
       await rm(root, { recursive: true, force: true });
     }
   });
 
-  it("rejects lease evidence regression and immutable acquisition drift", async () => {
-    const store = new InMemoryManagedJobStore();
-    const options = createOptions();
-    const service = new ManagedJobApplicationService({
-      ...options,
-      store,
-      runtime: { invoke: async (input) => successfulRuntimeResult(input) },
-    });
-    const job = await service.submit(request);
-    const base = {
-      leaseId: `lease-${job.id}`,
-      accountPolicyId: "managed-opencode",
-      accountRef: "configured:account-a",
-      route: { providerId: "opencode-go", providerModelId: "qwen3.6-plus", scope: "virtual:managed-opencode" },
-      jobId: job.id,
-      runtimeInvocationId: job.id,
-      credentialRevisionId: "a".repeat(64),
-      selectionReason: "least-pressure" as const,
-      acquiredAt: now.toISOString(),
-      resourceUris: [`kiln://managed-accounts/leases/lease-${job.id}`],
-      diagnosticUris: [],
-    };
-    await store.recordAccountLease(job.id, { ...base, lifecycleState: "held" }, new Date(now.getTime() + 1000).toISOString());
-    await expect(store.recordAccountLease(job.id, {
-      ...base,
-      lifecycleState: "held",
-      diagnosticUris: [`kiln://managed-accounts/leases/lease-${job.id}/release-failed`],
-    }, new Date(now.getTime() + 1500).toISOString())).rejects.toThrow("incompatible diagnostic evidence");
-    const pendingUri = `kiln://managed-accounts/leases/lease-${job.id}/settlement-pending`;
-    const unknownUri = `kiln://managed-accounts/leases/lease-${job.id}/settlement-unknown`;
-    await store.recordAccountLease(job.id, {
-      ...base,
-      lifecycleState: "settlement-pending",
-      diagnosticUris: [pendingUri],
-    }, new Date(now.getTime() + 1600).toISOString());
-    const enriched = await store.recordAccountLease(job.id, {
-      ...base,
-      lifecycleState: "settlement-pending",
-      diagnosticUris: [pendingUri, unknownUri],
-    }, new Date(now.getTime() + 1700).toISOString());
-    const reordered = await store.recordAccountLease(job.id, {
-      ...base,
-      lifecycleState: "settlement-pending",
-      diagnosticUris: [unknownUri, pendingUri],
-    }, new Date(now.getTime() + 1800).toISOString());
-    expect(reordered).toEqual(enriched);
-    expect(reordered.accountLeaseHistory).toHaveLength(3);
-    await store.recordAccountLease(job.id, {
-      ...base,
-      lifecycleState: "released",
-      affinityCommitOutcome: "won",
-      releasedAt: new Date(now.getTime() + 2000).toISOString(),
-      diagnosticUris: [pendingUri, unknownUri],
-    }, new Date(now.getTime() + 2000).toISOString());
-
-    await expect(store.recordAccountLease(job.id, {
-      ...base,
-      lifecycleState: "held",
-    }, new Date(now.getTime() + 3000).toISOString())).rejects.toMatchObject({ code: "invalid_transition" });
-    await expect(store.recordAccountLease(job.id, {
-      ...base,
-      acquiredAt: new Date(now.getTime() + 1).toISOString(),
-      lifecycleState: "released",
-      releasedAt: new Date(now.getTime() + 3000).toISOString(),
-      diagnosticUris: [pendingUri, unknownUri],
-    }, new Date(now.getTime() + 3000).toISOString())).rejects.toMatchObject({ code: "invalid_transition" });
-  });
-
-  it("persists the same immutable result across restart and fails closed for corrupt result evidence", async () => {
-    const root = await mkdtemp(join(tmpdir(), "kiln-managed-job-results-"));
+  it("fails closed for corrupt V5 candidate evidence", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kiln-managed-jobs-corrupt-"));
     try {
-      const first = new ManagedJobApplicationService(createOptions({ store: new FilesystemManagedJobStore(root) }));
-      const job = await first.submit(request);
-      const second = new ManagedJobApplicationService(createOptions({ store: new FilesystemManagedJobStore(root) }));
-      await expect(second.getResult(query, job.id)).resolves.toMatchObject({ availability: "available", handoff: { summary: "done" } });
-      await expect(second.getReplay(query, job.id)).resolves.toMatchObject({
-        availability: "available",
-        lifecycle: [
-          { sequence: 1, state: "queued" },
-          { sequence: 2, state: "running" },
-          { sequence: 3, state: "succeeded" },
-        ],
-        resultAvailability: "available",
-      });
-      const payload = JSON.parse(await (await import("node:fs/promises")).readFile(join(root, "managed-jobs.json"), "utf8")) as Array<Record<string, unknown>>;
-      payload[0]!.result = { version: 1, jobId: "other-job" };
-      await writeFile(join(root, "managed-jobs.json"), `${JSON.stringify(payload)}\n`, "utf8");
-      await expect(second.getResult(query, job.id)).rejects.toMatchObject({ code: "job_persistence_corrupt" });
-    } finally { await rm(root, { recursive: true, force: true }); }
+      const service = new ManagedJobApplicationService(createOptions({
+        store: new FilesystemManagedJobStore(root),
+      }));
+      const created = await service.submit(submission);
+      const path = join(root, "managed-jobs.json");
+      const records = JSON.parse(await readFile(path, "utf8")) as Array<
+        Record<string, unknown>
+      >;
+      const candidateSetRecord = records[0]?.candidateSet as {
+        rejections: Array<Record<string, unknown>>;
+      };
+      candidateSetRecord.rejections[0]!.reason = "unowned-reason";
+      await writeFile(path, `${JSON.stringify(records)}\n`, "utf8");
+
+      await expect(
+        new FilesystemManagedJobStore(root).get(created.id),
+      ).rejects.toMatchObject({ code: "job_persistence_corrupt" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
-  it("recovers persisted nonterminal work as interrupted and preserves parent-child separation", async () => {
-    const store = new InMemoryManagedJobStore();
-    await store.reserve({ job: { version: 3, id: "job-running", state: "queued", projectId: "kiln", callerId: query.callerId, configuredAgentProfileId: "scout", admissionProfileId: "foundation-readonly-plan", routeId: "opencode-go-scout-readonly", providerId: "opencode-go", governanceSource: "kiln-config-status", admissionId: "admission-001", timeoutSource: "default", requestFingerprint: "a".repeat(64), idempotencyKeyHash: "b".repeat(64), createdAt: now.toISOString(), updatedAt: now.toISOString(), lifecycle: [{ sequence: 1, state: "queued", observedAt: now.toISOString() }], parent: { invocationId: "parent-invocation", turnId: "parent-turn" } } });
-    const service = new ManagedJobApplicationService(createOptions({ store }));
-    const recovered = await service.recoverInterrupted();
-    expect(recovered).toMatchObject([{ id: "job-running", state: "interrupted", parent: { invocationId: "parent-invocation", turnId: "parent-turn" } }]);
-  });
+  it("normalizes storage failures without leaking infrastructure errors", async () => {
+    const service = new ManagedJobApplicationService(createOptions({
+      store: {
+        reserve: async () => {
+          throw new Error("C:\\operator\\secret-provider-payload");
+        },
+        get: async () => undefined,
+        transition: async () => {
+          throw new Error("unused");
+        },
+        completeSuccess: async () => {
+          throw new Error("unused");
+        },
+        recordAccountLease: async () => {
+          throw new Error("unused");
+        },
+        listNonterminal: async () => [],
+      },
+    }));
 
-  it("preserves idempotency across a filesystem-store restart and fails closed on corruption", async () => {
+    await expect(service.submit(submission)).rejects.toEqual(
+      expect.objectContaining({
+        code: "job_persistence_unavailable",
+        message: "job_persistence_unavailable",
+      }),
+    );
+  });
+});
+
+describe("Managed job historical readers", () => {
+  const historicalBase = {
+    id: "job-historical-001",
+    state: "failed" as const,
+    projectId: "kiln",
+    callerId: "codex-app:caller-001",
+    configuredAgentProfileId: "scout",
+    admissionProfileId: "foundation-readonly-plan",
+    routeId: "historical-route",
+    providerId: "opencode-go",
+    governanceSource: "kiln-config-status",
+    admissionId: "admission-historical",
+    timeoutSource: "explicit-route" as const,
+    requestFingerprint: "a".repeat(64),
+    idempotencyKeyHash: "b".repeat(64),
+    createdAt: "2026-07-29T17:00:00.000Z",
+    updatedAt: "2026-07-29T17:01:00.000Z",
+    diagnostic: "provider_rejected" as const,
+    lifecycle: [
+      {
+        sequence: 1,
+        state: "queued" as const,
+        observedAt: "2026-07-29T17:00:00.000Z",
+      },
+      {
+        sequence: 2,
+        state: "failed" as const,
+        observedAt: "2026-07-29T17:01:00.000Z",
+        diagnostic: "provider_rejected" as const,
+      },
+    ],
+  };
+
+  it.each([
+    { ...historicalBase, version: 3 as const } satisfies ManagedJobRecordV3,
+    {
+      ...historicalBase,
+      version: 4 as const,
+      accountLeaseHistory: [],
+    } satisfies ManagedJobRecordV4,
+  ])("reads V$version without rewriting it", async (fixture) => {
     const root = await mkdtemp(join(tmpdir(), "kiln-managed-jobs-"));
+    const path = join(root, "managed-jobs.json");
+    const serialized = `${JSON.stringify([fixture])}\n`;
     try {
-      const first = new ManagedJobApplicationService(createOptions({ store: new FilesystemManagedJobStore(root) }));
-      const job = await first.submit(request);
-      const second = new ManagedJobApplicationService(createOptions({ store: new FilesystemManagedJobStore(root) }));
-      await expect(second.submit(request)).resolves.toMatchObject({ id: job.id });
-      await writeFile(join(root, "managed-jobs.json"), "{not-json", "utf8");
-      const corrupt = new ManagedJobApplicationService(createOptions({ store: new FilesystemManagedJobStore(root) }));
-      await expect(corrupt.getStatus(query, job.id)).rejects.toMatchObject({ code: "job_persistence_corrupt" });
-    } finally { await rm(root, { recursive: true, force: true }); }
+      await writeFile(path, serialized, "utf8");
+      const store = new FilesystemManagedJobStore(root);
+
+      await expect(store.get(fixture.id)).resolves.toEqual(fixture);
+      expect(await readFile(path, "utf8")).toBe(serialized);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
-  it("does not leak errors or accept invalid lifecycle transitions", async () => {
-    const store: ManagedJobStore = { reserve: async () => { throw new Error("C:/secret/token") }, get: async () => undefined, transition: async () => { throw new Error("C:/secret/token") }, completeSuccess: async () => { throw new Error("C:/secret/token") }, listNonterminal: async () => [] };
+  it("recovers historical nonterminal records through their original lifecycle", async () => {
+    const running: ManagedJobRecordV4 = {
+      ...historicalBase,
+      version: 4,
+      state: "running",
+      updatedAt: "2026-07-29T17:00:30.000Z",
+      diagnostic: undefined,
+      lifecycle: [
+        {
+          sequence: 1,
+          state: "queued",
+          observedAt: "2026-07-29T17:00:00.000Z",
+        },
+        {
+          sequence: 2,
+          state: "running",
+          observedAt: "2026-07-29T17:00:30.000Z",
+        },
+      ],
+      accountLeaseHistory: [],
+    };
+    const store = new InMemoryManagedJobStore([running]);
     const service = new ManagedJobApplicationService(createOptions({ store }));
-    await expect(service.submit(request)).rejects.toEqual(expect.objectContaining({ code: "job_persistence_unavailable", message: "job_persistence_unavailable" }));
-    expect(() => { throw new ManagedJobApplicationError("invalid_transition", "Keep terminal managed-job states immutable."); }).toThrow("invalid_transition");
+
+    await expect(service.recoverInterrupted()).resolves.toEqual([
+      expect.objectContaining({
+        version: 4,
+        state: "interrupted",
+        diagnostic: "invocation_failed",
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Define and validate canonical managed-route economic capability and policy bindings.
- Project policy-owned invocations as complete candidate sets without selecting a route, credential, account, lease, reservation, or adapter.
- Persist only V5 precommit jobs on new writes while retaining strict V3/V4 historical readers.
- Fail closed with economic_commitment_unavailable until Slice 4 supplies one durable commitment.
- Defer direct, CLI-harness, and remote-harness adapter construction until commitment.
- Preserve governance, context, skill, authority, health, and caller-constraint admission before economic candidate exposure.
- Include the branch's previously completed owner-only native credential activation and status work.

## Verification

- Runtime focused: 41 passed.
- CLI focused: 86 passed.
- Runtime full: 225 files, 3051 passed, 4 skipped; Bun SQLite durability checks passed.
- CLI full: passed.
- Workspace build: passed.
- Workspace typecheck: passed.
- Git diff check: passed.

## Review

Independent standard-depth re-review found no actionable High/Medium findings. The next boundary is Slice 4: atomic commitment, fencing, and dispatch.

Refs #34