### PR TITLE
docs(roadmap): correct managed dispatch availability and index state

### DIFF
--- a/docs/architecture/managed-agents.md
+++ b/docs/architecture/managed-agents.md
@@ -192,10 +192,15 @@ candidate admission or commitment. The application boundary refreshes
 canonical eligibility for every submission, resolves the configured policy and
 narrow-only route constraints, and persists the V6 precommit record with its
 `economicAttemptId` and pinned `adoptedDecisionAt` before snapshot adoption.
-Roadmap issue #34 internal Slice 4 stops before provider dispatch; this is not
-Roadmap 02 Slice 5 cross-path convergence. The MCP adapter never selects a
-route. Capability inspection
-projects safe configured-agent identity, optional role/display name, availability,
+Roadmap issue #34 internal Slice 4 stops before provider dispatch, so managed
+jobs cannot execute in shipped builds today: every submission acquires its
+commitment, releases it pre-fence with reason
+`slice-4-provider-dispatch-unavailable`, and terminates `failed` /
+`economic_commitment_unavailable`. This is a deliberate ordered-delivery state
+that ends with issue #34 internal Slice 5, and it is not Roadmap 02 Slice 5
+cross-path convergence. The MCP adapter never selects a route. Capability
+inspection projects safe configured-agent identity, optional role/display
+name, availability,
 provider family, admission profile, and stable action; it does not expose route
 configuration. Status, result, cancellation, and replay operations are
 authorized by the application owner

--- a/docs/roadmap/02-managed-invocation-routing.md
+++ b/docs/roadmap/02-managed-invocation-routing.md
@@ -4,6 +4,20 @@ Status: Active delivery track
 Execution: Slices 1, 2, 3, and 4 complete; Slice 5 queued.
 Created: 2026-07-23
 
+> **Managed-job execution is unavailable in shipped builds.** Every managed-job
+> submission currently terminates `failed` / `economic_commitment_unavailable`.
+> The economic commitment is acquired and then released pre-fence with reason
+> `slice-4-provider-dispatch-unavailable`, because provider dispatch is not yet
+> wired (`packages/runtime/src/managed-jobs/index.ts:496-577`).
+>
+> This is a deliberate ordered-delivery state, not a regression. Dispatch
+> returns with issue #34 internal Slice 5. "Slices 1-4 complete" above describes
+> the delivered authority contracts, not a working end-to-end managed route.
+>
+> Unaffected surfaces: `kiln run` sessions, the GUI, and the managed-invocation
+> runtime tool all execute normally. They do not traverse
+> `ManagedJobApplication`.
+
 ## Objective
 
 Own managed-job admission, route/account selection, execution lifecycle, result,

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -22,7 +22,7 @@ roadmap reorganization.
 
 | Order | Track | State | Next bounded work |
 | --- | --- | --- | --- |
-| 1 | [02 - Managed Invocation Routing](./02-managed-invocation-routing.md) | Blocked | Obtain explicit operator authorization for the bounded Slice 3 live probe. |
+| 1 | [02 - Managed Invocation Routing](./02-managed-invocation-routing.md) | Ready | Deliver issue #34 internal Slice 5: restore provider dispatch behind a real quota-evidence producer, the orchestration migration off `RuntimeBudgetAdmissionService`, and the mandatory pre-effect dispatch fence. Managed-job execution is unavailable until it lands. |
 | 2 | [03 - Model Gateway Lifecycle](./03-model-gateway-lifecycle.md) | Blocked | Fix deterministic teardown, then apply and live-prove the reviewed user-scoped gateway configuration on an operator machine. |
 | 3 | [04 - Cross-Harness Integration](./04-cross-harness-integration.md) | Blocked | Close OpenCode live parity, then migrate and prove the harness-neutral control-plane bridge. |
 | 4 | [05 - Skill Capability Plane](./05-skill-capability-plane.md) | Research | Define the provider-neutral skill evidence and admission contract. |


### PR DESCRIPTION
## Summary

Closes issue #34 findings **F1** and **F7**, which the end-to-end audit at `4c11cf6c` required to be corrected immediately, in one atomic change, independent of the remaining slices (binding decision 2).

## F1 - managed-job execution is unavailable, and the docs did not say so

`docs/roadmap/02-managed-invocation-routing.md` recorded "Slices 1, 2, 3, and 4 complete; Slice 5 queued", which a reader takes as a working managed route. In shipped builds no managed job can execute at all.

`commitEconomicAttempt` acquires the economic commitment and then, on every path, calls `releaseInterimCommitment`, which releases pre-fence with reason `slice-4-provider-dispatch-unavailable` and transitions the job to `failed` / `economic_commitment_unavailable` (`packages/runtime/src/managed-jobs/index.ts:496-577`).

Both the roadmap track and `docs/architecture/managed-agents.md` now state the observable terminal state and name it as deliberate ordered delivery rather than a regression. The architecture doc previously said only "stops before provider dispatch", which is true but leaves a reader unable to tell whether a job hangs, queues, or fails.

Both records also list the surfaces that do **not** traverse `ManagedJobApplication` and are therefore unaffected — `kiln run` sessions, the GUI, and the managed-invocation runtime tool — so the statement is not read as "Kiln cannot execute work".

## F7 - roadmap index drift, two slices stale

`docs/roadmap/README.md` still listed Roadmap 02 as `Blocked` on "Obtain explicit operator authorization for the bounded Slice 3 live probe". That probe completed and is recorded in the track's own Slice 3 section. This drift was flagged as a blocking amendment in the original audit, was assigned to internal Slice 7, and has since survived Slices 1, 2, 3, and 4.

The row is now `Ready` and names the actual next bounded work: issue #34 internal Slice 5, with its quota-evidence producer, orchestration migration off `RuntimeBudgetAdmissionService`, and mandatory pre-effect dispatch fence.

This also restores the index's own operating model — "only the first `Ready` item is the default next task" — which could not hold while order 1 was `Blocked`.

## Boundaries

- Documentation only. No production, test, workflow, manifest, or dependency changes.
- No roadmap priority reordering. Roadmap 02 was already order 1.
- Does not close any other #34 finding. F2, F3, F5, F6, and F8 remain open and are tracked on #34.

## Verification

- `git diff --check` clean
- One H1 per touched document
- All relative links in the touched files resolve
- No remaining reference anywhere in `docs/` to Slice 3 authorization as a blocker

## Related

- Slice 4 closeout and F9 discharge: https://github.com/sequelcore/kiln/issues/34#issuecomment-5150183085
- #37 closeout: https://github.com/sequelcore/kiln/issues/37#issuecomment-5150181483
